### PR TITLE
Add a rule for roofingmegastore.co.uk

### DIFF
--- a/rules/autoconsent/roofingmegastore-co-uk.json
+++ b/rules/autoconsent/roofingmegastore-co-uk.json
@@ -1,0 +1,20 @@
+{
+  "name": "roofingmegastore.co.uk",
+  "runContext": {
+    "urlPattern": "^https://(www\\.)?roofingmegastore\\.co\\.uk"
+  },
+  "prehideSelectors": ["#m-cookienotice"],
+  "detectCmp": [
+    { "exists": "#m-cookienotice" }
+  ],
+  "detectPopup": [
+    { "visible": "#m-cookienotice" }
+  ],
+  "optIn": [
+    { "click": "#accept-cookies" }
+  ],
+  "optOut": [
+    { "click": "#manage-cookies" },
+    { "waitForThenClick": "#accept-selected" }
+  ]
+}

--- a/tests/roofingmegastore-co-uk.spec.ts
+++ b/tests/roofingmegastore-co-uk.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from "../playwright/runner";
+
+generateCMPTests('roofingmegastore.co.uk', [
+  'https://www.roofingmegastore.co.uk/',
+]);


### PR DESCRIPTION
refs https://github.com/ghostery/broken-page-reports/issues/344

<details>
<summary>Test results</summary>

```
% npx playwright test --grep roofingmegastore.co.uk

Running 8 tests using 4 workers

  -  1 [iphoneSE] › ../playwright/runner.ts:50:9 › roofingmegastore.co.uk › www.roofingmegastore.co.uk/ .NA optIn 
  ✓  2 [webkit] › ../playwright/runner.ts:50:9 › roofingmegastore.co.uk › www.roofingmegastore.co.uk/ .NA optIn  (4.3s)
  ✓  3 [chrome] › ../playwright/runner.ts:50:9 › roofingmegastore.co.uk › www.roofingmegastore.co.uk/ .NA optIn  (5.5s)
  ✓  4 [firefox] › ../playwright/runner.ts:50:9 › roofingmegastore.co.uk › www.roofingmegastore.co.uk/ .NA optIn  (5.5s)
  -  5 [iphoneSE] › ../playwright/runner.ts:50:9 › roofingmegastore.co.uk › www.roofingmegastore.co.uk/ .NA optOut 
  ✓  6 [webkit] › ../playwright/runner.ts:50:9 › roofingmegastore.co.uk › www.roofingmegastore.co.uk/ .NA optOut  (2.7s)
  ✓  7 [chrome] › ../playwright/runner.ts:50:9 › roofingmegastore.co.uk › www.roofingmegastore.co.uk/ .NA optOut  (2.5s)
  ✓  8 [firefox] › ../playwright/runner.ts:50:9 › roofingmegastore.co.uk › www.roofingmegastore.co.uk/ .NA optOut  (5.2s)

  2 skipped
  6 passed (12.2s)
```

</details>