### PR TITLE
Fix borlabs tests.

### DIFF
--- a/rules/autoconsent/borlabs.json
+++ b/rules/autoconsent/borlabs.json
@@ -1,12 +1,43 @@
 {
   "name": "borlabs",
-  "prehideSelectors": ["#BorlabsCookieBox"],
-  "detectCmp": [{ "exists": "._brlbs-block-content"}],
-  "detectPopup": [{ "visible": "._brlbs-bar-wrap,._brlbs-box-wrap" }],
-  "optIn": [{ "click": "a[data-cookie-accept-all]" }],
+  "detectCmp": [
+    {
+      "exists": "._brlbs-block-content"
+    }
+  ],
+  "detectPopup": [
+    {
+      "visible": "._brlbs-bar-wrap,._brlbs-box-wrap"
+    }
+  ],
+  "optIn": [
+    {
+      "click": "a[data-cookie-accept-all]"
+    }
+  ],
   "optOut": [
-      {
-          "click": "a[data-cookie-refuse]"
-      }
-  ]
+    {
+      "click": "a[data-cookie-individual]"
+    },
+    {
+      "waitForVisible": ".cookie-preference"
+    },
+    {
+      "click": "input[data-borlabs-cookie-checkbox]:checked",
+      "all": true,
+      "optional": true
+    },
+    {
+      "click": "#CookiePrefSave"
+    },
+    {
+      "wait": 500
+    }
+  ],
+  "prehideSelectors": [
+    "#BorlabsCookieBox"
+  ],
+  "test": [{
+    "eval": "!JSON.parse(decodeURIComponent(document.cookie.split(';').find(c => c.indexOf('borlabs-cookie') !== -1).split('=', 2)[1])).consents.statistics"
+  }]
 }

--- a/tests/borlabs.spec.ts
+++ b/tests/borlabs.spec.ts
@@ -1,7 +1,7 @@
 import generateCMPTests from "../playwright/runner";
 
 generateCMPTests('borlabs', [
-    'https://reitschuster.de'], {
-        skipRegions: ["US"]
-    }
+    'https://www.experto.de/', 'https://www.kesselheld.de/'], {
+    skipRegions: ["US"]
+}
 );

--- a/tests/sourcepoint.spec.ts
+++ b/tests/sourcepoint.spec.ts
@@ -10,6 +10,7 @@ generateCMPTests('Sourcepoint-frame', [
     "https://www.brianmadden.com/",
     "https://www.csoonline.com/blogs",
     "https://www.independent.co.uk/",
+    "https://reitschuster.de/"
 ], {
     skipRegions: ["US", "GB"],
 });


### PR DESCRIPTION
https://app.asana.com/0/1203268166580279/1203312927712136/f

 1. The borlabs test case was using reitschuster.de, which now uses Sourcepoint. I've moved that site to the Sourcepoint test cases.
 2. On sites using borlabs, the popup is not correctly dismissed anymore. I've updated the rule to correctly run the opt-out, and added a self-test.