### PR TITLE
Add a rule for admiral CMP

### DIFF
--- a/rules/autoconsent/admiral.json
+++ b/rules/autoconsent/admiral.json
@@ -1,15 +1,15 @@
 {
   "name": "admiral",
   "detectCmp": [{
-    "exists": "div[style*=\"z-index\"] > link + div[width] + div > a[href*=\"/pb/\"] > span + svg > g > path[d^=\"M925 116h59l166 386h-78l-36-88H869l-35\"]"
+    "exists": "div[class^='a__'][style^='z-index'] path[d^='M925']"
   }],
   "detectPopup": [{
-    "visible": "div[style*=\"z-index\"] > link + div[width] + div > a[href*=\"/pb/\"] > span + svg > g > path[d^=\"M925 116h59l166 386h-78l-36-88H869l-35\"]"
+    "visible": "div[class^='a__'][style^='z-index'] path[d^='M925']"
   }],
   "optIn": [{
-    "click": "div[style*=\"z-index\"] > link + div[width] > div > div[direction=\"row\"] > button:nth-child(2)"
+    "click": "div[class^='a__'][style^='z-index'] div[class^='Frame'] > button:nth-child(2)"
   }],
   "optOut": [{
-    "click": "div[style*=\"z-index\"] > link + div[width] > div > div[direction=\"row\"] > button:nth-child(1)"
+    "click": "div[class^='a__'][style^='z-index'] div[class^='Frame'] > button:nth-child(1)"
   }]
 }

--- a/rules/autoconsent/admiral.json
+++ b/rules/autoconsent/admiral.json
@@ -1,0 +1,15 @@
+{
+  "name": "admiral",
+  "detectCmp": [{
+    "exists": "div[style*=\"z-index\"] > link + div[width] + div > a[href*=\"/pb/\"] > span + svg > g > path[d^=\"M925 116h59l166 386h-78l-36-88H869l-35\"]"
+  }],
+  "detectPopup": [{
+    "visible": "div[style*=\"z-index\"] > link + div[width] + div > a[href*=\"/pb/\"] > span + svg > g > path[d^=\"M925 116h59l166 386h-78l-36-88H869l-35\"]"
+  }],
+  "optIn": [{
+    "click": "div[style*=\"z-index\"] > link + div[width] > div > div[direction=\"row\"] > button:nth-child(2)"
+  }],
+  "optOut": [{
+    "click": "div[style*=\"z-index\"] > link + div[width] > div > div[direction=\"row\"] > button:nth-child(1)"
+  }]
+}

--- a/tests/admiral.spec.ts
+++ b/tests/admiral.spec.ts
@@ -1,6 +1,5 @@
 import generateCMPTests from "../playwright/runner";
 
 generateCMPTests('admiral', [
-  'https://www.pocket-lint.com/what-rabbit-r1-does-it-use-ai-and-how-does-it-work/',
   'https://www.getadmiral.com/',
 ]);

--- a/tests/admiral.spec.ts
+++ b/tests/admiral.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from "../playwright/runner";
+
+generateCMPTests('admiral', [
+  'https://www.pocket-lint.com/what-rabbit-r1-does-it-use-ai-and-how-does-it-work/',
+  'https://www.getadmiral.com/',
+]);


### PR DESCRIPTION
This adds a global rule for Admiral CMP. It seems like they tries to avoid being detected by any kind of adblocker or automation. I think using svg tag to match their CMP is pretty reasonable here.

```
  4 skipped
  12 passed (54.9s)
```