### PR TITLE
Update trustarc-frame.ts

### DIFF
--- a/lib/cmps/trustarc-frame.ts
+++ b/lib/cmps/trustarc-frame.ts
@@ -82,16 +82,12 @@ export default class TrustArcFrame extends AutoConsentCMPBase {
 
     if (click("#catDetails0")) {
       click(".submit");
-      waitForElement("#gwt-debug-close_id", 5000).then(() => {
-        click("#gwt-debug-close_id");
-      });
+      waitForThenClick("#gwt-debug-close_id", 5000);
       return true;
     }
 
     if (click(".required")) {
-      waitForElement("#gwt-debug-close_id", 5000).then(() => {
-        click("#gwt-debug-close_id");
-      });
+      waitForThenClick("#gwt-debug-close_id", 5000);
       return true;
     }
 
@@ -102,9 +98,7 @@ export default class TrustArcFrame extends AutoConsentCMPBase {
     click(".submit");
 
     // at this point, iframe usually closes. Sometimes we need to close manually, but we don't wait for it to report success
-    waitForElement("#gwt-debug-close_id", 300000).then(() => {
-      click("#gwt-debug-close_id");
-    });
+    waitForThenClick("#gwt-debug-close_id", 300000);
 
     return true;
   }

--- a/lib/cmps/trustarc-frame.ts
+++ b/lib/cmps/trustarc-frame.ts
@@ -82,10 +82,16 @@ export default class TrustArcFrame extends AutoConsentCMPBase {
 
     if (click("#catDetails0")) {
       click(".submit");
+      waitForElement("#gwt-debug-close_id", 5000).then(() => {
+        click("#gwt-debug-close_id");
+      });
       return true;
     }
 
     if (click(".required")) {
+      waitForElement("#gwt-debug-close_id", 5000).then(() => {
+        click("#gwt-debug-close_id");
+      });
       return true;
     }
 


### PR DESCRIPTION
Added condition to close the modal window if the CMP is configured with an opt-out confirmation
Expected: The modal window should close when the opt-out done message appears.
Current:  The modal window keeps open after the opt-out done message appears.