### PR TITLE
Only use sites where the popup is open by default as examples

### DIFF
--- a/data/coverage.json
+++ b/data/coverage.json
@@ -20,8 +20,7 @@
         "http://www.backblaze.com/",
         "http://www.design911.co.uk/",
         "http://www.merseyrail.org/",
-        "http://www.ruarkaudio.com/",
-        "http://www.wanderlust.co.uk/"
+        "http://www.ruarkaudio.com/"
       ],
       "failingSites": [],
       "errorSites": [
@@ -36,10 +35,10 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://gadgetmates.com/",
-        "http://hiconsumption.com/",
-        "http://thecoconutmama.com/",
         "http://www.interweave.com/",
-        "http://www.oann.com/"
+        "http://mechanicsnews.com/",
+        "http://sailboatdata.com/",
+        "http://washingtoncitypaper.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -49,11 +48,11 @@
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.googlewatchblog.de/",
-        "http://aphog.com/",
-        "http://www.technikaffe.de/",
-        "http://vaterzeiten.de/",
-        "http://wolles-elektronikkiste.de/"
+        "http://macandegg.de/",
+        "http://echtsolar.de/",
+        "http://www.openmediavault.org/",
+        "http://blog.berrybase.de/",
+        "http://michael-nehls.de/"
       ],
       "failingSites": [
         "http://macandegg.de/"
@@ -65,11 +64,11 @@
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://svr.co.uk/",
-        "http://gadgetmates.com/",
-        "http://legalvision.co.uk/",
-        "http://www.westendtheatre.com/",
-        "http://www.southtees.nhs.uk/"
+        "http://thecocktailsociety.uk/",
+        "http://pandalondon.com/",
+        "http://www.newcastle-hospitals.nhs.uk/",
+        "http://horoscopes.co.uk/",
+        "http://thefast800.com/"
       ],
       "failingSites": [
         "http://rsgb.org/"
@@ -96,11 +95,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.ima-usa.com/",
-        "http://apmex.com/",
-        "http://www.opensubtitles.com/",
-        "http://www.wikifeet.com/",
-        "http://www.worldometers.info/"
+        "http://projectcamelotportal.com/",
+        "http://www.techgearlab.com/",
+        "http://www.outdoorgearlab.com/",
+        "http://coinapps.com/",
+        "http://www.tapatalk.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -110,11 +109,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.funkbasis.de/",
-        "http://allevents.in/",
-        "http://www.libreoffice-forum.de/",
-        "http://www.uniklinikum-dresden.de/",
-        "http://www.unitjuggler.com/"
+        "http://everymac.com/",
+        "http://www.outdoorgearlab.com/",
+        "http://www.internisten-im-netz.de/",
+        "http://blenderartists.org/",
+        "http://www.opensubtitles.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -124,11 +123,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.pinkbike.com/",
-        "http://archaeologydataservice.ac.uk/",
-        "http://www.exeter.ac.uk/",
-        "http://www.opendemocracy.net/",
-        "http://www.opensubtitles.com/"
+        "http://gparted.org/",
+        "http://www.harrisontelescopes.co.uk/",
+        "http://www.danword.com/",
+        "http://dating.telegraph.co.uk/",
+        "http://www.harmonystore.co.uk/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -141,9 +140,9 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://handbrake.fr/",
-        "http://shop.panasonic.com/",
         "http://www.lionbrand.com/",
-        "http://www.umcdiscipleship.org/",
+        "http://support.roku.com/",
+        "http://www.greenpan.us/",
         "http://www.laurageller.com/"
       ],
       "failingSites": [],
@@ -154,11 +153,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.lebenshilfe.de/",
-        "http://handbrake.fr/",
-        "http://support.polar.com/",
-        "http://www.kvberlin.de/",
-        "http://www.rheuma-liga.de/"
+        "http://www.dell.com/",
+        "http://www.awista.de/",
+        "http://www.edelmetall-handel.de/",
+        "http://rhinoshield.de/",
+        "http://www.dresden.de/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -168,11 +167,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.uclh.nhs.uk/",
-        "http://dl.dell.com/",
-        "http://jaycotts.co.uk/",
-        "http://www.surreycc.gov.uk/",
-        "http://www.roofbox.co.uk/"
+        "http://uk.kef.com/",
+        "http://mr-fothergills.co.uk/",
+        "http://www.hertz.co.uk/",
+        "http://handbrake.fr/",
+        "http://www.dartscorner.co.uk/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -184,11 +183,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.hifiklubben.de/",
-        "http://de.ecco.com/",
-        "http://www.boconcept.com/",
+        "http://www.netto.de/",
         "http://www.captureone.com/",
-        "http://www.colorline.de/"
+        "http://jysk.de/",
+        "http://skylum.com/",
+        "http://www.ortovox.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -199,9 +198,9 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://consumer.huawei.com/",
-        "http://flyingtiger.com/",
-        "http://www.carpetright.co.uk/",
         "http://www.puregym.com/",
+        "http://gb.ecco.com/",
+        "http://jysk.co.uk/",
         "http://www.sinful.co.uk/"
       ],
       "failingSites": [],
@@ -214,11 +213,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.scribbr.com/",
-        "http://business.tutsplus.com/",
-        "http://www.irishcentral.com/",
-        "http://www.redbubble.com/",
-        "http://www.redwoodcu.org/"
+        "http://www.jiffylube.com/",
+        "http://www.gelighting.com/",
+        "http://www.rheem.com/",
+        "http://server.nitrado.net/",
+        "http://www.mdlottery.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -228,11 +227,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.vrr.de/",
-        "http://www.koeln.de/",
-        "http://www.usm.com/",
-        "http://www.nuernberg.de/",
-        "http://stock3.com/"
+        "http://bistum-regensburg.de/",
+        "http://www.hamburg-airport.de/",
+        "http://www.visitvalencia.com/",
+        "http://www.erf.de/",
+        "http://priwatt.de/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -242,11 +241,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.poetryfashion.co.uk/",
-        "http://www.refinery29.com/",
-        "http://www.gog.com/",
-        "http://www.ucas.com/",
-        "http://www.architecture.com/"
+        "http://envato.com/",
+        "http://www.networkrail.co.uk/",
+        "http://tfl.gov.uk/",
+        "http://www.jarrolds.co.uk/",
+        "http://www.agathachristie.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -291,8 +290,8 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://mein-toilettenfetisch.com/",
-        "http://smago.de/",
         "http://www.umrechnung-zoll-cm.de/",
+        "http://www.aquaristik.org/",
         "http://www.oldiepornos.net/",
         "http://www.sky-angebot.de/"
       ],
