### PR TITLE
Reduce triggering of coinbase and theverge rules

### DIFF
--- a/rules/autoconsent/coinbase.json
+++ b/rules/autoconsent/coinbase.json
@@ -3,7 +3,8 @@
     "intermediate": false,
     "runContext": {
         "frame": true,
-        "main": true
+        "main": true,
+        "urlPattern": "^https://(www|help)\\.coinbase\\.com"
     },
     "prehideSelectors": [],
     "detectCmp": [
@@ -36,7 +37,7 @@
     ],
     "test": [
         {
-            "eval": "JSON.parse(decodeURIComponent(document.cookie.match(/cm_eu_preferences=([0-9a-zA-Z\\{\\}\\[\\]%:]*);?/)[1])).consent.length <= 1"
+            "eval": "JSON.parse(decodeURIComponent(document.cookie.match(/cm_(eu|default)_preferences=([0-9a-zA-Z\\{\\}\\[\\]%:]*);?/)[2])).consent.length <= 1"
         }
     ]
 }

--- a/rules/autoconsent/theverge.json
+++ b/rules/autoconsent/theverge.json
@@ -2,7 +2,8 @@
     "name": "theverge",
     "runContext": {
         "frame": false,
-        "main": true
+        "main": true,
+        "urlPattern": "^https://(www)?.\\theverge\\.com"
     },
     "intermediate": false,
     "prehideSelectors": [

--- a/rules/autoconsent/theverge.json
+++ b/rules/autoconsent/theverge.json
@@ -3,7 +3,7 @@
     "runContext": {
         "frame": false,
         "main": true,
-        "urlPattern": "^https://(www)?.\\theverge\\.com"
+        "urlPattern": "^https://(www)?\\.theverge\\.com"
     },
     "intermediate": false,
     "prehideSelectors": [


### PR DESCRIPTION
Followup on #95. Crawl data shows no additional sites match, so we might as well encode that in the `urlFilter`.