### PR TITLE
Update release workflow to support Apple monorepo

### DIFF
--- a/.github/workflows/ddg-release.yml
+++ b/.github/workflows/ddg-release.yml
@@ -192,7 +192,7 @@ jobs:
             - name: Checkout Apple monorepo
               uses: actions/checkout@v3
               with:
-                  repository: duckduckgo/apple-monorepo-test # TODO: Update with final monorepo URL
+                  repository: duckduckgo/apple-browsers
                   path: apple-monorepo/
                   token: ${{ secrets.DAX_WEB_AUTOFILL_AUTOMATION }}
             - uses: actions/setup-node@v3

--- a/.github/workflows/ddg-release.yml
+++ b/.github/workflows/ddg-release.yml
@@ -11,13 +11,8 @@ on:
                 type: boolean
                 required: true
                 default: true
-            ios:
-                description: 'Propagate to iOS'
-                type: boolean
-                required: true
-                default: true
-            macos:
-                description: 'Propagate to macOS'
+            apple:
+                description: 'Propagate to iOS & macOS'
                 type: boolean
                 required: true
                 default: true
@@ -37,12 +32,8 @@ on:
                 description: 'Propagate to Android'
                 type: boolean
                 default: true
-            ios:
-                description: 'Propagate to iOS'
-                type: boolean
-                default: true
-            macos:
-                description: 'Propagate to macOS'
+            apple:
+                description: 'Propagate to iOS & macOS'
                 type: boolean
                 default: true
             windows:
@@ -178,11 +169,11 @@ jobs:
                   token: ${{ secrets.DAX_WEB_AUTOFILL_AUTOMATION }}
 
     # ------------------------------------------------------------------------------
-    # Create PR with updated autoconsent on iOS
+    # Create PR with updated autoconsent on iOS & macOS
     # ------------------------------------------------------------------------------
 
-    update_ios:
-        if: ${{ inputs.ios }}
+    update_apple:
+        if: ${{ inputs.apple }}
         runs-on: ubuntu-latest
         outputs:
             pull-request-url: ${{ steps.create-pr.outputs.pull-request-url }}
@@ -198,107 +189,54 @@ jobs:
                   path: autoconsent/
             - uses: ./autoconsent/.github/actions/setup-release-scripts
             # --- Action ---
-            - name: Checkout iOS
+            - name: Checkout Apple monorepo
               uses: actions/checkout@v3
               with:
-                  repository: duckduckgo/iOS
-                  path: ios/
+                  repository: duckduckgo/apple-monorepo-test # TODO: Update with final monorepo URL
+                  path: apple-monorepo/
                   token: ${{ secrets.DAX_WEB_AUTOFILL_AUTOMATION }}
             - uses: actions/setup-node@v3
               with:
                   node-version: current
             - name: Update iOS autoconsent reference
               run: |
-                  cd ios
+                  cd apple-monorepo/iOS
                   npm install @duckduckgo/autoconsent@${{ env.TAG }}
                   npm run rebuild-autoconsent
                   cd ..
-            - name: Create iOS PR Body
-              env:
-                  ASANA_OUTPUT: ${{ needs.create_asana_tasks.outputs.asana-output }}
-              run: |
-                  TEMPLATE="$(node ./autoconsent/ci/create-pr-template.js ios)"
-                  # Creates a randomised delimiter. See https://app.asana.com/0/1199892415909552/1203243297643584/f
-                  DELIMITER=$(echo $RANDOM | md5sum | head -c 20;)
-                  echo "PR_BODY_IOS<<$DELIMITER" >> $GITHUB_ENV
-                  echo "$TEMPLATE" >> $GITHUB_ENV
-                  echo "$DELIMITER" >> $GITHUB_ENV
-            # --- Effect ---
-            - name: Create PR for iOS
-              uses: peter-evans/create-pull-request@v7
-              id: create-pr
-              with:
-                  path: ios/
-                  add-paths: |
-                      package.json
-                      package-lock.json
-                      DuckDuckGo/Autoconsent/
-                  commit-message: Update autoconsent to ${{ env.TAG }}
-                  branch: update-autoconsent
-                  title: Update autoconsent to ${{ env.TAG }}
-                  body: '${{ env.PR_BODY_IOS }}'
-                  token: ${{ secrets.DAX_WEB_AUTOFILL_AUTOMATION }}
-
-    # ------------------------------------------------------------------------------
-    # Create PR with updated autoconsent on macOS
-    # ------------------------------------------------------------------------------
-
-    update_macos:
-        if: ${{ inputs.macos }}
-        runs-on: ubuntu-latest
-        outputs:
-            pull-request-url: ${{ steps.create-pr.outputs.pull-request-url }}
-        needs:
-            - create_asana_tasks
-            - get_release_info
-        env:
-            RELEASE_URL: ${{ needs.get_release_info.outputs.release-url }}
-        steps:
-            # --- Setup ---
-            - uses: actions/checkout@v3
-              with:
-                  path: autoconsent/
-            - uses: ./autoconsent/.github/actions/setup-release-scripts
-            # --- Action ---
-            - name: Checkout macOS
-              uses: actions/checkout@v3
-              with:
-                  repository: duckduckgo/macos-browser
-                  path: macos/
-                  token: ${{ secrets.DAX_WEB_AUTOFILL_AUTOMATION }}
-            - uses: actions/setup-node@v3
-              with:
-                  node-version: current
             - name: Update macOS autoconsent reference
               run: |
