### PR TITLE
Add tests for DomActions.prehide()

### DIFF
--- a/tests-wtr/dom-actions/prehide/README.md
+++ b/tests-wtr/dom-actions/prehide/README.md
@@ -1,0 +1,1 @@
+Note: The test cases for `prehide()` have to be separated into dedicated files, as the generated HTML element `style#autoconsent-prehide` always has the same id and thus the test cases would interfere with one another.

--- a/tests-wtr/dom-actions/prehide/dom-actions.prehide.delayed-element.html
+++ b/tests-wtr/dom-actions/prehide/dom-actions.prehide.delayed-element.html
@@ -1,0 +1,11 @@
+<html>
+    <body>
+        <script type="module">
+            import { runTests } from '@web/test-runner-mocha';
+
+            runTests(async () => {
+                await import('./dom-actions.prehide.delayed-element');
+            });
+        </script>
+    </body>
+</html>

--- a/tests-wtr/dom-actions/prehide/dom-actions.prehide.delayed-element.ts
+++ b/tests-wtr/dom-actions/prehide/dom-actions.prehide.delayed-element.ts
@@ -1,0 +1,34 @@
+import { expect } from '@esm-bundle/chai';
+import { DomActions } from '../../../lib/dom-actions';
+import { instantiateDomActions } from '../utils';
+
+// must be run from dom-actions.prehide.delayed-element.html
+describe('prehide', () => {
+    let domActions: DomActions;
+
+    beforeEach(() => {
+        // Given
+        domActions = instantiateDomActions();
+    });
+
+    it('returns true even when element is only created after the call, and is immediately hidden', () => {
+        // Given
+        expect(document.querySelector('style#autoconsent-prehide')).to.be.null; // check that style element does not yet exist
+
+        // When
+        const result = domActions.prehide('#nonexistent');
+
+        // Then
+        expect(result).to.be.true;
+        expect(document.querySelector('style#autoconsent-prehide')).not.to.be.null; // check that style element was created
+
+        // we create element ex post and it will be hidden immediately
+        const createdDiv = document.createElement('div');
+        createdDiv.innerText = 'Here is some content';
+        createdDiv.id = 'nonexistent';
+
+        document.getElementsByTagName('body')[0].appendChild(createdDiv);
+
+        expect(createdDiv.checkVisibility({ checkOpacity: true })).to.be.false;
+    });
+});

--- a/tests-wtr/dom-actions/prehide/dom-actions.prehide.empty-selector.html
+++ b/tests-wtr/dom-actions/prehide/dom-actions.prehide.empty-selector.html
@@ -1,0 +1,12 @@
+<html>
+    <body>
+        <script type="module">
+            import { runTests } from '@web/test-runner-mocha';
+
+            runTests(async () => {
+                await import('./dom-actions.prehide.empty-selector');
+            });
+        </script>
+        <div id="visible">Here is some visible content!</div>
+    </body>
+</html>

--- a/tests-wtr/dom-actions/prehide/dom-actions.prehide.empty-selector.ts
+++ b/tests-wtr/dom-actions/prehide/dom-actions.prehide.empty-selector.ts
@@ -1,0 +1,27 @@
+import { expect } from '@esm-bundle/chai';
+import { DomActions } from '../../../lib/dom-actions';
+import { instantiateDomActions } from '../utils';
+
+// must be run from dom-actions.prehide.empty-selector.html
+describe('prehide', () => {
+    let domActions: DomActions;
+
+    beforeEach(() => {
+        // Given
+        domActions = instantiateDomActions();
+    });
+
+    it('returns false when selector is empty string', () => {
+        // Given
+        expect(document.getElementById('visible').checkVisibility({ checkOpacity: true })).to.be.true; // establish baseline to prevent false positive
+        expect(document.querySelector('style#autoconsent-prehide')).to.be.null; // check that style element does not yet exist
+
+        // When
+        const result = domActions.prehide('');
+
+        // Then
+        expect(result).to.be.false;
+        expect(document.getElementById('visible').checkVisibility({ checkOpacity: true })).to.be.true;
+        expect(document.querySelector('style#autoconsent-prehide')).not.to.be.null; // check that style element was created
+    });
+});

--- a/tests-wtr/dom-actions/prehide/dom-actions.prehide.preexisting-element.html
+++ b/tests-wtr/dom-actions/prehide/dom-actions.prehide.preexisting-element.html
@@ -1,0 +1,12 @@
+<html>
+    <body>
+        <script type="module">
+            import { runTests } from '@web/test-runner-mocha';
+
+            runTests(async () => {
+                await import('./dom-actions.prehide.preexisting-element');
+            });
+        </script>
+        <div id="visible">Here is some visible content!</div>
+    </body>
+</html>

--- a/tests-wtr/dom-actions/prehide/dom-actions.prehide.preexisting-element.ts
+++ b/tests-wtr/dom-actions/prehide/dom-actions.prehide.preexisting-element.ts
@@ -1,0 +1,28 @@
+import { expect } from '@esm-bundle/chai';
+import { instantiateDomActions } from '../utils';
+import { DomActions } from '../../../lib/dom-actions';
+
+// must be run from dom-actions.prehide.preexisting-element.html
+describe('prehide', () => {
+    let domActions: DomActions;
+
+    beforeEach(() => {
+        // Given
+        domActions = instantiateDomActions();
+    });
+
+    it('prehides preexisting element by selector', async () => {
+        // Given
+        expect(document.getElementById('visible').checkVisibility({ checkOpacity: true })).to.be.true; // establish baseline to prevent false positive
+        expect(document.querySelector('style#autoconsent-prehide')).to.be.null; // check that style element does not yet exist
+
+        // When
+        const result = domActions.prehide('#visible');
+
+        // Then
+        expect(result).to.be.true;
+
+        expect(document.getElementById('visible').checkVisibility({ checkOpacity: true })).to.be.false;
+        expect(document.querySelector('style#autoconsent-prehide')).not.to.be.null; // check that style element was created
+    });
+});


### PR DESCRIPTION
As described in the mini README, I had to split the tests into multiple files, as I didn't find any option of WTR to refresh files between runs.

I suppose potentially we could introduce such logic ourselves by using the "barebones" variant of html tests (the 2nd code snippet in [this page](https://modern-web.dev/docs/test-runner/writing-tests/html-tests/)), where `runTests` would be replaced by direct calls to specific test cases and we would perform a reload after each of them, but I'm not sure it's worth it, let me know if I should give it a try 🚀 

EDIT: Or, we could leverage undoPrehide() to get rid of the element again. However, I'm not sure if we want to couple the tests to its implementation like that.