### PR TITLE
Add rules from Jan 10 Ghostery fixes

### DIFF
--- a/rules/autoconsent/canyon-com.json
+++ b/rules/autoconsent/canyon-com.json
@@ -1,0 +1,19 @@
+{
+  "name": "canyon.com",
+  "runContext": {
+      "urlPattern": "^https://www\\.canyon\\.com/"
+    },
+  "cosmetic": true,
+  "prehideSelectors": ["div.modal.cookiesModal.is-open"],
+  "detectCmp": [{ "exists": "div.modal.cookiesModal.is-open" }],
+  "detectPopup": [{ "visible": "div.modal.cookiesModal.is-open" }],
+  "optIn": [{ "click": "div.cookiesModal__buttonWrapper > button[data-closecause=\"close-by-submit\"]" }],
+  "optOut": [
+    {
+      "click": "div.cookiesModal__buttonWrapper > button[data-closecause=\"close-by-manage-cookies\"]"
+    },
+    {
+      "waitForThenClick": "button#js-manage-data-privacy-save-button"
+    }
+  ]
+}

--- a/rules/autoconsent/canyon-com.json
+++ b/rules/autoconsent/canyon-com.json
@@ -2,8 +2,7 @@
   "name": "canyon.com",
   "runContext": {
       "urlPattern": "^https://www\\.canyon\\.com/"
-    },
-  "cosmetic": true,
+  },
   "prehideSelectors": ["div.modal.cookiesModal.is-open"],
   "detectCmp": [{ "exists": "div.modal.cookiesModal.is-open" }],
   "detectPopup": [{ "visible": "div.modal.cookiesModal.is-open" }],

--- a/rules/autoconsent/hetzner-com.json
+++ b/rules/autoconsent/hetzner-com.json
@@ -1,0 +1,12 @@
+{
+  "name": "hetzner.com",
+  "runContext": {
+    "urlPattern": "^https://www\\.hetzner\\.com/"
+  },
+  "cosmetic": true,
+  "prehideSelectors": ["#CookieConsent"],
+  "detectCmp": [{ "exists": "#CookieConsent" }],
+  "detectPopup": [{ "visible": "#CookieConsent" }],
+  "optIn": [{ "click": "#CookieConsentGiven" }],
+  "optOut": [{ "click": "#CookieConsentDeclined" }]
+}

--- a/rules/autoconsent/hetzner-com.json
+++ b/rules/autoconsent/hetzner-com.json
@@ -3,7 +3,6 @@
   "runContext": {
     "urlPattern": "^https://www\\.hetzner\\.com/"
   },
-  "cosmetic": true,
   "prehideSelectors": ["#CookieConsent"],
   "detectCmp": [{ "exists": "#CookieConsent" }],
   "detectPopup": [{ "visible": "#CookieConsent" }],

--- a/rules/autoconsent/rog-forum-asus-com.json
+++ b/rules/autoconsent/rog-forum-asus-com.json
@@ -1,15 +1,14 @@
 {
-    "name": "rog-forum.asus.com",
-    "runContext": {
-      "urlPattern": "^https://rog-forum\\.asus\\.com/"
-    },
-    "cosmetic": true,
-    "prehideSelectors": ["#cookie-policy-info"],
-    "detectCmp": [{ "exists": "#cookie-policy-info" }],
-    "detectPopup": [{ "visible": "#cookie-policy-info" }],
-    "optIn": [{ "click": "div.cookie-btn-box > div[aria-label=\"Accept\"]" }],
-    "optOut": [
-      { "click": "div.cookie-btn-box > div[aria-label=\"Reject\"]" },
-      { "waitForThenClick": ".cookie-policy-lightbox-bottom > div[aria-label=\"Save Settings\"]" }
-    ]
+  "name": "rog-forum.asus.com",
+  "runContext": {
+    "urlPattern": "^https://rog-forum\\.asus\\.com/"
+  },
+  "prehideSelectors": ["#cookie-policy-info"],
+  "detectCmp": [{ "exists": "#cookie-policy-info" }],
+  "detectPopup": [{ "visible": "#cookie-policy-info" }],
+  "optIn": [{ "click": "div.cookie-btn-box > div[aria-label=\"Accept\"]" }],
+  "optOut": [
+    { "click": "div.cookie-btn-box > div[aria-label=\"Reject\"]" },
+    { "waitForThenClick": ".cookie-policy-lightbox-bottom > div[aria-label=\"Save Settings\"]" }
+  ]
 }

