### PR TITLE
Fix CSP errors when running eval rules in MV3 extension

### DIFF
--- a/addon/background.ts
+++ b/addon/background.ts
@@ -1,4 +1,5 @@
 import { enableLogs } from "../lib/config";
+import { snippets } from "../lib/eval-snippets";
 import { BackgroundMessage, ContentScriptMessage, DevtoolsMessage, ReportMessage } from "../lib/messages";
 import { Config, RuleBundle } from "../lib/types";
 import { manifestVersion, storageGet, storageRemove, storageSet } from "./mv-compat";
@@ -19,7 +20,7 @@ async function loadRules() {
   });
 }
 
-async function evalInTab(tabId: number, frameId: number, code: string): Promise<chrome.scripting.InjectionResult<boolean>[]> {
+async function evalInTab(tabId: number, frameId: number, code: string, snippetId?: keyof typeof snippets): Promise<chrome.scripting.InjectionResult<boolean>[]> {
   if (manifestVersion === 2) {
     return new Promise((resolve) => {
       chrome.tabs.executeScript(tabId, {
@@ -39,16 +40,7 @@ async function evalInTab(tabId: number, frameId: number, code: string): Promise<
       frameIds: [frameId],
     },
     world: "MAIN",
-    args: [code],
-    func: (code) => {
-      try {
-        return window.eval(code);
-      } catch (e) {
-        // ignore CSP errors
-        console.warn('eval error', code, e);
-        return;
-      }
-    },
+    func: snippets[snippetId],
   })
 }
 
@@ -104,7 +96,7 @@ chrome.runtime.onMessage.addListener(
         });
         break;
       case "eval":
-        evalInTab(tabId, frameId, msg.code).then(([result]) => {
+        evalInTab(tabId, frameId, msg.code, msg.snippetId).then(([result]) => {
           if (enableLogs) {
             console.groupCollapsed(`eval result for ${sender.origin || sender.url}`);
             console.log(msg.code, result.result);

--- a/lib/cmps/base.ts
+++ b/lib/cmps/base.ts
@@ -64,7 +64,7 @@ export default class AutoConsentCMPBase implements AutoCMP {
 
     const snippetSrc = getFunctionBody(snippet);
     enableLogs && console.log('async eval:', snippetId, snippetSrc);
-    return requestEval(snippetSrc).catch((e) => {
+    return requestEval(snippetSrc, snippetId).catch((e) => {
       enableLogs && console.error('error evaluating rule', snippetId, e);
       return false;
     });

--- a/lib/eval-handler.ts
+++ b/lib/eval-handler.ts
@@ -1,3 +1,4 @@
+import { snippets } from "./eval-snippets";
 import { ContentScriptMessage } from "./messages";
 import { getRandomID } from "./random";
 
@@ -30,12 +31,13 @@ export const evalState: EvalState = {
   sendContentMessage: null,
 }
 
-export function requestEval(code: string): Promise<boolean> {
+export function requestEval(code: string, snippetId?: keyof typeof snippets): Promise<boolean> {
   const id = getRandomID();
   evalState.sendContentMessage({
     type: 'eval',
     id,
     code,
+    snippetId,
   });
   const deferred = new Deferred<boolean>(id);
   evalState.pending.set(deferred.id, deferred);

--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -63,7 +63,7 @@ export const snippets = {
   EVAL_MEDIAVINE_0: () => document.querySelectorAll("[data-name=\"mediavine-gdpr-cmp\"] input[type=checkbox]").forEach(x => x.checked && x.click()) || true,
   EVAL_MICROSOFT_0: () => Array.from(document.querySelectorAll('div > button')).filter(el => el.innerText.match('Reject|Ablehnen'))[0].click() || true,
   EVAL_MICROSOFT_1: () => Array.from(document.querySelectorAll('div > button')).filter(el => el.innerText.match('Accept|Annehmen'))[0].click() || true,
-  EVAL_MICROSOFT_2: () => !!document.cookie.match('MSCC'),
+  EVAL_MICROSOFT_2: () => !!document.cookie.match('MSCC|GHCC'),
   EVAL_MOOVE_0: () => document.querySelectorAll('#moove_gdpr_cookie_modal input').forEach(i => { if (!i.disabled && i.name !== 'moove_gdpr_strict_cookies') i.checked = false }) || true,
   EVAL_ONENINETWO_0: () => document.cookie.includes('CC_ADVERTISING=NO') && document.cookie.includes('CC_ANALYTICS=NO'),
   EVAL_OPERA_0: () => document.cookie.includes('cookie_consent_essential=true') && !document.cookie.includes('cookie_consent_marketing=true'),

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -1,3 +1,4 @@
+import { snippets } from "./eval-snippets";
 import { Config, ConsentState, RuleBundle } from "./types";
 
 export type BackgroundMessage =
@@ -36,6 +37,7 @@ export type EvalMessage = {
   type: "eval";
   id: string;
   code: string;
+  snippetId?: keyof typeof snippets
 };
 
 export type DetectedMessage = {

--- a/tests/microsoft.spec.ts
+++ b/tests/microsoft.spec.ts
@@ -2,7 +2,8 @@ import generateCMPTests from "../playwright/runner";
 
 generateCMPTests('microsoft.com', [
   'https://docs.microsoft.com',
-  'https://answers.microsoft.com'
+  'https://answers.microsoft.com',
+  'https://github.com/enterprise',
 ], {
   skipRegions: ["US"]
 }


### PR DESCRIPTION
This works by passing a snippet id in the request message to the background script. In MV3, we use it to fetch the snippet function object and pass it to the API directly, avoiding `window.eval()`.
This is a follow up to #317, so some credit goes to @seia-soto