### PR TITLE
Fix popup showing after opt-out complete on stackoverflow.com

### DIFF
--- a/lib/cmps/onetrust.ts
+++ b/lib/cmps/onetrust.ts
@@ -37,6 +37,7 @@ export default class Onetrust extends AutoConsentCMPBase {
     await wait(1000);
     click("#onetrust-consent-sdk input.category-switch-handler:checked,.js-editor-toggle-state:checked", true); // optional step
 
+    await wait(1000);
     await waitForElement(".save-preference-btn-handler,.js-consent-save", 2000);
     click(".save-preference-btn-handler,.js-consent-save");
 


### PR DESCRIPTION
https://app.asana.com/0/1201844467387842/1203298895976359/f

Stackoverflow popup remains open after opt-out when access from the US.

Seems to be some kind of race condition caused by generate UI slowness (probably we're clicking the save button before a handler is registered.