### PR TITLE
fix: outdated strato.de

### DIFF
--- a/rules/autoconsent/strato-de.json
+++ b/rules/autoconsent/strato-de.json
@@ -1,20 +1,20 @@
 {
     "name": "strato.de",
-    "prehideSelectors": ["#cookie_initial_modal", ".modal-backdrop"],
+    "prehideSelectors": [".consent__wrapper"],
     "runContext": {
         "urlPattern": "^https://www\\.strato\\.de/"
     },
-    "detectCmp": [{ "exists": "#cookie_initial_modal" }],
-    "detectPopup": [{ "visible": "#cookie_initial_modal" }],
+    "detectCmp": [{ "exists": ".consent" }],
+    "detectPopup": [{ "visible": ".consent" }],
     "optIn": [{
-        "click": "button#jss_consent_all_initial_modal"
+        "click": "button.consentAgree"
     }],
     "optOut": [
         {
-            "click": "button#jss_open_settings_modal"
+            "click": "button.consentSettings"
         },
         {
-            "click": "button#jss_consent_checked"
+            "waitForThenClick": "button#consentSubmit"
         }
     ]
 }


### PR DESCRIPTION
Ths PR fixes the GitLab breakage due to widely used prehide selector in the `strato.de` rule. All websites using bootstrap vue ui library creates a temporary div element with a class name of `modal-backdrop` to check the user defined `z-index` value for modals. However, the style injected into the page with prehide selectors resets the `z-index` to `-1` which makes the modal `z-index` to be `-1`.

```js
    getBaseZIndex: function getBaseZIndex() {
      if (IS_BROWSER && isNull(this.baseZIndex)) {
        // Create a temporary `div.modal-backdrop` to get computed z-index
        var div = document.createElement('div');
        addClass(div, 'modal-backdrop');
        addClass(div, 'd-none');
        setStyle(div, 'display', 'none');
        document.body.appendChild(div);
        this.baseZIndex = toInteger(getCS(div).zIndex, DEFAULT_ZINDEX);
        document.body.removeChild(div);
      }

      return this.baseZIndex || DEFAULT_ZINDEX;
    }
```