### PR TITLE
Adjusted TrustArc optout

### DIFF
--- a/lib/cmps/trustarc-frame.ts
+++ b/lib/cmps/trustarc-frame.ts
@@ -68,7 +68,7 @@ export default class TrustArcFrame extends AutoConsentCMPBase {
   async optOut() {
 
     // if the user has already opted out, let's not close the window
-    if (await this.mainWorldEval('EVAL_TRUSTART_FRAME_TEST')){
+    if (await this.mainWorldEval('EVAL_TRUSTARC_FRAME_TEST')){
       return true;
     }
 

--- a/lib/cmps/trustarc-frame.ts
+++ b/lib/cmps/trustarc-frame.ts
@@ -68,7 +68,7 @@ export default class TrustArcFrame extends AutoConsentCMPBase {
   async optOut() {
 
     // if the user has already opted out, let's not close the window
-    if (await this.mainWorldEval('EVAL_TRUSTARC_FRAME')){
+    if (await this.mainWorldEval('EVAL_TRUSTART_FRAME_TEST')){
       return true;
     }
 
@@ -133,6 +133,6 @@ export default class TrustArcFrame extends AutoConsentCMPBase {
     //Test JS variable to check the user's preference
     //preferences = undefined means no consent is set, preferences = '0' means consent is set to required only 
     await this.wait(500);
-    return await this.mainWorldEval('EVAL_TRUSTARC_FRAME');
+    return await this.mainWorldEval('EVAL_TRUSTART_FRAME_TEST');
   }
 }

--- a/lib/cmps/trustarc-frame.ts
+++ b/lib/cmps/trustarc-frame.ts
@@ -12,7 +12,7 @@ export default class TrustArcFrame extends AutoConsentCMPBase {
   }
 
   get hasSelfTest(): boolean {
-    return false;
+    return true;
   }
 
   get isIntermediate(): boolean {
@@ -66,25 +66,37 @@ export default class TrustArcFrame extends AutoConsentCMPBase {
   }
 
   async optOut() {
+
+    // if the user has already opted out, let's not close the window
+    if(await this.mainWorldEval('EVAL_TRUSTARC_FRAME')){
+      return true;
+    }
+
+    //When Tags are being controlled through a tag managment system, the window will not call the vendors' opt-out
+    let timeout = 3000;
+    if(await this.mainWorldEval('EVAL_TRUSTARC_FRAME_GTM')) {
+      timeout = 1500;
+    }
+
     await waitFor(() => document.readyState === 'complete', 20, 100);
-    await this.waitForElement(".mainContent[aria-hidden=false]", 5000);
+    await this.waitForElement(".mainContent[aria-hidden=false]", timeout);
 
     if (this.click(".rejectAll")) {
       return true;
     }
 
     if (this.elementExists('.prefPanel')) {
-      await this.waitForElement('.prefPanel[style="visibility: visible;"]', 3000);
+      await this.waitForElement('.prefPanel[style="visibility: visible;"]', timeout);
     }
 
     if (this.click("#catDetails0")) {
       this.click(".submit");
-      this.waitForThenClick("#gwt-debug-close_id", 5000);
+      this.waitForThenClick("#gwt-debug-close_id", timeout);
       return true;
     }
 
     if (this.click(".required")) {
-      this.waitForThenClick("#gwt-debug-close_id", 5000);
+      this.waitForThenClick("#gwt-debug-close_id", timeout);
       return true;
     }
 
@@ -95,7 +107,7 @@ export default class TrustArcFrame extends AutoConsentCMPBase {
     this.click(".submit");
 
     // at this point, iframe usually closes. Sometimes we need to close manually, but we don't wait for it to report success
-    this.waitForThenClick("#gwt-debug-close_id", 300000);
+    this.waitForThenClick("#gwt-debug-close_id", timeout*10);
 
     return true;
   }
@@ -115,5 +127,12 @@ export default class TrustArcFrame extends AutoConsentCMPBase {
     });
 
     return true;
+  }
+
+  async test() {
+    //Test JS variable to check the user's preference
+    //preferences = undefined means no consent is set, preferences = '0' means consent is set to required only 
+    await this.wait(500);
+    return await this.mainWorldEval('EVAL_TRUSTARC_FRAME');
   }
 }

--- a/lib/cmps/trustarc-frame.ts
+++ b/lib/cmps/trustarc-frame.ts
@@ -74,7 +74,7 @@ export default class TrustArcFrame extends AutoConsentCMPBase {
 
     //When Tags are being controlled through a tag managment system, the window will not call the vendors' opt-out
     let timeout = 3000;
-    if(await this.mainWorldEval('EVAL_TRUSTARC_FRAME_GTM')) {
+    if (await this.mainWorldEval('EVAL_TRUSTARC_FRAME_GTM')) {
       timeout = 1500;
     }
 

--- a/lib/cmps/trustarc-frame.ts
+++ b/lib/cmps/trustarc-frame.ts
@@ -133,6 +133,6 @@ export default class TrustArcFrame extends AutoConsentCMPBase {
     //Test JS variable to check the user's preference
     //preferences = undefined means no consent is set, preferences = '0' means consent is set to required only 
     await this.wait(500);
-    return await this.mainWorldEval('EVAL_TRUSTART_FRAME_TEST');
+    return await this.mainWorldEval('EVAL_TRUSTARC_FRAME_TEST');
   }
 }

--- a/lib/cmps/trustarc-frame.ts
+++ b/lib/cmps/trustarc-frame.ts
@@ -68,7 +68,7 @@ export default class TrustArcFrame extends AutoConsentCMPBase {
   async optOut() {
 
     // if the user has already opted out, let's not close the window
-    if(await this.mainWorldEval('EVAL_TRUSTARC_FRAME')){
+    if (await this.mainWorldEval('EVAL_TRUSTARC_FRAME')){
       return true;
     }
 

--- a/lib/cmps/trustarc-top.ts
+++ b/lib/cmps/trustarc-top.ts
@@ -31,7 +31,7 @@ export default class TrustArcTop extends AutoConsentCMPBase {
   }
 
   get hasSelfTest(): boolean {
-    return false;
+    return true;
   }
 
   get isIntermediate(): boolean {
@@ -97,6 +97,7 @@ export default class TrustArcTop extends AutoConsentCMPBase {
   async test() {
     //Test JS variable to check the user's preference
     //PrefCookie = undefined means no consent is set, PrefCookie = '0' means consent is set to required only 
+    await this.wait(500);
     return await this.mainWorldEval('EVAL_TRUSTARC_TOP');
   }
 }

--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -49,7 +49,7 @@ export const snippets = {
   },
   EVAL_ONETRUST_1: () => window.OnetrustActiveGroups.split(',').filter(s => s.length > 0).length <= 1,
   EVAL_TRUSTARC_TOP: () => window && window.truste && window.truste.eu.bindMap.prefCookie === '0',
-  EVAL_TRUSTART_FRAME_TEST: () => window && window.QueryString && window.QueryString.preferences === '0',
+  EVAL_TRUSTARC_FRAME_TEST: () => window && window.QueryString && window.QueryString.preferences === '0',
   EVAL_TRUSTARC_FRAME_GTM: () => window && window.QueryString && window.QueryString.gtm === '1',
 
   // declarative rules

--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -49,6 +49,8 @@ export const snippets = {
   },
   EVAL_ONETRUST_1: () => window.OnetrustActiveGroups.split(',').filter(s => s.length > 0).length <= 1,
   EVAL_TRUSTARC_TOP: () => window && window.truste && window.truste.eu.bindMap.prefCookie === '0',
+  EVAL_TRUSTARC_FRAME: () => window && window.QueryString && window.QueryString.preferences === '0',
+  EVAL_TRUSTARC_FRAME_GTM: () => window && window.QueryString && window.QueryString.gtm === '1',
 
   // declarative rules
   EVAL_ADROLL_0: () => !document.cookie.includes('__adroll_fpc'),
@@ -109,6 +111,7 @@ export const snippets = {
   EVAL_PRIMEBOX_0: () => !document.cookie.includes('cb-enabled=accepted'),
   EVAL_PUBTECH_0: () => document.cookie.includes('euconsent-v2') && (document.cookie.match(/.YAAAAAAAAAAA/) || document.cookie.match(/.aAAAAAAAAAAA/) || document.cookie.match(/.YAAACFgAAAAA/)) ,
   EVAL_REDDIT_0: () => document.cookie.includes('eu_cookie={%22opted%22:true%2C%22nonessential%22:false}'),
+  EVAL_SIBBO_0: () => !!window.localStorage.getItem('euconsent-v2'),
   EVAL_SIRDATA_UNBLOCK_SCROLL: () => {
     document.documentElement.classList.forEach(cls => {
       if (cls.startsWith('sd-cmp-')) document.documentElement.classList.remove(cls)

--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -111,7 +111,6 @@ export const snippets = {
   EVAL_PRIMEBOX_0: () => !document.cookie.includes('cb-enabled=accepted'),
   EVAL_PUBTECH_0: () => document.cookie.includes('euconsent-v2') && (document.cookie.match(/.YAAAAAAAAAAA/) || document.cookie.match(/.aAAAAAAAAAAA/) || document.cookie.match(/.YAAACFgAAAAA/)) ,
   EVAL_REDDIT_0: () => document.cookie.includes('eu_cookie={%22opted%22:true%2C%22nonessential%22:false}'),
-  EVAL_SIBBO_0: () => !!window.localStorage.getItem('euconsent-v2'),
   EVAL_SIRDATA_UNBLOCK_SCROLL: () => {
     document.documentElement.classList.forEach(cls => {
       if (cls.startsWith('sd-cmp-')) document.documentElement.classList.remove(cls)

--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -49,7 +49,7 @@ export const snippets = {
   },
   EVAL_ONETRUST_1: () => window.OnetrustActiveGroups.split(',').filter(s => s.length > 0).length <= 1,
   EVAL_TRUSTARC_TOP: () => window && window.truste && window.truste.eu.bindMap.prefCookie === '0',
-  EVAL_TRUSTARC_FRAME: () => window && window.QueryString && window.QueryString.preferences === '0',
+  EVAL_TRUSTART_FRAME_TEST: () => window && window.QueryString && window.QueryString.preferences === '0',
   EVAL_TRUSTARC_FRAME_GTM: () => window && window.QueryString && window.QueryString.gtm === '1',
 
   // declarative rules


### PR DESCRIPTION
Users were unable to open the modal window to review the settings. Adjusted the function to check if the opt-out has already been executed.
Steps to test

- Go to TrustArc.com
- Wait the autoconsent to execute
- Click the Cookie preferences link at the bottom of the page

Before fix
The modal will autoclose after a few seconds
After fix
The modal will remain open 