### PR TITLE
Klaro: fix toggle selectors

### DIFF
--- a/lib/cmps/klaro.ts
+++ b/lib/cmps/klaro.ts
@@ -36,7 +36,7 @@ export default class Klaro extends AutoConsentCMPBase {
     }
 
     if (!this.settingsOpen) {
-      click('.klaro .cn-learn-more');
+      click('.klaro .cn-learn-more,.klaro .cm-button-manage');
       await waitForElement('.klaro > .cookie-modal', 2000);
       this.settingsOpen = true;
     }
@@ -45,8 +45,8 @@ export default class Klaro extends AutoConsentCMPBase {
       return true;
     }
 
-    click('.cm-purpose:not(.cm-toggle-all) > input:not(.half-checked,.required,.only-required)', true);
-    return click('.cm-btn-accept');
+    click('.cm-purpose:not(.cm-toggle-all) > input:not(.half-checked,.required,.only-required),.cm-purpose:not(.cm-toggle-all) > div > input:not(.half-checked,.required,.only-required)', true);
+    return click('.cm-btn-accept,.cm-button');
   }
 
   async optIn() {

--- a/lib/cmps/klaro.ts
+++ b/lib/cmps/klaro.ts
@@ -46,7 +46,6 @@ export default class Klaro extends AutoConsentCMPBase {
     }
 
     click('.cm-purpose:not(.cm-toggle-all) > input:not(.half-checked,.required,.only-required)', true);
-
     return click('.cm-btn-accept');
   }
 

--- a/lib/cmps/klaro.ts
+++ b/lib/cmps/klaro.ts
@@ -45,10 +45,7 @@ export default class Klaro extends AutoConsentCMPBase {
       return true;
     }
 
-    // if there is no disableAll button, toggle all available toggles
-    if (!click('#purpose-item-disableAll')) {
-      click('.cm-purpose:not(.cm-toggle-all) > input:not(.half-checked)', true);
-    } 
+    click('.cm-purpose:not(.cm-toggle-all) > input:not(.half-checked,.required,.only-required)', true);
 
     return click('.cm-btn-accept');
   }

--- a/lib/cmps/klaro.ts
+++ b/lib/cmps/klaro.ts
@@ -45,7 +45,11 @@ export default class Klaro extends AutoConsentCMPBase {
       return true;
     }
 
-    click('.cm-purpose:not(.cm-toggle-all) > input:not(.half-checked)', true);
+    // if there is no disableAll button, toggle all available toggles
+    if (!click('#purpose-item-disableAll')) {
+      click('.cm-purpose:not(.cm-toggle-all) > input:not(.half-checked)', true);
+    } 
+
     return click('.cm-btn-accept');
   }
 

