### PR TITLE
Do not click on the youtube consent page

### DIFF
--- a/lib/rules.ts
+++ b/lib/rules.ts
@@ -22,9 +22,8 @@ export type RunContext = {
 
 export type ElementSelector = string | string[]
 
-export type AutoConsentRuleStep = { optional?: boolean } & Partial<
-  ElementExistsRule
-> &
+export type AutoConsentRuleStep = { optional?: boolean } &
+  Partial<ElementExistsRule> &
   Partial<ElementVisibleRule> &
   Partial<EvalRule> &
   Partial<WaitForRule> &
@@ -34,7 +33,7 @@ export type AutoConsentRuleStep = { optional?: boolean } & Partial<
   Partial<WaitRule> &
   Partial<UrlRule> &
   Partial<HideRule> &
-  Partial<IfRule> & 
+  Partial<IfRule> &
   Partial<AnyRule>
 
 export type ElementExistsRule = {

--- a/rules/autoconsent/google-consent-standalone.json
+++ b/rules/autoconsent/google-consent-standalone.json
@@ -3,15 +3,15 @@
   "prehideSelectors": [],
   "detectCmp": [
     { "exists": "a[href^=\"https://policies.google.com/technologies/cookies\"" },
-    { "exists": "form[action^=\"https://consent.\"][action$=\".com/save\"]" }
+    { "exists": "form[action^=\"https://consent.google.\"][action$=\".com/save\"]" }
   ],
   "detectPopup": [
     { "visible": "a[href^=\"https://policies.google.com/technologies/cookies\"" }
   ],
   "optIn": [
-    { "waitForThenClick": "form[action^=\"https://consent.\"][action$=\".com/save\"]:has(input[name=set_eom][value=false]) button" }
+    { "waitForThenClick": "form[action^=\"https://consent.google.\"][action$=\".com/save\"]:has(input[name=set_eom][value=false]) button" }
   ],
   "optOut": [
-    { "waitForThenClick": "form[action^=\"https://consent.\"][action$=\".com/save\"]:has(input[name=set_eom][value=true]) button" }
+    { "waitForThenClick": "form[action^=\"https://consent.google.\"][action$=\".com/save\"]:has(input[name=set_eom][value=true]) button" }
   ]
 }

--- a/rules/autoconsent/testcmp.json
+++ b/rules/autoconsent/testcmp.json
@@ -12,4 +12,4 @@
       { "click": "#reject-all" }
     ],
     "test": [{ "eval": "EVAL_TESTCMP_0" }]
-  }
+}


### PR DESCRIPTION
<!-- 
  PLEASE NOTE: Many people are automatically added as reviewers by default.
  Consider setting your PR as a draft unless you know you are ready for a review.
  Use the "merge when ready" label to help reviewers know to merge your PR as soon
  as it's reviewed.
-->

Mitigate https://github.com/duckduckgo/autoconsent/issues/310

**Asana Task/Github Issue:**
- https://app.asana.com/0/1177771139624306/1206194460412262/f
- https://github.com/duckduckgo/autoconsent/issues/310

## Description
Youtube doesn't allow rejecting cookies without disabling history, which may be too inconvenient for some users. So we should let users manage it themselves.

#### Reference
- [Config Reviewer Documentation](https://app.asana.com/0/1200890834746050/1204443212791216/f)
- [Config Maintainer Documentation](https://app.asana.com/0/1200890834746050/1200573250322769/f)
- [Feature Implementer Documentation](https://app.asana.com/0/1200890834746050/1201498956177210/f)

