### PR TITLE
fix: instagram.com

### DIFF
--- a/rules/autoconsent/instagram.json
+++ b/rules/autoconsent/instagram.json
@@ -4,7 +4,7 @@
   "runContext": {
     "urlPattern": "^https://www\\.instagram\\.com/"
   },
-  "prehideSelectors": [".x78zum5.xdt5ytf.xg6iff7.x1n2onr6"],
+  "prehideSelectors": [".x78zum5.xdt5ytf.xg6iff7.x1n2onr6:has(._a9--)"],
   "detectCmp": [
     {
       "exists": ".x1qjc9v5.x9f619.x78zum5.xdt5ytf.x1iyjqo2.xl56j7k"


### PR DESCRIPTION
This PR improves the Instagram prehide selector to include the cookie button as a breakage happened with other dialogues.

refs https://github.com/ghostery/broken-page-reports/issues/625