### PR TITLE
Restrict ensighten detection to only when popup is visible.

### DIFF
--- a/rules/autoconsent/ens-modal.json
+++ b/rules/autoconsent/ens-modal.json
@@ -1,7 +1,7 @@
 {
     "name": "Ensighten ensModal",
     "prehideSelectors": [".ensModal"],
-    "detectCmp": [{ "exists": ".ensModal" }],
+    "detectCmp": [{ "exists": ".ensModal" }, { "visible": "#ensModalWrapper[style*=block]" }],
     "detectPopup": [{ "visible": "#ensModalWrapper[style*=block]" }],
     "optIn": [{ "waitForThenClick": "#modalAcceptButton" }],
     "optOut": [


### PR DESCRIPTION
https://app.asana.com/0/1203268166580279/1208804603144201/f

Prevent detection on https://nb.fidelity.com/ (where Onetrust rule should be used).