@@ -306,11 +305,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.libe.net/",
-        "http://www.zambullo.de/",
-        "http://www.brainperform.de/",
-        "http://www.jesus-info.de/",
-        "http://www.kalender-uhrzeit.de/"
+        "http://feiertag.info/",
+        "http://www.dasbackstuebchen.de/",
+        "http://www.bauredakteur.de/",
+        "http://computingforgeeks.com/",
+        "http://www.dartn.de/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -320,11 +319,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.politics.co.uk/",
-        "http://anagram-solver.net/",
-        "http://www.beatlesbible.com/",
-        "http://www.linuxuprising.com/",
-        "http://www.marathi.tv/"
+        "http://funquizzes.uk/",
+        "http://www.cultofmac.com/",
+        "http://wahapedia.ru/",
+        "http://arduinogetstarted.com/",
+        "http://www.cookingtimes.co.uk/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -337,10 +336,10 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://www.amwater.com/",
-        "http://www.bigfishgames.com/",
-        "http://www.funimation.com/",
-        "http://www.subaru.com/",
-        "http://www.udiscovermusic.com/"
+        "http://www.udiscovermusic.com/",
+        "http://www.campbells.com/",
+        "http://www.drhorton.com/",
+        "http://www.firstam.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -351,8 +350,8 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://blog.de.playstation.com/",
-        "http://store.canon.de/",
         "http://www.playstation.com/",
+        "http://www.boels.com/",
         "http://www.canon-europe.com/",
         "http://www.canon.de/"
       ],
@@ -364,11 +363,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.cruisecritic.com/",
-        "http://devforum.roblox.com/",
-        "http://store.canon.co.uk/",
+        "http://www.holidaylettings.co.uk/",
         "http://www.atgtickets.com/",
-        "http://www.bigfishgames.com/"
+        "http://www.udiscovermusic.com/",
+        "http://en.help.roblox.com/",
+        "http://www.shell.co.uk/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -394,18 +393,18 @@
       "errors": 0,
       "selfTestFailures": 14,
       "exampleSites": [
-        "http://www.kodinerds.net/",
-        "http://forums.debian.net/",
-        "http://www.nachdenkseiten.de/",
-        "http://www.taschenhirn.de/",
-        "http://www.umweltbundesamt.de/"
+        "http://www.alteoper.de/",
+        "http://www.praxisdienst.de/",
+        "http://www.lebenslauf.de/",
+        "http://maconline.de/",
+        "http://www.potsdam.de/"
       ],
       "failingSites": [
+        "http://www.diabetesde.org/",
+        "http://www.kostuempalast.de/",
+        "http://www.fuerth.de/",
         "http://www.lebenslauf.de/",
-        "http://meinmacher.com/",
-        "http://www.alteoper.de/",
-        "http://www.ard-digital.de/",
-        "http://www.kostuempalast.de/"
+        "http://www.arturia.com/"
       ],
       "errorSites": []
     },
@@ -415,9 +414,9 @@
       "selfTestFailures": 2,
       "exampleSites": [
         "http://forums.debian.net/",
-        "http://simplyseaviews.co.uk/",
-        "http://www.groupaccommodation.com/",
         "http://www.powerhouse-fitness.co.uk/",
+        "http://www.arturia.com/",
+        "http://www.barbican.org.uk/",
         "http://www.spain.info/"
       ],
       "failingSites": [
@@ -433,11 +432,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.matthiashaltenhof.de/",
-        "http://akkusbatterien.de/",
-        "http://the3dprinterbee.com/",
-        "http://www.howtouselinux.com/",
-        "http://www.kanarenzeit.de/"
+        "http://exputer.com/",
+        "http://windowsreport.com/",
+        "http://stable-diffusion-art.com/",
+        "http://bobbyhadz.com/",
+        "http://wiesieliebt.de/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -447,11 +446,11 @@
       "errors": 1,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://moneyzine.com/",
-        "http://spreadsheetplanet.com/",
-        "http://www.headphonesty.com/",
-        "http://thegadgetbuyer.com/",
-        "http://missvickie.com/"
+        "http://bobbyhadz.com/",
+        "http://integraudio.com/",
+        "http://happymuncher.com/",
+        "http://www.joincake.com/",
+        "http://insanelygoodrecipes.com/"
       ],
       "failingSites": [],
       "errorSites": [
@@ -466,10 +465,8 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://celebrityinside.com/",
-        "http://robots.net/",
-        "http://www.seymourduncan.com/",
-        "http://www.cbinsights.com/",
-        "http://www.henryusa.com/"
+        "http://www.henryusa.com/",
+        "http://www.seymourduncan.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -480,10 +477,10 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://augengeradeaus.net/",
-        "http://dikgames.com/",
-        "http://robots.net/",
-        "http://www.messer-mojo.de/",
-        "http://www.mwgfd.org/"
+        "http://www.schiffe-und-kreuzfahrten.de/",
+        "http://hejsweden.com/",
+        "http://immotags.de/",
+        "http://www.schulferien-online.de/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -494,10 +491,10 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://celebrityinside.com/",
-        "http://dikgames.com/",
-        "http://storables.com/",
         "http://www.goonhammer.com/",
-        "http://www.wheelbase.co.uk/"
+        "http://hoa.org.uk/",
+        "http://skygarden.london/",
+        "http://theaudiophileman.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -509,11 +506,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.spglobal.com/",
-        "http://www.taxact.com/",
-        "http://www.mlb.com/",
-        "http://www.labcorp.com/",
-        "http://gis.stackexchange.com/"
+        "http://askubuntu.com/",
+        "http://www.49ers.com/",
+        "http://www.tatler.com/",
+        "http://softwareengineering.stackexchange.com/",
+        "http://eu4.paradoxwikis.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -523,11 +520,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.premierleague.com/",
-        "http://www.realvnc.com/",
-        "http://www.izotope.com/",
-        "http://www.h-hotels.com/",
-        "http://de.statista.com/"
+        "http://www.wolle-roedel.com/",
+        "http://www.thieme-connect.de/",
+        "http://www.pioneerdj.com/",
+        "http://lifehacker.com/",
+        "http://de.freepik.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -537,11 +534,11 @@
       "errors": 2,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.cnet.com/",
-        "http://www.coop.co.uk/",
-        "http://www.beano.com/",
-        "http://www.treehugger.com/",
-        "http://www.massimodutti.com/"
+        "http://www.winfieldsoutdoors.co.uk/",
+        "http://www.pocruises.com/",
+        "http://www.christopherward.com/",
+        "http://www.three.co.uk/",
+        "http://www.warhammer.com/"
       ],
       "failingSites": [],
       "errorSites": [
@@ -568,9 +565,9 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://berlin.kauperts.de/",
-        "http://odir.org/",
-        "http://www.manualsbase.com/",
         "http://www.palmengarten.de/",
+        "http://www.buchfreund.de/",
+        "http://www.hautschutzengel.de/",
         "http://www.vfb.de/"
       ],
       "failingSites": [],
@@ -581,10 +578,10 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.rspca.org.uk/",
-        "http://n-somerset.gov.uk/",
-        "http://www.glasgow.gov.uk/",
+        "http://map.projectzomboid.com/",
         "http://www.j2ski.com/",
