### PR TITLE
Add a rule for ciaopeople.it

### DIFF
--- a/rules/autoconsent/ciaopeople-it.json
+++ b/rules/autoconsent/ciaopeople-it.json
@@ -1,16 +1,11 @@
 {
   "name": "ciaopeople.it",
-  "runContext": {
-    "urlPattern": "^https://(www\\.)?(ohga|lexplain|wamily|fanpage)\\.it/"
-  },
   "prehideSelectors": ["#cp-gdpr-choices"],
   "detectCmp": [
-    { "waitForVisible": "#cp-gdpr-choices" },
     { "exists": "#cp-gdpr-choices" }
   ],
   "detectPopup": [
-    { "waitForVisible": "#cp-gdpr-choices" },
-    { "exists": "#cp-gdpr-choices" }
+    { "visible": "#cp-gdpr-choices" }
   ],
   "optIn": [
     { "waitForThenClick": ".gdpr-btm__right > button:nth-child(2)" }

--- a/rules/autoconsent/ciaopeople-it.json
+++ b/rules/autoconsent/ciaopeople-it.json
@@ -1,7 +1,7 @@
 {
-  "name": "ohga.it",
+  "name": "ciaopeople.it",
   "runContext": {
-    "urlPattern": "^https://(www\\.)?ohga\\.it/"
+    "urlPattern": "^https://(www\\.)?(ohga|lexplain|wamily|fanpage)\\.it/"
   },
   "prehideSelectors": ["#cp-gdpr-choices"],
   "detectCmp": [

--- a/rules/autoconsent/ohga-it.json
+++ b/rules/autoconsent/ohga-it.json
@@ -1,0 +1,29 @@
+{
+  "name": "ohga.it",
+  "runContext": {
+    "urlPattern": "^https://(www\\.)?ohga\\.it/"
+  },
+  "prehideSelectors": ["#cp-gdpr-choices"],
+  "detectCmp": [
+    { "waitForVisible": "#cp-gdpr-choices" },
+    { "exists": "#cp-gdpr-choices" }
+  ],
+  "detectPopup": [
+    { "waitForVisible": "#cp-gdpr-choices" },
+    { "exists": "#cp-gdpr-choices" }
+  ],
+  "optIn": [
+    { "waitForThenClick": ".gdpr-btm__right > button:nth-child(2)" }
+  ],
+  "optOut": [
+    { "waitForThenClick": ".gdpr-top-content > button" },
+    { "waitFor": ".gdpr-top-back" },
+    { "waitForThenClick": ".gdpr-btm__right > button:nth-child(1)" }
+  ],
+  "test": [
+    {
+      "visible": "#cp-gdpr-choices",
+      "check": "none"
+    }
+  ]
+}

--- a/tests/ciaopeople-it.spec.ts
+++ b/tests/ciaopeople-it.spec.ts
@@ -1,6 +1,6 @@
 import generateCMPTests from "../playwright/runner";
 
-generateCMPTests('ciaopeople-it', [
+generateCMPTests('ciaopeople.it', [
   'https://ohga.it/',
   'https://lexplain.it/',
   'https://wamily.it/',

--- a/tests/ciaopeople-it.spec.ts
+++ b/tests/ciaopeople-it.spec.ts
@@ -1,0 +1,8 @@
+import generateCMPTests from "../playwright/runner";
+
+generateCMPTests('ciaopeople-it', [
+  'https://ohga.it/',
+  'https://lexplain.it/',
+  'https://wamily.it/',
+  'https://fanpage.it/'
+]);


### PR DESCRIPTION
The CMP in `ohga.it` looks like unique. I couldn't find a matching CMP in npm and publicwww. You can see the cookie consent popup in [`ohga.it`](https://ohga.it).

- https://publicwww.com/websites/%22%23cp-gdpr-choices%22/
- https://static-cmp22.ciaopeople.it/assets/r/2.0.44/sdk-gdpr-client.min.js
- https://ciaopeople.it

The value for `runContext.urlPattern` was referenced from the sidebar of `ciaopeople.it`.

refs https://github.com/ghostery/broken-page-reports/issues/318