### PR TITLE
Add .cc-type-out-out variant of Complianz popup

### DIFF
--- a/rules/autoconsent/complianz-opt-out.json
+++ b/rules/autoconsent/complianz-opt-out.json
@@ -1,0 +1,35 @@
+{
+    "name": "Complianz opt-out",
+    "prehideSelectors": [
+        "[aria-describedby=\"cookieconsent:desc\"].cc-type-opt-out"
+    ],
+    "detectCmp": [
+        {
+            "exists": "[aria-describedby=\"cookieconsent:desc\"].cc-type-opt-out"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "[aria-describedby=\"cookieconsent:desc\"].cc-type-opt-out"
+        }
+    ],
+    "optIn": [
+        {
+            "click": ".cc-accept-all",
+            "optional": true
+        },
+        {
+            "click": ".cc-allow",
+            "optional": true
+        },
+        {
+            "click": ".cc-dismiss",
+            "optional": true
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": ".cc-deny"
+        }
+    ]
+}

--- a/rules/autoconsent/complianz-opt-out.json
+++ b/rules/autoconsent/complianz-opt-out.json
@@ -29,7 +29,19 @@
     ],
     "optOut": [
         {
-            "waitForThenClick": ".cc-deny"
+            "if": {
+                "exists": ".cc-deny"
+            },
+            "then": [
+                {
+                    "click": ".cc-deny"
+                }
+            ],
+            "else": [
+                {
+                    "hide": "[aria-describedby=\"cookieconsent:desc\"]"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Support another variant of the Complianz popups, as seen on https://www.banad.brussels/

https://app.asana.com/0/1203268166580279/1206856544511310/f