+        "http://radioreferenceuk.co.uk/",
+        "http://tv-films.co.uk/",
         "http://www.lse.ac.uk/"
       ],
       "failingSites": [],
@@ -598,9 +595,9 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://archzine.net/",
-        "http://classic.goldgoblin.net/",
-        "http://www.betaseries.com/",
         "http://www.free-scores.com/",
+        "http://deavita.com/",
+        "http://manacrew.de/",
         "http://www.tokyvideo.com/"
       ],
       "failingSites": [],
@@ -612,8 +609,8 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://aleteia.org/",
-        "http://cineuropa.org/",
         "http://www.free-scores.com/",
+        "http://tunebat.com/",
         "http://www.dafont.com/",
         "http://www.for-sale.co.uk/"
       ],
@@ -627,10 +624,10 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.skysports.com/",
-        "http://news.sky.com/",
-        "http://www.gardenersworld.com/",
+        "http://www.theguardian.com/",
         "http://www.myfitnesspal.com/",
+        "http://www.economist.com/",
+        "http://www.eurogamer.net/",
         "http://www.radiotimes.com/"
       ],
       "failingSites": [],
@@ -641,11 +638,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.planespotters.net/",
-        "http://www.fremdwort.de/",
-        "http://www.wieistmeineip.de/",
-        "http://www.the-sun.com/",
-        "http://service.sueddeutsche.de/"
+        "http://die-frau-am-grill.de/",
+        "http://www.hannover.de/",
+        "http://nebenan.de/",
+        "http://www.economist.com/",
+        "http://ratgeber.bunte.de/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -655,11 +652,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.portsmouth.co.uk/",
-        "http://www.serebii.net/",
-        "http://www.worldatlas.com/",
-        "http://www.tomsguide.com/",
-        "http://www.bucksfreepress.co.uk/"
+        "http://eso-hub.com/",
+        "http://www.neowin.net/",
+        "http://themanc.com/",
+        "http://www.hamhigh.co.uk/",
+        "http://www.audi-sport.net/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -671,11 +668,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.oakley.com/",
-        "http://help.brother-usa.com/",
-        "http://www.brother-usa.com/",
+        "http://www.otterbox.com/",
         "http://www.hagerty.com/",
-        "http://www.jacquielawson.com/"
+        "http://www.americangreetings.com/",
+        "http://www.bluemountain.com/",
+        "http://www.tdameritrade.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -685,11 +682,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.uber.com/",
-        "http://dsl.1und1.de/",
-        "http://hilfe-center.1und1.de/",
-        "http://www.otterbox.de/",
-        "http://www.sim.de/"
+        "http://www.avis.de/",
+        "http://telekom.de/",
+        "http://www.eurostar.com/",
+        "http://falke.com/",
+        "http://www.blacksim.de/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -699,11 +696,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.sainsburysbank.co.uk/",
-        "http://bank.barclays.co.uk/",
-        "http://personal.help.royalmail.com/",
-        "http://www.holidayhypermarket.co.uk/",
-        "http://www.nisbets.co.uk/"
+        "http://www.avis.co.uk/",
+        "http://tuclothing.sainsburys.co.uk/",
+        "http://www.tsb.co.uk/",
+        "http://help.argos.co.uk/",
+        "http://www.barclays.co.uk/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -715,11 +712,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.solostove.com/",
-        "http://fightingirish.com/",
-        "http://ukathletics.com/",
+        "http://codes.iccsafe.org/",
         "http://www.msisurfaces.com/",
-        "http://www.partzilla.com/"
+        "http://hawkeyesports.com/",
+        "http://kuathletics.com/",
+        "http://www.solostove.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -729,11 +726,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.classic.co.uk/",
-        "http://blackcircles.com/",
-        "http://wave.video/",
-        "http://www.vintagesynth.com/",
-        "http://www.whiskyshop.com/"
+        "http://www.maxphoto.co.uk/",
+        "http://www.andertons.co.uk/",
+        "http://www.qmul.ac.uk/",
+        "http://koinly.io/",
+        "http://www.nymr.co.uk/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -745,10 +742,10 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.irobot.com/",
-        "http://commercial.century21.com/",
-        "http://seaworld.com/",
-        "http://www.underarmour.com/",
+        "http://hamiltonbeach.com/",
+        "http://www.wacom.com/",
+        "http://www.philips-hue.com/",
+        "http://www.pickswise.com/",
         "http://www.usa.philips.com/"
       ],
       "failingSites": [],
@@ -759,11 +756,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.ihg.com/",
-        "http://css-tricks.com/",
-        "http://fortune.com/",
-        "http://www.westerndigital.com/",
-        "http://www.digitalocean.com/"
+        "http://www.linode.com/",
+        "http://www.flickr.com/",
+        "http://dev.mysql.com/",
+        "http://docs.oracle.com/",
+        "http://www.philips-hue.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -773,11 +770,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.redrow.co.uk/",
-        "http://api.flickr.com/",
-        "http://www.underarmour.co.uk/",
-        "http://www.flickr.com/",
-        "http://www.java.com/"
+        "http://flickr.com/",
+        "http://dev.mysql.com/",
+        "http://store.ee.co.uk/",
+        "http://community.bt.com/",
+        "http://my.bt.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -789,11 +786,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.westerndigital.com/",
-        "http://answers.sap.com/",
-        "http://firsttechfed.com/",
-        "http://www.lincolnfinancial.com/",
-        "http://www.pickswise.com/"
+        "http://www.delonghi.com/",
+        "http://opensource.com/",
+        "http://www.hillspet.com/",
+        "http://commercial.century21.com/",
+        "http://www.dnb.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -803,11 +800,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.ibm.com/",
-        "http://answers.sap.com/",
-        "http://docs.nginx.com/",
-        "http://www.hostelworld.com/",
-        "http://www.osprey.com/"
+        "http://support.garmin.com/",
+        "http://eu.zwift.com/",
+        "http://www.braunhousehold.com/",
+        "http://connect.garmin.com/",
+        "http://www.aboutamazon.de/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -817,11 +814,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.sagasavings.co.uk/",
-        "http://connect.garmin.com/",
-        "http://www.trade-point.co.uk/",
-        "http://www.hostelworld.com/",
-        "http://www.landrover.co.uk/"
+        "http://www.akaipro.com/",
+        "http://www8.garmin.com/",
+        "http://www.squarespace.com/",
+        "http://fortune.com/",
+        "http://www.zwift.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -878,8 +875,8 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://uk.lycoschat.com/",
-        "http://www.football365.com/",
         "http://www.vivobarefoot.com/",
+        "http://www.gsmarena.com/",
         "http://www.planetf1.com/",
         "http://www.searchenginejournal.com/"
       ],
@@ -893,11 +890,8 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://bittel.tv/",
         "http://starthardware.org/",