--- a/rules/autoconsent/rog-forum-asus-com.json
+++ b/rules/autoconsent/rog-forum-asus-com.json
@@ -1,0 +1,15 @@
+{
+    "name": "rog-forum.asus.com",
+    "runContext": {
+      "urlPattern": "^https://rog-forum\\.asus\\.com/"
+    },
+    "cosmetic": true,
+    "prehideSelectors": ["#cookie-policy-info"],
+    "detectCmp": [{ "exists": "#cookie-policy-info" }],
+    "detectPopup": [{ "visible": "#cookie-policy-info" }],
+    "optIn": [{ "click": "div.cookie-btn-box > div[aria-label=\"Accept\"]" }],
+    "optOut": [
+      { "click": "div.cookie-btn-box > div[aria-label=\"Reject\"]" },
+      { "waitForThenClick": ".cookie-policy-lightbox-bottom > div[aria-label=\"Save Settings\"]" }
+    ]
+}

--- a/rules/autoconsent/strato-de.json
+++ b/rules/autoconsent/strato-de.json
@@ -1,0 +1,20 @@
+{
+    "name": "strato.de",
+    "prehideSelectors": ["#cookie_initial_modal", ".modal-backdrop"],
+    "runContext": {
+        "urlPattern": "^https://www\\.strato\\.de/"
+    },
+    "detectCmp": [{ "exists": "#cookie_initial_modal" }],
+    "detectPopup": [{ "visible": "#cookie_initial_modal" }],
+    "optIn": [{
+        "click": "button#jss_consent_all_initial_modal"
+    }],
+    "optOut": [
+        {
+            "click": "button#jss_open_settings_modal"
+        },
+        {
+            "click": "button#jss_consent_checked"
+        }
+    ]
+}

--- a/rules/autoconsent/transip-nl.json
+++ b/rules/autoconsent/transip-nl.json
@@ -2,8 +2,7 @@
   "name": "transip-nl",
   "runContext": {
       "urlPattern": "^https://www\\.transip\\.nl/"
-    },
-  "cosmetic": true,
+  },
   "prehideSelectors": ["#consent-modal"],
   "detectCmp": [{
     "any": [

--- a/rules/autoconsent/transip-nl.json
+++ b/rules/autoconsent/transip-nl.json
@@ -1,0 +1,50 @@
+{
+  "name": "transip-nl",
+  "runContext": {
+      "urlPattern": "^https://www\\.transip\\.nl/"
+    },
+  "cosmetic": true,
+  "prehideSelectors": ["#consent-modal"],
+  "detectCmp": [{
+    "any": [
+      {
+        "exists": "#consent-modal"
+      },
+      {
+        "exists": "#privacy-settings-content"
+      }
+    ]
+  }],
+  "detectPopup": [{
+    "any": [
+      {
+        "visible": "#consent-modal"
+      },
+      {
+        "visible": "#privacy-settings-content"
+      }
+    ]
+  }],
+  "optIn": [
+    {
+      "click": "button[type=\"submit\"]"
+    }
+  ],
+  "optOut": [
+    {
+      "if": {
+        "exists": "#privacy-settings-content"
+      },
+      "then": [
+        {
+          "click": "button[type=\"submit\"]"
+        }
+      ],
+      "else": [
+        {
+          "click": "div.one-modal__action-footer-column--secondary > a"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/canyon-com.spec.ts
+++ b/tests/canyon-com.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from "../playwright/runner";
+
+generateCMPTests('canyon.com', [
+  'https://www.canyon.com/en-us/'
+], {});

--- a/tests/hetzner-com.spec.ts
+++ b/tests/hetzner-com.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from "../playwright/runner";
+
+generateCMPTests('hetzner.com', [
+  'https://www.hetzner.com/news/12-22-cloud-usa',
+]);

--- a/tests/rog-forum-asus-com.spec.ts
+++ b/tests/rog-forum-asus-com.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from "../playwright/runner";
+
+generateCMPTests('rog-forum.asus.com', [
+  'https://rog-forum.asus.com/'
+], {});

--- a/tests/strato-de.spec.ts
+++ b/tests/strato-de.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from "../playwright/runner";
+
+generateCMPTests('strato.de', [
+  'https://www.strato.de/apps/CustomerService',
+], {});


### PR DESCRIPTION
refs https://github.com/ghostery/broken-page-reports/pull/429
refs https://github.com/ghostery/broken-page-reports/pull/432

In case of `transip.nl`, the user had to be redirected. Is there a standard way to write test over multiple redirects?