### PR TITLE
Remove wait from detectCmp step

### DIFF
--- a/rules/autoconsent/truyo.json
+++ b/rules/autoconsent/truyo.json
@@ -2,7 +2,6 @@
   "name": "truyo",
   "prehideSelectors": ["#truyo-consent-module"],
   "detectCmp": [
-    { "wait": 1000 },
     { "exists": "#truyo-cookieBarContent" }
   ],
   "detectPopup": [


### PR DESCRIPTION
We shouldn't be waiting in `detectCmp` steps, as this slows down the whole CMP detection process. This detection is retried multiple times anyway, so waiting is redundant.