-        "http://www.meininger.de/",
-        "http://www.hamburgausflug.de/",
-        "http://www.madymorrison.com/"
+        "http://www.meininger.de/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -910,9 +904,9 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://de.finance.yahoo.com/",
-        "http://de.hilfe.yahoo.com/",
-        "http://news.yahoo.com/",
         "http://www.aol.de/",
+        "http://de.nachrichten.yahoo.com/",
+        "http://de.yahoo.com/",
         "http://www.engadget.com/"
       ],
       "failingSites": [],
@@ -923,10 +917,10 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.engadget.com/",
-        "http://help.yahoo.com/",
-        "http://uk.finance.yahoo.com/",
+        "http://www.yahoo.com/",
         "http://uk.style.yahoo.com/",
+        "http://news.yahoo.com/",
+        "http://overview.mail.yahoo.com/",
         "http://uk.yahoo.com/"
       ],
       "failingSites": [],
@@ -1023,9 +1017,9 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://cricut.com/",
-        "http://www.dunhamssports.com/",
-        "http://www.martinguitar.com/",
         "http://www.towerhobbies.com/",
+        "http://www.horizonhobby.com/",
+        "http://www.hpb.com/",
         "http://www.westmarine.com/"
       ],
       "failingSites": [],
@@ -1082,12 +1076,7 @@
       "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
-      "exampleSites": [
-        "http://aws.amazon.com/",
-        "http://docs.aws.amazon.com/",
-        "http://repost.aws/",
-        "http://s3.amazonaws.com/"
-      ],
+      "exampleSites": [],
       "failingSites": [],
       "errorSites": []
     },
@@ -1181,11 +1170,11 @@
       "errors": 0,
       "selfTestFailures": 3,
       "exampleSites": [
-        "http://www.careelite.de/",
-        "http://www.famila-nordost.de/",
-        "http://www.nikon-fotografie.de/",
-        "http://www.geschichte-abitur.de/",
-        "http://www.bonedo.de/"
+        "http://ebike-mtb.com/",
+        "http://www.abenteuerfreundschaft.de/",
+        "http://splendido-magazin.de/",
+        "http://www.project-audio.com/",
+        "http://www.abenteuer-brettspiele.de/"
       ],
       "failingSites": [
         "http://funduino.de/",
@@ -1227,10 +1216,10 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://www.audio-technica.com/",
-        "http://www.burpee.com/",
-        "http://www.omegawatches.com/",
+        "http://www.truevalue.com/",
+        "http://www.knfilters.com/",
         "http://www.mossberg.com/",
-        "http://www.nosler.com/"
+        "http://www.omegawatches.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1252,11 +1241,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.nevisport.com/",
-        "http://bananafingers.co.uk/",
-        "http://www.anglingdirect.co.uk/",
+        "http://www.hifigear.co.uk/",
+        "http://www.charlies.co.uk/",
         "http://www.moleonline.com/",
-        "http://www.shedstore.co.uk/"
+        "http://www.anglingdirect.co.uk/",
+        "http://www.houseofwatches.co.uk/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1329,9 +1318,9 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://gamcore.com/",
-        "http://govsalaries.com/",
-        "http://www.corporationwiki.com/",
         "http://www.nationsonline.org/",
+        "http://nytminicrossword.com/",
+        "http://orteil.dashnet.org/",
         "http://www.umass.edu/"
       ],
       "failingSites": [],
@@ -1342,11 +1331,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.angst-verstehen.de/",
-        "http://board.jdownloader.org/",
-        "http://gamcore.com/",
-        "http://www.schule-bw.de/",
-        "http://www.semperoper.de/"
+        "http://www.de-bedienungsanleitung.de/",
+        "http://retropie.org.uk/",
+        "http://www.grundtabelle.de/",
+        "http://distrowatch.com/",
+        "http://www.die-bibel.de/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1356,11 +1345,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.food.gov.uk/",
-        "http://gamcore.com/",
-        "http://retropie.org.uk/",
+        "http://www.naturespot.org.uk/",
         "http://www.citypopulation.de/",
-        "http://www.easyliveauction.com/"
+        "http://www.walkhighlands.co.uk/",
+        "http://meetyou.me/",
+        "http://www.sevenoaks.gov.uk/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1383,10 +1372,10 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://community.naimaudio.com/",
-        "http://tetris.com/",
-        "http://www.soundonsound.com/",
+        "http://www.film.tv/",
         "http://www.gameswelt.de/",
-        "http://www.jamieoliver.com/"
+        "http://www.jamieoliver.com/",
+        "http://www.soundonsound.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1396,11 +1385,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.newham.gov.uk/",
-        "http://www.swinton.co.uk/",
-        "http://www.eastsuffolk.gov.uk/",
-        "http://www.whitehorsedc.gov.uk/",
-        "http://www.midsuffolk.gov.uk/"
+        "http://maidstone.gov.uk/",
+        "http://www.hants.gov.uk/",
+        "http://www.dorsetcouncil.gov.uk/",
+        "http://community.naimaudio.com/",
+        "http://www.freedom-leisure.co.uk/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1424,8 +1413,8 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://tellymix.co.uk/",
-        "http://www.hifiwigwam.com/",
         "http://www.thesalarycalculator.co.uk/",
+        "http://www.housepricesintheuk.co.uk/",
         "http://www.income-tax.co.uk/",
         "http://www.pdc.tv/"
       ],
@@ -1438,9 +1427,7 @@
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.prostata-hilfe-deutschland.de/"
-      ],
+      "exampleSites": [],
       "failingSites": [],
       "errorSites": []
     }
@@ -1463,11 +1450,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.theweathernetwork.com/",
-        "http://dictionary.reverso.net/",
-        "http://filehippo.com/",
-        "http://www.shure.com/",
-        "http://www.msccruisesusa.com/"
+        "http://en.as.com/",
+        "http://www.rajce.idnes.cz/",
+        "http://giphy.com/",
+        "http://guide.michelin.com/",
+        "http://www.shure.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1477,11 +1464,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.viamichelin.de/",
-        "http://context.reverso.net/",
-        "http://www.leboncoin.fr/",
-        "http://www.saechsische.de/",
-        "http://www.senscritique.com/"
+        "http://kurier.at/",
+        "http://www.marmiton.org/",
+        "http://www.gamestar.de/",
+        "http://dictionary.reverso.net/",
+        "http://www.manomano.de/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1491,11 +1478,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.plantura.garden/",
-        "http://context.reverso.net/",
-        "http://www.utorrent.com/",
-        "http://www.filmweb.pl/",
-        "http://www.independent.ie/"
+        "http://www.90min.com/",
+        "http://www.vivino.com/",
+        "http://www.shure.com/",
+        "http://elpais.com/",
+        "http://www.atseuromaster.co.uk/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1508,8 +1495,8 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://ersatzteildirect.de/",
-        "http://www.ersatzteilfachmann.de/",
         "http://www.wolf-online-shop.de/",