-                  cd macos
+                  cd apple-monorepo/macOS
                   npm install @duckduckgo/autoconsent@${{ env.TAG }}
                   npm run rebuild-autoconsent
                   cd ..
-            - name: Create macOS PR Body
+            - name: Create Apple PR Body
               env:
                   ASANA_OUTPUT: ${{ needs.create_asana_tasks.outputs.asana-output }}
               run: |
-                  TEMPLATE="$(node ./autoconsent/ci/create-pr-template.js macos)"
+                  TEMPLATE="$(node ./autoconsent/ci/create-pr-template.js apple)"
                   # Creates a randomised delimiter. See https://app.asana.com/0/1199892415909552/1203243297643584/f
                   DELIMITER=$(echo $RANDOM | md5sum | head -c 20;)
-                  echo "PR_BODY_MACOS<<$DELIMITER" >> $GITHUB_ENV
+                  echo "PR_BODY_APPLE<<$DELIMITER" >> $GITHUB_ENV
                   echo "$TEMPLATE" >> $GITHUB_ENV
                   echo "$DELIMITER" >> $GITHUB_ENV
             # --- Effect ---
-            - name: Create PR for macOS
+            - name: Create PR for Apple platforms
               uses: peter-evans/create-pull-request@v7
               id: create-pr
               with:
-                  path: macos/
+                  path: apple-monorepo/
                   add-paths: |
-                      package.json
-                      package-lock.json
-                      DuckDuckGo/Autoconsent/
+                      iOS/package.json
+                      iOS/package-lock.json
+                      iOS/DuckDuckGo/Autoconsent/
+                      macOS/package.json
+                      macOS/package-lock.json
+                      macOS/DuckDuckGo/Autoconsent/
                   commit-message: Update autoconsent to ${{ env.TAG }}
                   branch: update-autoconsent
                   title: Update autoconsent to ${{ env.TAG }}
-                  body: '${{ env.PR_BODY_MACOS }}'
+                  body: '${{ env.PR_BODY_APPLE }}'
                   token: ${{ secrets.DAX_WEB_AUTOFILL_AUTOMATION }}
 
     # ------------------------------------------------------------------------------
@@ -370,7 +308,7 @@ jobs:
         # Always run this final step, even if any of the updates have failed
         # unless the previous jobs were cancelled
         if: ${{ always() && !contains(needs.*.result, 'cancelled') }}
-        needs: [create_asana_tasks, update_android, update_ios, update_macos, update_windows]
+        needs: [create_asana_tasks, update_android, update_apple, update_windows]
         steps:
             # --- Setup ---
             - uses: actions/checkout@v3
@@ -382,8 +320,7 @@ jobs:
               env:
                   ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
                   ASANA_OUTPUT: ${{ needs.create_asana_tasks.outputs.asana-output }}
-                  IOS_PR_URL: ${{ needs.update_ios.outputs.pull-request-url }}
-                  MACOS_PR_URL: ${{ needs.update_macos.outputs.pull-request-url }}
+                  APPLE_PR_URL: ${{ needs.update_apple.outputs.pull-request-url }}
                   WINDOWS_PR_URL: ${{ needs.update_windows.outputs.pull-request-url }}
                   ANDROID_PR_URL: ${{ needs.update_android.outputs.pull-request-url }}
               run: |

