### PR TITLE
Fix Klaro rule (wogibtswas.de, www.suedtirol.com)

### DIFF
--- a/lib/cmps/klaro.ts
+++ b/lib/cmps/klaro.ts
@@ -30,12 +30,18 @@ export default class Klaro extends AutoConsentCMPBase {
   }
 
   async optOut() {
+    const apiOptOutSuccess = await this.mainWorldEval("EVAL_KLARO_TRY_API_OPT_OUT")
+    if (apiOptOutSuccess) {
+      return true
+    }
+    // if the API is broken for some reason, try clicking instead
+
     if (this.click('.klaro .cn-decline')) {
       return true;
     }
 
     // open popup via Javascript API
-    await this.mainWorldEval("EVAL_KLARO_2")
+    await this.mainWorldEval("EVAL_KLARO_OPEN_POPUP")
 
     if (this.click('.klaro .cn-decline')) {
       return true;

--- a/lib/cmps/klaro.ts
+++ b/lib/cmps/klaro.ts
@@ -34,11 +34,8 @@ export default class Klaro extends AutoConsentCMPBase {
       return true;
     }
 
-    if (!this.settingsOpen) {
-      this.click('.klaro .cn-learn-more,.klaro .cm-button-manage');
-      await this.waitForElement('.klaro > .cookie-modal', 2000);
-      this.settingsOpen = true;
-    }
+    // open popup via Javascript API
+    await this.mainWorldEval("EVAL_KLARO_2")
 
     if (this.click('.klaro .cn-decline')) {
       return true;

--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -30,8 +30,22 @@ export const snippets = {
       return Object.keys(consents).filter(k => optionalServices.includes(k)).every(k => consents[k] === false)
     }
   },
-  EVAL_KLARO_2: () => {
+  EVAL_KLARO_OPEN_POPUP: () => {
     klaro.show(undefined, true)
+  },
+  EVAL_KLARO_TRY_API_OPT_OUT: () => {
+    if (window.klaro && typeof klaro.show === 'function' && typeof klaro.getManager === 'function') {
+      try {
+        // opt-out directly via API
+        klaro.getManager().changeAll(false)
+        klaro.getManager().saveAndApplyConsents()
+        return true
+      } catch (e) {
+        console.warn(e)
+        return false
+      }
+    }
+    return false
   },
   EVAL_ONETRUST_1: () => window.OnetrustActiveGroups.split(',').filter(s => s.length > 0).length <= 1,
   EVAL_TRUSTARC_TOP: () => window && window.truste && window.truste.eu.bindMap.prefCookie === '0',

--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -30,6 +30,9 @@ export const snippets = {
       return Object.keys(consents).filter(k => optionalServices.includes(k)).every(k => consents[k] === false)
     }
   },
+  EVAL_KLARO_2: () => {
+    klaro.show(undefined, true)
+  },
   EVAL_ONETRUST_1: () => window.OnetrustActiveGroups.split(',').filter(s => s.length > 0).length <= 1,
   EVAL_TRUSTARC_TOP: () => window && window.truste && window.truste.eu.bindMap.prefCookie === '0',
 


### PR DESCRIPTION
The Klaro rule was failing to open the popup on the following sites:
- wogibtswas.de
- www.suedtirol.com

This changes the rule to use the `klaro` JS API to open the popup. This seems more robust for the different ways of embedding this.