+        "http://www.fein-hifi.de/",
         "http://www.ipc-computer.de/",
         "http://www.led-centrum.de/"
       ],
@@ -1560,11 +1547,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.oxford.gov.uk/",
-        "http://community.st.com/",
-        "http://storelocator.asda.com/",
+        "http://www.poundstretcher.co.uk/",
         "http://www.britishgas.co.uk/",
-        "http://www.chinasearch.co.uk/"
+        "http://eu.forums.blizzard.com/",
+        "http://forums.sketchup.com/",
+        "http://www.stovax.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1576,11 +1563,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://nomanssky.fandom.com/",
-        "http://anno1800.fandom.com/",
-        "http://terraria.fandom.com/",
-        "http://harry-potter.fandom.com/",
-        "http://jedipedia.fandom.com/"
+        "http://dontstarve.fandom.com/",
+        "http://witcher.fandom.com/",
+        "http://reddead.fandom.com/",
+        "http://baldursgate.fandom.com/",
+        "http://warhammer40k.fandom.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1590,11 +1577,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://sims.fandom.com/",
-        "http://zelda.fandom.com/",
-        "http://lotr.fandom.com/",
-        "http://residentevil.fandom.com/",
-        "http://riskofrain2.fandom.com/"
+        "http://coronationstreet.fandom.com/",
+        "http://memory-alpha.fandom.com/",
+        "http://hypixel-skyblock.fandom.com/",
+        "http://ark.fandom.com/",
+        "http://megamitensei.fandom.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1618,7 +1605,6 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://coupons.businessinsider.com/",
         "http://coupons.cnn.com/",
         "http://financeband.com/",
         "http://www.bosch-home.com/",
@@ -1632,11 +1618,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.verdi.de/",
-        "http://www.landundforst.de/",
-        "http://www.trauer.ms/",
-        "http://www.nordbayern.de/",
-        "http://waschbaer.de/"
+        "http://correctiv.org/",
+        "http://www.grazia-magazin.de/",
+        "http://www.wer-weiss-was.de/",
+        "http://www.engelhorn.de/",
+        "http://shop.zeit.de/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1646,11 +1632,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.lights.co.uk/",
-        "http://professional.vaillant.co.uk/",
-        "http://www.allbatteries.co.uk/",
+        "http://www.mytyres.co.uk/",
         "http://www.brita.co.uk/",
-        "http://www.findaphd.com/"
+        "http://www.vaillant.co.uk/",
+        "http://slashdot.org/",
+        "http://www.nivea.co.uk/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1662,11 +1648,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://theskilesson.com/",
-        "http://christianeducatorsacademy.com/",
-        "http://gflenv.com/",
+        "http://www.diamonds.pro/",
+        "http://overviewbible.com/",
         "http://www.queerty.com/",
-        "http://www.uchealth.org/"
+        "http://drhyman.com/",
+        "http://www.mysextoyguide.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1676,11 +1662,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.dzi.de/",
-        "http://blockchainwelt.de/",
-        "http://intelligent-leben.de/",
-        "http://www.doppelkopf-palast.de/",
-        "http://www.plattenspieler-guru.de/"
+        "http://schnittmuster-datenbank.de/",
+        "http://oyva.de/",
+        "http://www.bessermorgen.com/",
+        "http://gocuckold.com/",
+        "http://torsearch.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1690,11 +1676,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.live-darts.com/",
-        "http://baddiehub.com/",
-        "http://www.thegreenage.co.uk/",
-        "http://theorytest.org.uk/",
-        "http://winaero.com/"
+        "http://mobalytics.gg/",
+        "http://hifiplus.com/",
+        "http://www.sunstore.co.uk/",
+        "http://bushcraftuk.com/",
+        "http://moneytothemasses.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1706,11 +1692,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.dentaly.org/",
-        "http://fnamerica.com/",
-        "http://ridermagazine.com/",
+        "http://www.earthtrekkers.com/",
         "http://ubuntuhandbook.org/",
-        "http://ultimaker.com/"
+        "http://www.sixflags.com/",
+        "http://kingcomix.com/",
+        "http://www.libertynation.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1720,11 +1706,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.vitalstoffmedizin.com/",
-        "http://artinwords.de/",
-        "http://expressantworten.com/",
-        "http://www.frauporn.com/",
-        "http://www.laweekly.com/"
+        "http://technoguru.istocks.club/",
+        "http://kingcomix.com/",
+        "http://uncutnews.ch/",
+        "http://esmark.de/",
+        "http://thelordofporn.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1734,11 +1720,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.transact-online.co.uk/",
-        "http://britishturkey.org.uk/",
-        "http://kingcomix.com/",
-        "http://www.thephoblographer.com/",
-        "http://www.mysmallspace.co.uk/"
+        "http://ultimaker.com/",
+        "http://naturaler.co.uk/",
+        "http://www.dxomark.com/",
+        "http://grumpygreen.cricket/",
+        "http://www.anytimefitness.co.uk/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1762,11 +1748,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.webcamgalore.de/",
-        "http://botland.de/",
-        "http://lewdspot.com/",
-        "http://www.vrm-trauer.de/",
-        "http://www.regioactive.de/"
+        "http://www.arzt-auskunft.de/",
+        "http://sich-erinnern.de/",
+        "http://www.helles-koepfchen.de/",
+        "http://fixthephoto.com/",
+        "http://www.elriwa.de/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1776,11 +1762,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.fwi.co.uk/",
-        "http://fixthephoto.com/",
-        "http://sparxmaths.com/",
-        "http://www.webcamgalore.com/",
-        "http://www.bes.co.uk/"
+        "http://www.gramophone.co.uk/",
+        "http://www.247backgammon.org/",
+        "http://www.skiworld.co.uk/",
+        "http://mopoga.com/",
+        "http://www.moddb.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -1802,11 +1788,11 @@
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.norddeich.de/",
-        "http://ead.darmstadt.de/",
-        "http://www.saalbach.com/",
-        "http://www.g-portal.com/",
-        "http://www.horl.com/"
+        "http://www.avr-kommunal.de/",
+        "http://www.tourentipp.com/",
+        "http://www.preiswert-uebernachten.de/",
+        "http://gesundpedia.de/",
+        "http://www.stadtwerke-osnabrueck.de/"
       ],
       "failingSites": [
         "http://www.smeg.com/"
@@ -1818,10 +1804,10 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.smeguk.com/",
-        "http://moneynerd.co.uk/",
-        "http://www.hussle.com/",
+        "http://www.unbiased.co.uk/",
         "http://www.jollyes.co.uk/",
+        "http://rab.equipment/",
+        "http://warthunder.com/",
         "http://www.knivesandtools.co.uk/"
       ],
       "failingSites": [],