--- a/ci/asana-create-tasks.js
+++ b/ci/asana-create-tasks.js
@@ -11,7 +11,7 @@ const releaseUrl = process.env.RELEASE_URL || 'https://example.com/';
 const releaseNotesRaw = process.env.RELEASE_NOTES || '<EMPTY RELEASE NOTES>';
 const releaseNotes = md.render(releaseNotesRaw);
 
-const templateTaskGid = '1209334124753471'; /* TODO: Replace with original template ID after monorepo migration */
+const templateTaskGid = '1206774921409831';
 const autoconsentProjectGid = '1201844467387842';
 const releaseSectionGid = '1202253736774466';
 const projectExtractorRegex = /\[\[project_gids=(.*)]]/;

--- a/ci/asana-create-tasks.js
+++ b/ci/asana-create-tasks.js
@@ -11,7 +11,7 @@ const releaseUrl = process.env.RELEASE_URL || 'https://example.com/';
 const releaseNotesRaw = process.env.RELEASE_NOTES || '<EMPTY RELEASE NOTES>';
 const releaseNotes = md.render(releaseNotesRaw);
 
-const templateTaskGid = '1206774921409831';
+const templateTaskGid = '1209334124753471'; /* TODO: Replace with original template ID after monorepo migration */
 const autoconsentProjectGid = '1201844467387842';
 const releaseSectionGid = '1202253736774466';
 const projectExtractorRegex = /\[\[project_gids=(.*)]]/;
@@ -21,7 +21,8 @@ const projectExtractorRegex = /\[\[project_gids=(.*)]]/;
  *
  * @typedef {{
  *   android: platformData,
- *   windows: platformData
+ *   windows: platformData,
+ *   apple: platformData
  * }} AsanaOutput
  */
 
@@ -37,13 +38,8 @@ const platforms = {
         taskGid: '',
         taskUrl: '',
     },
-    ios: {
-        displayName: 'iOS',
-        taskGid: '',
-        taskUrl: '',
-    },
-    macos: {
-        displayName: 'macOS',
+    apple: {
+        displayName: 'Apple',
         taskGid: '',
         taskUrl: '',
     },

--- a/ci/asana-update-tasks.js
+++ b/ci/asana-update-tasks.js
@@ -4,8 +4,7 @@ const { replaceAllInString, getLink } = require('./release-utils.js');
 const ASANA_ACCESS_TOKEN = process.env.ASANA_ACCESS_TOKEN;
 const prUrls = {
     android: process.env.ANDROID_PR_URL,
-    ios: process.env.IOS_PR_URL,
-    macos: process.env.MACOS_PR_URL,
+    apple: process.env.APPLE_PR_URL,
     windows: process.env.WINDOWS_PR_URL,
 };
 const asanaOutputRaw = process.env.ASANA_OUTPUT;

--- a/ci/create-pr-template.js
+++ b/ci/create-pr-template.js
@@ -11,7 +11,7 @@ const filepath = (...path) => join(cwd, ...path);
  *   releaseUrl: string,
  *   version: string
  * }} CreatePRTemplateData
- * @typedef {'android' | 'extensions' | 'bsk' | 'ios' | 'macos' | 'windows'} ReleasePlatform
+ * @typedef {'android' | 'extensions' | 'apple' | 'windows'} ReleasePlatform
  */
 
 const platform = /** @type {ReleasePlatform} */ (process.argv[2]);


### PR DESCRIPTION
Task: https://app.asana.com/0/72649045549333/1209197424401946

This PR updates the release workflow to support the Apple monorepo, replacing the individual iOS and macOS platforms with a single `iOS & macOS` option that will create a single PR and add it to both iOS and macOS app boards.

**How to test:**
1. Run the workflow from this branch and check the `iOS & macOS` option
2. Confirm that a PR is created in [this repo](https://github.com/duckduckgo/apple-monorepo-test/pulls) and that the created release task includes the Apple subtask
3. Alternatively, see [this workflow run](https://github.com/duckduckgo/autoconsent/actions/runs/13167711724) for a successful example of this working, and [this PR](https://github.com/duckduckgo/apple-monorepo-test/pull/15)