### PR TITLE
Fix Tealium rule on barmer.de

### DIFF
--- a/rules/autoconsent/tealium.json
+++ b/rules/autoconsent/tealium.json
@@ -8,7 +8,7 @@
         { "eval": "EVAL_TEALIUM_DONOTSELL" },
         { "hide": "#__tealiumGDPRecModal,#__tealiumGDPRcpPrefs,#__tealiumImplicitmodal" },
         {
-            "waitForThenClick": "#cm-acceptNone,.js-accept-essential-cookies,#continueWithoutAccepting",
+            "waitForThenClick": "#cm-acceptNone,.js-accept-essential-cookies,#continueWithoutAccepting,#no_consent",
             "timeout": 1000,
             "optional": true
         }


### PR DESCRIPTION
https://app.asana.com/0/1203268166580279/1209097847679118

Site has a custom implementation of Tealium that adds `body-no-scroll` when popup appears. It’s not removed when Autoconsent evaluates `EVAL_TEALIUM_1`. This causes scrolling to break after Autoconsent runs. Fix is to have Autoconsent click on the `#no_consent` button if it can.