### PR TITLE
Optin hotfix

### DIFF
--- a/lib/cmps/trustarc-frame.ts
+++ b/lib/cmps/trustarc-frame.ts
@@ -100,6 +100,9 @@ export default class TrustArcFrame extends AutoConsentCMPBase {
   }
 
   async optIn() {
+    if (click('.call')) {
+      return true;
+    }
     await this.navigateToSettings();
     click(".switch span:nth-child(2)", true);
 

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -334,6 +334,9 @@ export default class AutoConsent {
       case 'initResp':
         this.initialize(message.config, message.rules);
         break;
+      case 'optIn':
+        await this.doOptIn();
+        break;
       case 'optOut':
         await this.doOptOut();
         break;

--- a/rules/autoconsent/moove.json
+++ b/rules/autoconsent/moove.json
@@ -14,7 +14,7 @@
       "then": [
         { "click": "#moove_gdpr_cookie_info_bar .change-settings-button" },
         { "waitForVisible": "#moove_gdpr_cookie_modal" },
-        { "eval": "document.querySelectorAll('#moove_gdpr_cookie_modal input').forEach(i => { if (!i.disabled) i.checked = false }) || true" },
+        { "eval": "document.querySelectorAll('#moove_gdpr_cookie_modal input').forEach(i => { if (!i.disabled && i.name !== 'moove_gdpr_strict_cookies') i.checked = false }) || true" },
         { "click": ".moove-gdpr-modal-save-settings" }
       ],
       "else": [

--- a/tests/moove.spec.ts
+++ b/tests/moove.spec.ts
@@ -4,6 +4,7 @@ generateCMPTests('Moove', [
     'https://impact.parkinson.org/',
     'https://wamu.org/',
     'https://www.phorest.com/',
+    'https://theposterclub.com/',
 ], {});
 
 generateCMPTests('Moove', [


### PR DESCRIPTION
This fixes
- a bug reported in https://github.com/duckduckgo/tracker-radar-collector/issues/80
- a bug in the Moove rule that can cause infinite reload: https://app.asana.com/0/1201844467387842/1203086455748981/f