### PR TITLE
Fix detection of frame-based sourcepoint CMP

### DIFF
--- a/lib/cmps/sourcepoint-frame.ts
+++ b/lib/cmps/sourcepoint-frame.ts
@@ -36,6 +36,18 @@ export default class SourcePoint extends AutoConsentCMPBase {
   }
 
   async detectPopup() {
+
+    // we only return true if the manager is open and we can actually perform an opt-out
+    // otherwise the rule might produce a dialogue in our browser asking the user whether to
+    // enable autoconsent, and then if the user clicks "yes" nothing will happen as the
+    // autoconsent won't work for this CPM unless the manager is open...
+    if (!this.isManagerOpen()) {
+      const actionable = await waitForElement('.sp_choice_type_12,.sp_choice_type_13', 2000);
+      if (!actionable) {
+        return false;
+      }
+    }
+
     return true;
   }
 

--- a/lib/cmps/sourcepoint-top.ts
+++ b/lib/cmps/sourcepoint-top.ts
@@ -27,7 +27,8 @@ export default class SourcePoint extends AutoConsentCMPBase {
   }
 
   async detectPopup() {
-    return elementVisible("div[id^='sp_message_container_']", 'all');
+    // we only return true if the container is visible, as otherwise we won't be able to perform the opt-out...
+    return elementVisible("div[id^='sp_message_container_']", 'all') && document.querySelector('.sp-message-open') !== null;
   }
 
   async optIn() {

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -16,8 +16,14 @@ export default class AutoConsent {
   protected sendContentMessage: MessageSender;
 
   constructor(sendContentMessage: MessageSender, config: Config = null, declarativeRules: RuleBundle = null) {
-    evalState.sendContentMessage = sendContentMessage;
-    this.sendContentMessage = sendContentMessage;
+
+    let scm = sendContentMessage;
+
+    if (enableLogs)
+      scm = async (msg) => {console.log(`Sending content message of type ${msg.type}:`, msg);return sendContentMessage(msg);}
+
+    evalState.sendContentMessage = scm;
+    this.sendContentMessage = scm;
     this.rules = [...dynamicRules];
 
     enableLogs && console.log('autoconsent init', window.location.href);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckduckgo/autoconsent",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "",
   "main": "dist/autoconsent.cjs.js",
   "module": "dist/autoconsent.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckduckgo/autoconsent",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "",
   "main": "dist/autoconsent.cjs.js",
   "module": "dist/autoconsent.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckduckgo/autoconsent",
-  "version": "3.0.2",
+  "version": "2.2.1",
   "description": "",
   "main": "dist/autoconsent.cjs.js",
   "module": "dist/autoconsent.esm.js",
@@ -36,7 +36,7 @@
     "chai": "^4.2.0",
     "eslint-config-airbnb": "^19.0.4",
     "mocha": "^10.0.0",
-    "rollup": "^2.79.1",
+    "rollup": "^2.73.0",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-terser": "^7.0.2",
     "tslib": "^2.4.0",


### PR DESCRIPTION
There seems to be an issue with the iframe based sourcepoint CMP, where a consent management popup gets detected even if it is not open.

This PR aims to fix this behavior by changing the `detectPopup` method of the `sourcepoint-frame` CMP so that it only returns true if the popup is actionable.