### PR TITLE
Add a deferred check for usercentrics

### DIFF
--- a/rules/autoconsent/usercentrics-api.json
+++ b/rules/autoconsent/usercentrics-api.json
@@ -10,6 +10,10 @@
         "#usercentrics-root",
         "[data-testid=uc-container]"
       ]
+    },
+    {
+      "waitForVisible": "#usercentrics-root",
+      "timeout": 2000
     }
   ],
   "optIn": [


### PR DESCRIPTION
refs https://github.com/ghostery/broken-page-reports/issues/419

The current approach of usercentrics popup detection may not work for users experiencing a slow internet connection or slow page load. By adding `waitForVisible`, `autoconsent` can wait until the element is actually pops up.

- https://www.jochen-schweizer.de/geschenkgutscheine/Wertgutscheine/l/gwtim