### PR TITLE
Add a rule for csu-landtag.de

### DIFF
--- a/rules/autoconsent/csu-landtag-de.json
+++ b/rules/autoconsent/csu-landtag-de.json
@@ -1,0 +1,27 @@
+{
+    "name": "csu-landtag-de",
+    "runContext": {
+        "urlPattern": "^https://(www|)?\\.csu-landtag\\.de"
+    },
+    "prehideSelectors": ["#cookie-disclaimer"],
+    "detectCmp": [
+        {
+            "exists": "#cookie-disclaimer"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#cookie-disclaimer"
+        }
+    ],
+    "optIn": [
+        {
+            "click": "#cookieall"
+        }
+    ],
+    "optOut": [
+        {
+            "click": "#cookiesel"
+        }
+    ]
+}

--- a/tests/csu-landtag-de.spec.ts
+++ b/tests/csu-landtag-de.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from "../playwright/runner";
+
+generateCMPTests('csu-landtag-de', [
+  'https://www.csu-landtag.de/',
+]);


### PR DESCRIPTION
- https://www.csu-landtag.de/

refs https://github.com/ghostery/broken-page-reports/issues/337

The element with `#cookieno` selector exists but it isn't visible. `#cookiesel` with default checkbox works perfect.

<details>
<summary>Test results</summary>

```sh
% npx playwright test --grep csu-landtag-de

Running 8 tests using 4 workers

  ✓  1 [firefox] › ../playwright/runner.ts:50:9 › csu-landtag-de › www.csu-landtag.de/ .KR optIn  (6.7s)
  ✓  2 [chrome] › ../playwright/runner.ts:50:9 › csu-landtag-de › www.csu-landtag.de/ .KR optIn  (8.2s)
  -  3 [iphoneSE] › ../playwright/runner.ts:50:9 › csu-landtag-de › www.csu-landtag.de/ .KR optIn 
  ✓  4 [webkit] › ../playwright/runner.ts:50:9 › csu-landtag-de › www.csu-landtag.de/ .KR optIn  (6.1s)
  -  5 [iphoneSE] › ../playwright/runner.ts:50:9 › csu-landtag-de › www.csu-landtag.de/ .KR optOut 
  ✓  6 [webkit] › ../playwright/runner.ts:50:9 › csu-landtag-de › www.csu-landtag.de/ .KR optOut  (6.3s)
  ✓  7 [firefox] › ../playwright/runner.ts:50:9 › csu-landtag-de › www.csu-landtag.de/ .KR optOut  (7.2s)
  ✓  8 [chrome] › ../playwright/runner.ts:50:9 › csu-landtag-de › www.csu-landtag.de/ .KR optOut  (7.5s)

  Slow test file: [chrome] › ../playwright/runner.ts (15.7s)
  Consider splitting slow test files to speed up parallel execution
  2 skipped
  6 passed (16.4s)
```

</details>