### PR TITLE
Update UserCentrics API

### DIFF
--- a/rules/autoconsent/usercentrics-api.json
+++ b/rules/autoconsent/usercentrics-api.json
@@ -1,19 +1,32 @@
 {
   "name": "usercentrics-api",
-  "detectCmp": [{ "exists": "#usercentrics-root" }],
+  "detectCmp": [{ "exists": "#usercentrics-root,#usercentrics-cmp-ui" }],
   "detectPopup": [
     {
       "eval": "EVAL_USERCENTRICS_API_0"
     },
     {
-      "exists": [
-        "#usercentrics-root",
-        "[data-testid=uc-container]"
+      "if": {
+        "exists": "#usercentrics-cmp-ui"
+      },
+      "then": [
+        {
+          "waitForVisible": "#usercentrics-cmp-ui",
+          "timeout": 2000
+        }
+      ],
+      "else": [
+        {
+          "exists": [
+            "#usercentrics-root",
+            "[data-testid=uc-container]"
+          ]
+        },
+        {
+          "waitForVisible": "#usercentrics-root",
+          "timeout": 2000
+        }
       ]
-    },
-    {
-      "waitForVisible": "#usercentrics-root",
-      "timeout": 2000
     }
   ],
   "optIn": [

--- a/tests/usercentrics-api.spec.ts
+++ b/tests/usercentrics-api.spec.ts
@@ -7,6 +7,7 @@ generateCMPTests('usercentrics-api', [
   'https://shopbetreiber-blog.de/',
   'https://www.kia.com/us/en',
   'https://www.sportscheck.com/filialen/dortmund/',
+  'https://www.idealo.de/',
 ], {
   skipRegions: ["US", "GB", "FR"]
 }


### PR DESCRIPTION
I think you can check the case on the most of countries but to be clear, reproduced on the geolocation of France.

The API interface was found on the following site and everything went well. We just need to add new selector: `#usercentrics-cmp-ui`.

```
https://www.idealo.de/
```

refs https://github.com/ghostery/broken-page-reports/issues/773