### PR TITLE
Fix burpee rule matching and add new rule

### DIFF
--- a/rules/autoconsent/burpee-com.json
+++ b/rules/autoconsent/burpee-com.json
@@ -8,6 +8,6 @@
     { "click": "#btn-cookie-allow" }
   ],
   "optOut": [
-    { "hide": ["#html-body #notice-cookie-block"] }
+    { "hide": ["#html-body #notice-cookie-block", "#notice-cookie"] }
   ]
 }

--- a/rules/autoconsent/cookie-manager-popup.json
+++ b/rules/autoconsent/cookie-manager-popup.json
@@ -1,0 +1,42 @@
+{
+  "name": "cookie-manager-popup",
+  "cosmetic": false,
+  "runContext": {
+    "main": true,
+    "frame": false
+  },
+  "intermediate": false,
+  "detectCmp": [
+    {
+      "exists": "#notice-cookie-block"
+    }
+  ],
+  "detectPopup": [
+    {
+      "visible": "#notice-cookie-block"
+    }
+  ],
+  "optIn": [
+    {
+      "click": "#btn-cookie-allow"
+    }
+  ],
+  "optOut": [
+    {
+      "if": {
+        "exists": "#allow-functional-cookies"
+      },
+      "then": [{ "click": "#allow-functional-cookies" }],
+      "else": [
+        { "waitForThenClick": "#btn-cookie-settings" },
+        { "waitForVisible": ".modal-body" },
+        { "click": ".modal-body input:checked, .switch[data-switch=\"on\"]", "all": true, "optional": true },
+        { "click": "[role=\"dialog\"] .modal-footer button"}
+      ]
+    }
+  ],
+  "prehideSelectors": ["#btn-cookie-settings"],
+  "test": [{
+    "eval": "JSON.parse(document.cookie.split(';').find(c => c.trim().startsWith('CookieLevel')).split('=')[1]).social === false"
+  }]
+}

--- a/rules/autoconsent/cookie-manager-popup.json
+++ b/rules/autoconsent/cookie-manager-popup.json
@@ -8,7 +8,7 @@
   "intermediate": false,
   "detectCmp": [
     {
-      "exists": "#notice-cookie-block"
+      "exists": "#notice-cookie-block #allow-functional-cookies, #notice-cookie-block #btn-cookie-settings"
     }
   ],
   "detectPopup": [

--- a/tests/burpee-com.spec.ts
+++ b/tests/burpee-com.spec.ts
@@ -1,5 +1,6 @@
 import generateCMPTests from "../playwright/runner";
 
 generateCMPTests('burpee.com', [
-  'https://www.burpee.com/'
+  'https://www.burpee.com/',
+  'https://granit.com/se'
 ], {});

--- a/tests/cookie-manager-popup.spec.ts
+++ b/tests/cookie-manager-popup.spec.ts
@@ -1,0 +1,8 @@
+import generateCMPTests from "../playwright/runner";
+
+generateCMPTests('cookie-manager-popup', [
+  'https://www.focus-bikes.com/de_de/',
+  'https://www.gazelle.de/',
+  'https://www.kalkhoff-bikes.com/de_de/'
+], {
+});


### PR DESCRIPTION
- Fixes an issue with the overlay not being hidden on granit.com.
- Adds a new opt-out rule 'cookie-manager-popup' for some sites with opt-out that were matching the burpee.com rule.