@@ -1834,11 +1820,11 @@
       "errors": 0,
       "selfTestFailures": 4,
       "exampleSites": [
-        "http://www.sheetmusicplus.com/",
-        "http://countylocalnews.com/",
-        "http://www.cpr.org/",
-        "http://www.earnthenecklace.com/",
-        "http://www.enginebuildermag.com/"
+        "http://www.wegmans.com/",
+        "http://www.enginebuildermag.com/",
+        "http://goodmenproject.com/",
+        "http://opencorporates.com/",
+        "http://www.gunmann.com/"
       ],
       "failingSites": [
         "http://trustandwill.com/",
@@ -1853,10 +1839,10 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.solaredge.com/",
-        "http://de.drivereasy.com/",
-        "http://www.blogseite.com/",
+        "http://www.sudelfeld.de/",
         "http://www.citysports.de/",
+        "http://ki-bild-erstellen.de/",
+        "http://knyfe.de/",
         "http://www.drivereasy.com/"
       ],
       "failingSites": [],
@@ -1867,11 +1853,11 @@
       "errors": 0,
       "selfTestFailures": 3,
       "exampleSites": [
-        "http://www.photoroom.com/",
-        "http://goodmenproject.com/",
-        "http://opencorporates.com/",
-        "http://www.naturalbedcompany.co.uk/",
-        "http://www.supereasy.com/"
+        "http://www.drivereasy.com/",
+        "http://thefamilycookbook.co.uk/",
+        "http://www.jdgyms.co.uk/",
+        "http://labour.org.uk/",
+        "http://www.firstlightoptics.com/"
       ],
       "failingSites": [
         "http://www.chards.co.uk/",
@@ -1900,8 +1886,8 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://camslib.com/",
-        "http://notube.cc/",
         "http://www.netgear.com/",
+        "http://pastly.de/",
         "http://www.corona-in-zahlen.de/",
         "http://www.esg-soest.de/"
       ],
@@ -1914,9 +1900,9 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://camslib.com/",
-        "http://hubite.com/",
-        "http://www.netgear.com/",
         "http://www.theenergyshop.com/",
+        "http://ldwa.org.uk/",
+        "http://www.houseofnames.com/",
         "http://www.ukclimbing.com/"
       ],
       "failingSites": [],
@@ -2020,11 +2006,7 @@
       "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
-      "exampleSites": [
-        "http://inews.co.uk/",
-        "http://metro.co.uk/",
-        "http://www.dailymail.com/"
-      ],
+      "exampleSites": [],
       "failingSites": [],
       "errorSites": []
     }
@@ -2071,10 +2053,10 @@
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.usccb.org/",
-        "http://www.aa.org/",
-        "http://www.flysfo.com/",
+        "http://www.visitmusiccity.com/",
         "http://www.myflfamilies.com/",
+        "http://www.adventhealth.com/",
+        "http://www.battlefields.org/",
         "http://www.natlawreview.com/"
       ],
       "failingSites": [
@@ -2087,11 +2069,11 @@
       "errors": 0,
       "selfTestFailures": 4,
       "exampleSites": [
-        "http://www.finanzverwaltung.nrw.de/",
-        "http://energiemarie.de/",
-        "http://www.bfn.de/",
-        "http://www.nokia.com/",
-        "http://www.schulministerium.nrw/"
+        "http://www.gardasee.de/",
+        "http://www.catan.de/",
+        "http://www.mannheim.de/",
+        "http://www.avery-zweckform.com/",
+        "http://www.heubach-edelmetalle.de/"
       ],
       "failingSites": [
         "http://www.avery-zweckform.com/",
@@ -2106,11 +2088,11 @@
       "errors": 0,
       "selfTestFailures": 6,
       "exampleSites": [
-        "http://www.staffordbc.gov.uk/",
-        "http://selectra.co.uk/",
-        "http://www.woking.gov.uk/",
-        "http://www.moorfields.nhs.uk/",
-        "http://www.northdevon.gov.uk/"
+        "http://www.fca.org.uk/",
+        "http://www.cfr.org/",
+        "http://www.wokingham.gov.uk/",
+        "http://www.avery.co.uk/",
+        "http://www.hart.gov.uk/"
       ],
       "failingSites": [
         "http://www.ucl.ac.uk/",
@@ -2166,11 +2148,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.meine-flugzeit.de/",
-        "http://www.niederschlagsradar.de/",
-        "http://zauber-magie.de/",
-        "http://www.taxi-rechner.de/",
-        "http://kreuzwortraetsel.net/"
+        "http://chordify.net/",
+        "http://www.gotarot.de/",
+        "http://flytant.com/",
+        "http://www.campingfrance.com/",
+        "http://game8.co/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -2180,11 +2162,11 @@
       "errors": 2,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.visualcapitalist.com/",
-        "http://www.ginx.tv/",
-        "http://www.tvadsongs.uk/",
-        "http://www.militaryfactory.com/",
-        "http://louderthanwar.com/"
+        "http://britishlistedbuildings.co.uk/",
+        "http://www.cleancss.com/",
+        "http://www.xxlmag.com/",
+        "http://www.airport-london-heathrow.com/",
+        "http://hbr.org/"
       ],
       "failingSites": [],
       "errorSites": [
@@ -2231,11 +2213,11 @@
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.nature.org/",
-        "http://code.visualstudio.com/",
-        "http://www.ubereats.com/",
-        "http://www.efirstbank.com/",
-        "http://www.hamradio.com/"
+        "http://social.technet.microsoft.com/",
+        "http://navient.com/",
+        "http://www.viki.com/",
+        "http://devblogs.microsoft.com/",
+        "http://support.xbox.com/"
       ],
       "failingSites": [
         "http://www.arturia.com/"
@@ -2247,11 +2229,11 @@
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
+        "http://support.xbox.com/",
         "http://www.viki.com/",
-        "http://code.visualstudio.com/",
-        "http://www.ihk-muenchen.de/",
-        "http://www.swp-potsdam.de/",
-        "http://www.typescriptlang.org/"
+        "http://www.overleaf.com/",
+        "http://hilfe.ard.de/",
+        "http://www.vbl.de/"
       ],
       "failingSites": [
         "http://www.arturia.com/"
@@ -2263,11 +2245,11 @@
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.fitflop.com/",
-        "http://www.machinerytrader.co.uk/",
-        "http://www.arturia.com/",
-        "http://www.nhsapp.service.nhs.uk/",
-        "http://www.evri.com/"
+        "http://hackaday.io/",
+        "http://www.gak.co.uk/",
+        "http://www.dicklovett.co.uk/",
+        "http://check-for-flooding.service.gov.uk/",
+        "http://www.fractal-design.com/"
       ],
       "failingSites": [
         "http://www.arturia.com/"
@@ -2282,8 +2264,8 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://bard.google.com/",
-        "http://maps.google.com/",
         "http://translate.google.com/",
+        "http://news.google.com/",
         "http://pixel.google.com/",
         "http://store.google.com/"
       ],
@@ -2296,8 +2278,8 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://bard.google.com/",
-        "http://maps.google.com/",
         "http://translate.google.com/",
+        "http://news.google.com/",
         "http://pixel.google.com/",
         "http://store.google.com/"
       ],
@@ -2312,8 +2294,8 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://images.google.com/",
-        "http://search.google.com/",
         "http://www.google.it/",
+        "http://www.google.com/",
         "http://www.google.de/",
         "http://www.google.fr/"
       ],
