### PR TITLE
Add extra options for Jenkins to improve test reliability.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 def runPlaywrightTests(resultDir, browser, grep) {
     try {
-        timeout(15) {
+        timeout(20) {
             sh 'mkdir -p ./test-results'
             sh """
                 PLAYWRIGHT_JUNIT_OUTPUT_NAME=results.xml npx playwright test --project $browser --reporter=junit --workers 10 --grep "$grep"|| true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ def runPlaywrightTests(resultDir, browser, grep) {
         timeout(10) {
             sh 'mkdir -p ./test-results'
             sh """
-                PLAYWRIGHT_JUNIT_OUTPUT_NAME=results.xml npx playwright test --project $browser --reporter=junit --workers 16 --grep "$grep"|| true
+                PLAYWRIGHT_JUNIT_OUTPUT_NAME=results.xml npx playwright test --project $browser --reporter=junit --workers 10 --grep "$grep"|| true
             """
         }
     } finally {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 def runPlaywrightTests(resultDir, browser, grep) {
     try {
-        timeout(10) {
+        timeout(15) {
             sh 'mkdir -p ./test-results'
             sh """
                 PLAYWRIGHT_JUNIT_OUTPUT_NAME=results.xml npx playwright test --project $browser --reporter=junit --workers 10 --grep "$grep"|| true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ def withEnvFile(envfile, Closure cb) {
 }
 
 pipeline {
-    agent { label 'crawler-worker' } // TODO - temporarily while crawler-autoconsent is occupied
+    agent { label 'autoconsent-crawler' }
     parameters {
         string(name: 'TEST_RESULT_ROOT', defaultValue: '/mnt/efs/users/smacbeth/autoconsent/ci', description: 'Where test results and configuration are stored')
         choice(name: 'BROWSER', choices: ['webkit', 'iphoneSE', 'chrome', 'firefox'], description: 'Browser')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,14 +1,19 @@
 def runPlaywrightTests(resultDir, browser, grep) {
-    sh 'mkdir -p ./test-results'
-    sh """
-        PLAYWRIGHT_JUNIT_OUTPUT_NAME=results.xml npx playwright test --project $browser --reporter=junit --workers 16 --grep "$grep"|| true
-    """
-    junit 'results.xml'
-    sh """
-        mkdir -p ${resultDir}/results/${BRANCH_NAME}/${BUILD_NUMBER}/$REGION/
-        mkdir -p ./test-results
-        mv ./test-results/ ${resultDir}/results/${BRANCH_NAME}/${BUILD_NUMBER}/$REGION/
-    """
+    try {
+        timeout(10) {
+            sh 'mkdir -p ./test-results'
+            sh """
+                PLAYWRIGHT_JUNIT_OUTPUT_NAME=results.xml npx playwright test --project $browser --reporter=junit --workers 16 --grep "$grep"|| true
+            """
+        }
+    } finally {
+        junit 'results.xml'
+        sh """
+            mkdir -p ${resultDir}/results/${BRANCH_NAME}/${BUILD_NUMBER}/$REGION/
+            mkdir -p ./test-results
+            mv ./test-results/ ${resultDir}/results/${BRANCH_NAME}/${BUILD_NUMBER}/$REGION/
+        """
+    }
 }
 
 def withEnvFile(envfile, Closure cb) {


### PR DESCRIPTION
 1. Test parameter to specific a browser to test on.
 2. Test parameter to run tests with grep (to get a quick result for a given CMP/site).
 3. Reduce workers, so we have fewer issues when running two jobs simultaneously on once instance.