### PR TITLE
Check runcontext for prehide selectors.

### DIFF
--- a/lib/cmps/sourcepoint-frame.ts
+++ b/lib/cmps/sourcepoint-frame.ts
@@ -10,7 +10,7 @@ export default class SourcePoint extends AutoConsentCMPBase {
   ccpaPopup = false;
 
   runContext: RunContext = {
-    main: false,
+    main: true,
     frame: true,
   }
 

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -411,12 +411,10 @@ export default class AutoConsent {
       "#didomi-popup,.didomi-popup-container,.didomi-popup-notice,.didomi-consent-popup-preferences,#didomi-notice,.didomi-popup-backdrop,.didomi-screen-medium",
     ]
 
-    const selectors = this.rules.reduce((selectorList, rule) => {
-      if (rule.prehideSelectors) {
-        return [...selectorList, ...rule.prehideSelectors];
-      }
-      return selectorList;
-    }, globalHidden);
+    const selectors = this.rules
+      .filter(rule => rule.prehideSelectors && rule.checkRunContext())
+      .reduce((selectorList, rule) => 
+        [...selectorList, ...rule.prehideSelectors], globalHidden);
 
     this.updateState({ prehideOn: true })
     setTimeout(() => {


### PR DESCRIPTION
Only apply a rule's prehide selectors if the rule itself should run in that context.

This prevents issues like #399 where a prehide selector for a site-specific rule broke unrelated sites.