### PR TITLE
Reduce triggering of affinity.serif.com rule

### DIFF
--- a/rules/autoconsent/affinity-serif-com.json
+++ b/rules/autoconsent/affinity-serif-com.json
@@ -2,10 +2,7 @@
   "name": "affinity.serif.com",
   "detectCmp": [
     {
-      "exists": ".c-cookie-banner"
-    },
-    {
-      "exists": ".c-cookie-banner button"
+      "exists": ".c-cookie-banner button[data-qa='allow-all-cookies']"
     }
   ],
   "detectPopup": [

--- a/tests/affinity-serif-com.spec.ts
+++ b/tests/affinity-serif-com.spec.ts
@@ -1,5 +1,5 @@
 import generateCMPTests from "../playwright/runner";
 
 generateCMPTests('affinity.serif.com', [
-    'https://affinity.serif.com/en-us/photo/'
+    'https://affinity.serif.com/en-us/photo/',
 ]);


### PR DESCRIPTION
detectCMP was triggering on sites with different popups - the selector is too generic.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203411184408889