--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -15,7 +15,11 @@ export const snippets = {
   EVAL_COOKIEBOT_4: () => window.Cookiebot.hide() || true,
   EVAL_COOKIEBOT_5: () => window.Cookiebot.declined === true,
   EVAL_KLARO_1: () => {
-    const config = globalThis.klaroConfig || globalThis.klaro.getManager().config
+    const config = globalThis.klaroConfig || (globalThis.klaro?.getManager && globalThis.klaro.getManager().config)
+    if (!config) {
+      // with no klaro globals, we can't test on this page
+      return true
+    }
     const optionalServices = (config.services || config.apps).filter(s => !s.required).map(s => s.name)
     if (klaro && klaro.getManager) {
       const manager = klaro.getManager()
@@ -25,7 +29,6 @@ export const snippets = {
       const consents = JSON.parse(decodeURIComponent(document.cookie.split(';').find(c => c.trim().startsWith(cookieName)).split('=')[1]))
       return Object.keys(consents).filter(k => optionalServices.includes(k)).every(k => consents[k] === false)
     }
-    return false
   },
   EVAL_ONETRUST_1: () => window.OnetrustActiveGroups.split(',').filter(s => s.length > 0).length <= 1,
   EVAL_TRUSTARC_TOP: () => window && window.truste && window.truste.eu.bindMap.prefCookie === '0',

--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -14,7 +14,15 @@ export const snippets = {
   EVAL_COOKIEBOT_3: () => window.Cookiebot.withdraw() || true,
   EVAL_COOKIEBOT_4: () => window.Cookiebot.hide() || true,
   EVAL_COOKIEBOT_5: () => window.Cookiebot.declined === true,
-  EVAL_KLARO_1: () => klaro.getManager().config.services.every(c => c.required || !klaro.getManager().consents[c.name]),
+  EVAL_KLARO_1: () => {
+    if (klaro && klaro.getManager) {
+      return klaro.getManager().config.services.every(c => c.required || !klaro.getManager().consents[c.name])
+    } else if (klaroConfig) {
+      const consents = JSON.parse(decodeURIComponent(document.cookie.split(';').find(c => c.trim().startsWith(klaroConfig.storageName)).split('=')[1]))
+      return Object.keys(consents).filter(k => k !== 'essential').every(k => consents[k] === false)
+    }
+    return false
+  },
   EVAL_ONETRUST_1: () => window.OnetrustActiveGroups.split(',').filter(s => s.length > 0).length <= 1,
   EVAL_TRUSTARC_TOP: () => window && window.truste && window.truste.eu.bindMap.prefCookie === '0',
 
@@ -112,5 +120,5 @@ export const snippets = {
 
 export function getFunctionBody(snippetFunc: () => any) {
   const snippetStr = snippetFunc.toString();
-  return snippetStr.substring(snippetStr.indexOf("=>") + 2);
+  return `(${snippetStr})()`
 }

--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -15,11 +15,15 @@ export const snippets = {
   EVAL_COOKIEBOT_4: () => window.Cookiebot.hide() || true,
   EVAL_COOKIEBOT_5: () => window.Cookiebot.declined === true,
   EVAL_KLARO_1: () => {
+    const config = globalThis.klaroConfig || globalThis.klaro.getManager().config
+    const optionalServices = (config.services || config.apps).filter(s => !s.required).map(s => s.name)
     if (klaro && klaro.getManager) {
-      return klaro.getManager().config.services.every(c => c.required || !klaro.getManager().consents[c.name])
-    } else if (klaroConfig) {
-      const consents = JSON.parse(decodeURIComponent(document.cookie.split(';').find(c => c.trim().startsWith(klaroConfig.storageName)).split('=')[1]))
-      return Object.keys(consents).filter(k => k !== 'essential').every(k => consents[k] === false)
+      const manager = klaro.getManager()
+      return optionalServices.every(name => !manager.consents[name])  
+    } else if (klaroConfig && klaroConfig.storageMethod === 'cookie') {
+      const cookieName = klaroConfig.cookieName || klaroConfig.storageName;
+      const consents = JSON.parse(decodeURIComponent(document.cookie.split(';').find(c => c.trim().startsWith(cookieName)).split('=')[1]))
+      return Object.keys(consents).filter(k => optionalServices.includes(k)).every(k => consents[k] === false)
     }
     return false
   },

--- a/tests/klaro.spec.ts
+++ b/tests/klaro.spec.ts
@@ -5,5 +5,6 @@ generateCMPTests('Klaro', [
   'https://www.zeitraum-moebel.de/',
   'https://repisalud.isciii.es/',
   'https://www.innogames.com/',
+  'https://www.lebenslauf.de/',
   // 'https://dspace.library.stonybrook.edu', // polyfills Promise so playwright doesn't work
 ]);


### PR DESCRIPTION
Fixes self test failures on some sites. We should avoid clicking 'only-required' check boxes, as that will turn on some consents.

There are also a few different variants of the klaro API we need to use for self-testing. I've updated the snippet to cover a few cases, though this may not be complete. I needed to also make a small change to allow support for multi-line snippets.

![Screenshot 2024-01-10 at 09 33 37](https://github.com/duckduckgo/autoconsent/assets/248111/7a712328-0adc-427f-a632-a0f2ee8bcfc5)