@@ -2326,8 +2308,8 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://google.co.uk/",
-        "http://images.google.co.uk/",
         "http://www.google.com/",
+        "http://images.google.com/",
         "http://search.google.com/",
         "http://www.google.co.uk/"
       ],
@@ -2362,9 +2344,9 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://community.hmrc.gov.uk/",
-        "http://coronavirus.data.gov.uk/",
-        "http://www.adur-worthing.gov.uk/",
         "http://www.ethnicity-facts-figures.service.gov.uk/",
+        "http://findajob.dwp.gov.uk/",
+        "http://honours.cabinetoffice.gov.uk/",
         "http://www.gov.uk/"
       ],
       "failingSites": [],
@@ -2441,10 +2423,10 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.tbn.org/",
-        "http://chministries.org/",
-        "http://www.blackriflecoffee.com/",
+        "http://www.truthforlife.org/",
         "http://www.hubspot.com/",
+        "http://resources.workable.com/",
+        "http://www.beretta.com/",
         "http://www.kff.org/"
       ],
       "failingSites": [],
@@ -2469,8 +2451,8 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://blog.hubspot.com/",
-        "http://blogs.transparent.com/",
         "http://www.countryside-alliance.org/",
+        "http://g-shock.co.uk/",
         "http://www.casio.co.uk/",
         "http://www.casio.com/"
       ],
@@ -2512,11 +2494,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.crazygames.com/",
-        "http://coolors.co/",
-        "http://jobrapido.com/",
-        "http://www.weg.de/",
-        "http://www.automateexcel.com/"
+        "http://www.dslvergleich.net/",
+        "http://ricette.giallozafferano.it/",
+        "http://www.ranker.com/",
+        "http://forum.arduino.cc/",
+        "http://www.frolicme.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -2526,11 +2508,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.barbour.com/",
-        "http://coolors.co/",
-        "http://frame.work/",
-        "http://www.names.co.uk/",
-        "http://www.ranker.com/"
+        "http://www.elastic.co/",
+        "http://newatlas.com/",
+        "http://www.luggagesuperstore.co.uk/",
+        "http://dunsterhouse.co.uk/",
+        "http://www.frolicme.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -2556,9 +2538,9 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://arosalenzerheide.swiss/",
-        "http://pornhub-deutsch.info/",
-        "http://www.salzburg.info/",
         "http://www.stabilo-fachmarkt.de/",
+        "http://www.interaquaristik.de/",
+        "http://www.kleinwalsertal.com/",
         "http://www.reifetube.com/"
       ],
       "failingSites": [],
@@ -2635,8 +2617,8 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://at.linkedin.com/",
-        "http://ch.linkedin.com/",
         "http://uk.linkedin.com/",
+        "http://de.linkedin.com/",
         "http://fr.linkedin.com/",
         "http://nl.linkedin.com/"
       ],
@@ -2648,10 +2630,10 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://uk.linkedin.com/",
-        "http://br.linkedin.com/",
-        "http://fr.linkedin.com/",
+        "http://www.linkedin.com/",
         "http://ie.linkedin.com/",
+        "http://ca.linkedin.com/",
+        "http://de.linkedin.com/",
         "http://in.linkedin.com/"
       ],
       "failingSites": [],
@@ -2701,11 +2683,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://social.technet.microsoft.com/",
-        "http://answers.microsoft.com/",
-        "http://learn.microsoft.com/",
+        "http://support.microsoft.com/",
         "http://onedrive.live.com/",
-        "http://outlook.live.com/"
+        "http://www.outlook.com/",
+        "http://code.visualstudio.com/",
+        "http://windows.microsoft.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -2715,11 +2697,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://zone.msn.com/",
-        "http://answers.microsoft.com/",
-        "http://community.fabric.microsoft.com/",
-        "http://www.xbox.com/",
-        "http://www.onenote.com/"
+        "http://outlook.live.com/",
+        "http://devblogs.microsoft.com/",
+        "http://visualstudio.microsoft.com/",
+        "http://blogs.windows.com/",
+        "http://social.msdn.microsoft.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -2790,7 +2772,6 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://help.netflix.com/",
         "http://www.netflix.com/"
       ],
       "failingSites": [],
@@ -2801,7 +2782,6 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://help.netflix.com/",
         "http://www.netflix.com/"
       ],
       "failingSites": [],
@@ -2846,11 +2826,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.hearth.com/",
-        "http://forum.proxmox.com/",
-        "http://forums.socialmediagirls.com/",
+        "http://www.lpsg.com/",
         "http://forums.tdiclub.com/",
-        "http://scubaboard.com/"
+        "http://forums.anandtech.com/",
+        "http://forums.civfanatics.com/",
+        "http://www.snbforums.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -2860,10 +2840,10 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.lpsg.com/",
-        "http://forum.heimnetz.de/",
-        "http://messerforum.net/",
+        "http://www.taschenlampen-forum.de/",
         "http://tx-board.de/",
+        "http://forum.proxmox.com/",
+        "http://forums.freebsd.org/",
         "http://www.blacktowhite.net/"
       ],
       "failingSites": [],
@@ -2874,11 +2854,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.blacktowhite.net/",
-        "http://forums.anandtech.com/",
-        "http://forums.overclockers.co.uk/",
+        "http://www.cyclechat.net/",
         "http://forums.tdiclub.com/",
-        "http://pinkfishmedia.net/"
+        "http://www.snbforums.com/",
+        "http://forums.freebsd.org/",
+        "http://www.lrukforums.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -2968,11 +2948,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.nwitimes.com/",
-        "http://www.traeger.com/",
-        "http://www.dummies.com/",
-        "http://www.mdcalc.com/",
-        "http://www.mercurynews.com/"
+        "http://omaha.com/",
+        "http://www.jdsupra.com/",
+        "http://www.dpreview.com/",
+        "http://buffalonews.com/",
+        "http://www.hubermanlab.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -2982,11 +2962,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.expedia.de/",
-        "http://de.hotels.com/",
-        "http://openvpn.net/",
+        "http://www.g2.com/",
         "http://stocktwits.com/",
-        "http://support-leagueoflegends.riotgames.com/"
+        "http://www.peruvianconnection.de/",
+        "http://ieeexplore.ieee.org/",
+        "http://www.insider.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -2996,11 +2976,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.scribd.com/",
-        "http://clubspark.lta.org.uk/",
-        "http://markets.businessinsider.com/",
-        "http://www.dummies.com/",
-        "http://www.hobbycraft.co.uk/"
+        "http://spectrum.ieee.org/",
+        "http://onlinedoctor.boots.com/",
+        "http://uk.scalextric.com/",
+        "http://hotels.com/",
+        "http://uk.airfix.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -3059,11 +3039,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.indiewire.com/",
-        "http://robbreport.com/",
-        "http://tvline.com/",
+        "http://www.rollingstone.com/",
         "http://wwd.com/",
