### PR TITLE
Add a rule for hema.com

### DIFF
--- a/lib/cmps/cookiebot.ts
+++ b/lib/cmps/cookiebot.ts
@@ -1,5 +1,4 @@
 import { click, elementExists, wait } from '../rule-executors';
-import { waitFor } from '../utils';
 import AutoConsentCMPBase from './base';
 
 export default class Cookiebot extends AutoConsentCMPBase {
@@ -23,9 +22,7 @@ export default class Cookiebot extends AutoConsentCMPBase {
   }
 
   async detectPopup() {
-    return await waitFor(() => {
-      return this.mainWorldEval('EVAL_COOKIEBOT_2')
-    }, 10, 500);
+    return this.mainWorldEval('EVAL_COOKIEBOT_2');
   }
 
   async optOut() {

--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -57,6 +57,7 @@ export const snippets = {
   EVAL_EZOIC_0: () => ezCMP.handleAcceptAllClick(),
   EVAL_EZOIC_1: () => !!document.cookie.match(/ezCMPCookieConsent=[^;]+\|2=0\|3=0\|4=0/),
   EVAL_GOOGLE_0: () => !!document.cookie.match(/SOCS=CAE/),
+  EVAL_HEMA_TEST_0: () => document.cookie.includes('cookies_rejected=1'),
   EVAL_IUBENDA_0: () => document.querySelectorAll('.purposes-item input[type=checkbox]:not([disabled])').forEach(x => {if(x.checked) x.click()}) || true,
   EVAL_IUBENDA_1: () => !!document.cookie.match(/_iub_cs-\d+=/),
   EVAL_JQUERY_COOKIEBAR_0: () => !document.cookie.includes('cookies-state=accepted'),

--- a/rules/autoconsent/hema-com.json
+++ b/rules/autoconsent/hema-com.json
@@ -1,14 +1,10 @@
 {
   "name": "hema",
-  "runContext": {
-    "urlPattern": "^https://(www\\.)?hema\\.com/"
-  },
   "prehideSelectors": [".cookie-modal"],
   "detectCmp": [
-    { "exists": ".cookie-modal" }
+    { "visible": ".cookie-modal .cookie-accept-btn" }
   ],
   "detectPopup": [
-    { "visible": ".cookie-modal" },
     { "visible": ".cookie-modal .cookie-accept-btn" }
   ],
   "optIn": [

--- a/rules/autoconsent/hema-com.json
+++ b/rules/autoconsent/hema-com.json
@@ -1,0 +1,27 @@
+{
+  "name": "hema.com",
+  "runContext": {
+    "urlPattern": "^https://(www\\.)?hema\\.com/"
+  },
+  "prehideSelectors": [".cookie-modal"],
+  "detectCmp": [
+    { "waitForVisible": ".cookie-modal" },
+    { "exists": ".cookie-modal" }
+  ],
+  "detectPopup": [
+    { "waitForVisible": ".cookie-modal" },
+    { "exists": ".cookie-modal" }
+  ],
+  "optIn": [
+    { "waitForThenClick": ".cookie-accept-btn" }
+  ],
+  "optOut": [
+    { "waitForThenClick": ".cookie-reject-btn" }
+  ],
+  "test": [
+    {
+      "visible": ".cookie-modal",
+      "check": "none"
+    }
+  ]
+}

--- a/rules/autoconsent/hema-com.json
+++ b/rules/autoconsent/hema-com.json
@@ -1,5 +1,8 @@
 {
   "name": "hema",
+  "runContext": {
+    "urlPattern": "^https://(www\\.)?hema\\.com/"
+  },
   "prehideSelectors": [".cookie-modal"],
   "detectCmp": [
     { "exists": ".cookie-modal" }

--- a/rules/autoconsent/hema-com.json
+++ b/rules/autoconsent/hema-com.json
@@ -1,27 +1,22 @@
 {
-  "name": "hema.com",
-  "runContext": {
-    "urlPattern": "^https://(www\\.)?hema\\.com/"
-  },
+  "name": "hema",
   "prehideSelectors": [".cookie-modal"],
   "detectCmp": [
-    { "waitForVisible": ".cookie-modal" },
     { "exists": ".cookie-modal" }
   ],
   "detectPopup": [
-    { "waitForVisible": ".cookie-modal" },
-    { "exists": ".cookie-modal" }
+    { "visible": ".cookie-modal" },
+    { "visible": ".cookie-modal .cookie-accept-btn" }
   ],
   "optIn": [
-    { "waitForThenClick": ".cookie-accept-btn" }
+    { "waitForThenClick": ".cookie-modal .cookie-accept-btn" }
   ],
   "optOut": [
-    { "waitForThenClick": ".cookie-reject-btn" }
+    { "waitForThenClick": ".cookie-modal .js-cookie-reject-btn" }
   ],
   "test": [
     {
-      "visible": ".cookie-modal",
-      "check": "none"
+      "eval": "EVAL_HEMA_TEST_0"
     }
   ]
 }

--- a/tests/hema.spec.ts
+++ b/tests/hema.spec.ts
@@ -1,0 +1,7 @@
+import generateCMPTests from "../playwright/runner";
+
+generateCMPTests('hema', [
+  'https://hema.nl/',
+  'https://www.hema.com/de-de',
+], {
+});


### PR DESCRIPTION
`hema.com` includes Cookiebot CMP script inside their website but it's unused in actual. For clues, `window.Cookiebot.dialog` and `window.Cookiebot.dialog?.visible` are not working as expected since `hema.com` isn't using Cookiebot.

refs https://github.com/ghostery/broken-page-reports/issues/416