### PR TITLE
Cancel prehide rules if the pop-up takes too long to appear

### DIFF
--- a/addon/background.ts
+++ b/addon/background.ts
@@ -23,23 +23,31 @@ async function initConfig() {
   console.log('init sw');
   const storedConfig = await storageGet('config');
   console.log('storedConfig', storedConfig);
+  const defaultConfig: Config = {
+    enabled: true,
+    autoAction: 'optOut', // if falsy, the extension will wait for an explicit user signal before opting in/out
+    disabledCmps: [],
+    enablePrehide: true,
+    enableCosmeticRules: true,
+    detectRetries: 20,
+    prehideTimeout: 2000,
+  };
   if (!storedConfig) {
     console.log('init config');
-    const defaultConfig: Config = {
-      enabled: true,
-      autoAction: 'optOut', // if falsy, the extension will wait for an explicit user signal before opting in/out
-      disabledCmps: [],
-      enablePrehide: true,
-      enableCosmeticRules: true,
-      detectRetries: 20,
-    };
     await storageSet({
       config: defaultConfig,
     });
-  } else if (typeof storedConfig.enableCosmeticRules === 'undefined') { // upgrade from old versions
-    storedConfig.enableCosmeticRules = true;
+  } else { // clean up the old stored config in case there are new fields
+    const updatedConfig: Config = structuredClone(defaultConfig);
+    for (const key of Object.keys(defaultConfig)) {
+      if (typeof storedConfig[key] !== 'undefined') {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore - TS doesn't know that we've checked for undefined
+        updatedConfig[key] = storedConfig[key];
+      }
+    }
     await storageSet({
-      config: storedConfig,
+      config: updatedConfig,
     });
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -34,6 +34,7 @@ export type Config = {
   enablePrehide: boolean;
   enableCosmeticRules: boolean;
   detectRetries: number;
+  prehideTimeout: number;
 }
 
 export type LifecycleState = 'loading' |

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -349,6 +349,16 @@ export default class AutoConsent {
     }, globalHidden);
 
     this.updateState({ prehideOn: true })
+    setTimeout(() => {
+      // unhide things if we are still looking for a pop-up
+      if (
+        this.config.enablePrehide &&
+        this.state.prehideOn &&
+        !['runningOptOut', 'runningOptIn'].includes(this.state.lifecycle)
+      ) {
+        this.undoPrehide();
+      }
+    }, this.config.prehideTimeout || 2000);
     return prehide(selectors);
   }
 

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -4,7 +4,7 @@ import { ConsentOMaticCMP, ConsentOMaticConfig } from './cmps/consentomatic';
 import { AutoConsentCMPRule } from './rules';
 import { enableLogs } from './config';
 import { BackgroundMessage, InitMessage } from './messages';
-import { prehide, undoPrehide } from './rule-executors';
+import { prehide, undoPrehide, wait } from './rule-executors';
 import { evalState, resolveEval } from './eval-handler';
 import { getRandomID } from './random';
 
@@ -202,12 +202,8 @@ export default class AutoConsent {
     }
 
     if (foundCMPs.length === 0 && retries > 0) {
-      return new Promise((resolve) => {
-        setTimeout(async () => {
-          const result = this.findCmp(retries - 1);
-          resolve(result);
-        }, 500);
-      });
+      await wait(500);
+      return this.findCmp(retries - 1);
     }
 
     return foundCMPs;
@@ -332,7 +328,8 @@ export default class AutoConsent {
     enableLogs && console.log('checking if popup is open...', cmp.name);
     const isOpen = await cmp.detectPopup();
     if (!isOpen && retries > 0) {
-      return new Promise((resolve) => setTimeout(() => resolve(this.waitForPopup(cmp, retries - 1, interval)), interval));
+      await wait(interval);
+      return this.waitForPopup(cmp, retries - 1, interval);
     }
     enableLogs && console.log(cmp.name, `popup is ${isOpen ? 'open' : 'not open'}`);
     return isOpen;

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -356,6 +356,7 @@ export default class AutoConsent {
         this.state.prehideOn &&
         !['runningOptOut', 'runningOptIn'].includes(this.state.lifecycle)
       ) {
+        enableLogs && console.log('Process is taking too long, unhiding elements');
         this.undoPrehide();
       }
     }, this.config.prehideTimeout || 2000);


### PR DESCRIPTION
This PR cancels the prehide rules if the pop-up does not appear within 2s. In this case users can still interact with the pop-up, in case it's not known to autoconsent

- This should fix the UX in case of unknown pop-ups, like [✓ Nationalgrid screen blurred Android (2023-06-25)](https://app.asana.com/0/1200277586140538/1204522885984681)
- It should not affect slow pop-ups like [stackoverflow.com](https://stackoverflow.com/)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205001758773482