### PR TITLE
Some optimizations

### DIFF
--- a/lib/web.ts
+++ b/lib/web.ts
@@ -158,7 +158,11 @@ export default class AutoConsent {
       }
       return false;
     }
+
     this.updateState({ lifecycle: 'openPopupDetected' });
+    if (this.config.enablePrehide && !this.state.prehideOn) { // prehide might have timeouted by this time, apply it again
+      this.prehideElements();
+    }
 
     if (foundPopups.length > 1) {
       const errorDetails = {

--- a/rules/autoconsent/zdf.json
+++ b/rules/autoconsent/zdf.json
@@ -1,0 +1,9 @@
+{
+  "name": "zdf",
+  "prehideSelectors": ["#zdf-cmp-banner-sdk"],
+  "detectCmp": [{ "exists": "#zdf-cmp-banner-sdk" }],
+  "detectPopup": [{ "visible": "#zdf-cmp-main.zdf-cmp-show" }],
+  "optIn": [ { "waitForThenClick": "#zdf-cmp-main #zdf-cmp-accept-btn" } ],
+  "optOut": [ { "waitForThenClick": "#zdf-cmp-main #zdf-cmp-deny-btn" } ],
+  "test": []
+}

--- a/tests/onetrust.spec.ts
+++ b/tests/onetrust.spec.ts
@@ -2,7 +2,6 @@ import generateCMPTests from "../playwright/runner";
 
 generateCMPTests('Onetrust', [
   'https://stackoverflow.com/',
-  'https://www.zdf.de/',
   "https://www.lovescout24.de/",
   "https://www.okcupid.com/",
   "https://doodle.com/",

--- a/tests/zdf.spec.ts
+++ b/tests/zdf.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from "../playwright/runner";
+
+generateCMPTests('zdf', [
+  'https://www.zdf.de/',
+]);


### PR DESCRIPTION
- support OneTrust reject button
- separate rule for zdf.de
- re-applying expired prehide if the pop-up is found late. This is often the case with OneTrust and causes flicker