-        "http://www.artnews.com/"
+        "http://soaps.sheknows.com/",
+        "http://spy.com/",
+        "http://www.vibe.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -3121,11 +3101,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.einfachkochen.de/",
-        "http://biancazapatka.com/",
-        "http://www.jetpunk.com/",
-        "http://www.12gebrauchtwagen.de/",
-        "http://www.rhymezone.com/"
+        "http://ihreapotheken.de/",
+        "http://www.meine-familie-und-ich.de/",
+        "http://www.guidingtech.com/",
+        "http://de.epicdope.com/",
+        "http://www.macrumors.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -3135,11 +3115,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://thegimptutorials.com/",
-        "http://www.bluecinetech.co.uk/",
-        "http://www.logicprohelp.com/",
-        "http://www.cheatsheet.com/",
-        "http://tastesbetterfromscratch.com/"
+        "http://carwow.co.uk/",
+        "http://nosweatshakespeare.com/",
+        "http://liveboldandbloom.com/",
+        "http://www.nutritionadvance.com/",
+        "http://nerdtechy.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -3151,11 +3131,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.marinetraffic.com/",
-        "http://journals.sagepub.com/",
-        "http://www.dailystar.co.uk/",
+        "http://www.mirror.co.uk/",
         "http://www.express.co.uk/",
-        "http://www.filmaffinity.com/"
+        "http://www.typingtest.com/",
+        "http://www.bluestacks.com/",
+        "http://www.thejc.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -3165,11 +3145,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.beliebte-vornamen.de/",
-        "http://www.iplocation.net/",
-        "http://www.theatlantic.com/",
-        "http://www.manua.ls/",
-        "http://www.baeldung.com/"
+        "http://dnschecker.org/",
+        "http://trauer.shz.de/",
+        "http://poki.com/",
+        "http://www.trustedreviews.com/",
+        "http://tkp.at/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -3179,11 +3159,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.thefield.co.uk/",
-        "http://www.horoscope.com/",
-        "http://www.stylecraze.com/",
-        "http://www.mobafire.com/",
-        "http://pastebin.com/"
+        "http://cardealermagazine.co.uk/",
+        "http://www.doctify.com/",
+        "http://www.timeanddate.com/",
+        "http://www.brainyquote.com/",
+        "http://manuall.co.uk/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -3220,11 +3200,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.kreuzwortraetsellexikon.de/",
-        "http://administrator.de/",
-        "http://imslp.org/",
-        "http://www.notebookcheck.net/",
-        "http://www.supercoloring.com/"
+        "http://www.landwirt.com/",
+        "http://wordle.at/",
+        "http://www.manualslib.de/",
+        "http://devicetests.com/",
+        "http://www.linguee.de/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -3234,11 +3214,11 @@
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.windfinder.com/",
-        "http://helpdeskgeek.com/",
-        "http://mediabiasfactcheck.com/",
-        "http://www.w3schools.com/",
-        "http://www.numbeo.com/"
+        "http://www.fmscout.com/",
+        "http://wordfind.com/",
+        "http://www.maketecheasier.com/",
+        "http://kprofiles.com/",
+        "http://www.isitdownrightnow.com/"
       ],
       "failingSites": [
         "http://www.morewords.com/"
@@ -3362,7 +3342,6 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://itler.net/",
         "http://sciencefiles.org/",
         "http://terraherz.wpcomstaging.com/"
       ],
@@ -3386,9 +3365,7 @@
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.tiktok.com/"
-      ],
+      "exampleSites": [],
       "failingSites": [],
       "errorSites": []
     },
@@ -3444,8 +3421,8 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://www.arbys.com/",
-        "http://www.buffalowildwings.com/",
         "http://www.oreillyauto.com/",
+        "http://www.dunkindonuts.com/",
         "http://www.ethanallen.com/",
         "http://www.jimmyjohns.com/"
       ],
@@ -3566,11 +3543,10 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.trivago.com/",
-        "http://olukai.com/",
-        "http://www.fender.com/",
-        "http://www.greyhound.com/",
-        "http://www.kia.com/"
+        "http://www.festoolusa.com/",
+        "http://www.kia.com/",
+        "http://www.skillshare.com/",
+        "http://www.trivago.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -3580,11 +3556,11 @@
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.norisbank.de/",
-        "http://www.fussball.de/",
-        "http://www.welthungerhilfe.de/",
-        "http://www.studycheck.de/",
-        "http://shop.rewe.de/"
+        "http://bz-ticket.de/",
+        "http://www.enviam.de/",
+        "http://www.wohnungsboerse.net/",
+        "http://www.cherry.de/",
+        "http://porta.de/"
       ],
       "failingSites": [
         "http://www.advanzia.com/"
@@ -3596,11 +3572,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.villeroy-boch.co.uk/",
-        "http://en-uk.sennheiser.com/",
-        "http://paulsmith.com/",
-        "http://www.myunidays.com/",
-        "http://www.q-park.co.uk/"
+        "http://www.emma-sleep.co.uk/",
+        "http://www.avogel.co.uk/",
+        "http://www.jack-wolfskin.co.uk/",
+        "http://hugoboss.com/",
+        "http://www.fortnumandmason.com/"
       ],
       "failingSites": [],
       "errorSites": []
@@ -3612,18 +3588,18 @@
       "errors": 0,
       "selfTestFailures": 13,
       "exampleSites": [
-        "http://www.piper.de/",
-        "http://blog.nbb.com/",
-        "http://www.wir-machen-druck.de/",
-        "http://www.herrenausstatter.de/",
-        "http://www.kfw.de/"
+        "http://www.advocard.de/",
+        "http://www.zinspilot.de/",
+        "http://www.selfio.de/",
+        "http://forum.joomla.de/",
+        "http://www.zalando.de/"
       ],
       "failingSites": [
+        "http://www.meine-krankenkasse.de/",
+        "http://www.wandern.de/",
+        "http://www.nkd.com/",
         "http://www.zalando-lounge.de/",
-        "http://group.mercedes-benz.com/",
-        "http://mags.de/",
-        "http://www.eberhardt-travel.de/",
-        "http://www.wandern.de/"
+        "http://www.fcstpauli.com/"
       ],
       "errorSites": []
     },
@@ -3741,9 +3717,9 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://lovattspuzzles.com/",
-        "http://men.aznude.com/",
-        "http://www.discoverwalks.com/",
         "http://www.stockport.gov.uk/",
+        "http://thisvid.com/",
+        "http://www.askmid.com/",
         "http://www.thisvid.com/"
       ],
       "failingSites": [],


### PR DESCRIPTION
Filters the list of 'exampleSites' so only sites are shown where the CMP was open on the crawl.