### PR TITLE
fix: paypal-us

### DIFF
--- a/rules/autoconsent/paypal-us.json
+++ b/rules/autoconsent/paypal-us.json
@@ -1,8 +1,8 @@
 {
   "name": "paypal-us",
   "prehideSelectors": ["#ccpaCookieContent_wrapper, article.ppvx_modal--overpanel"],
-  "detectCmp": [{ "exists": "#ccpaCookieBanner, .privacy-modal-content" }],
-  "detectPopup": [{ "exists": "#ccpaCookieBanner, .privacy-modal-content" }],
+  "detectCmp": [{ "exists": "#ccpaCookieBanner, .privacy-sheet-content" }],
+  "detectPopup": [{ "exists": "#ccpaCookieBanner, .privacy-sheet-content" }],
   "optIn": [{ "click": "#acceptAllButton" }],
   "optOut": [
     { 
@@ -12,7 +12,7 @@
         { "click": "a#manageCookiesLink" }
       ],
       "else": [
-        { "waitForVisible": ".privacy-modal-content #formContent" },
+        { "waitForVisible": ".privacy-sheet-content #formContent" },
         { 
           "click": "#formContent .cookiepref-11m2iee-checkbox_base input:checked",
           "all": true,


### PR DESCRIPTION
`.privacy-modal-content` was not found on my side anymore. Requires US region IP address (without credentials).

refs https://github.com/ghostery/broken-page-reports/issues/472