### PR TITLE
Add Pandectes CMP

### DIFF
--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -167,6 +167,16 @@ export const snippets = {
     EVAL_OPENAI_TEST: () => document.cookie.includes('oai-allow-ne=false'),
     EVAL_OPERA_0: () =>
         document.cookie.includes('cookie_consent_essential=true') && !document.cookie.includes('cookie_consent_marketing=true'),
+    EVAL_PANDECTES_TEST: () =>
+        document.cookie.includes('_pandectes_gdpr=') &&
+        JSON.parse(
+            atob(
+                document.cookie
+                    .split(';')
+                    .find((s) => s.trim().startsWith('_pandectes_gdpr'))
+                    .split('=')[1],
+            ),
+        ).status === 'deny',
     EVAL_PAYPAL_0: () => document.cookie.includes('cookie_prefs') === true,
     EVAL_PRIMEBOX_0: () => !document.cookie.includes('cb-enabled=accepted'),
     EVAL_POSTNL_TEST: () => document.cookie.includes('CookiePermissionInfo'),

--- a/rules/autoconsent/pandectes.json
+++ b/rules/autoconsent/pandectes.json
@@ -1,0 +1,36 @@
+{
+    "name": "pandectes",
+    "vendorUrl": "https://pandectes.io/",
+    "prehideSelectors": ["#pandectes-banner"],
+    "detectCmp": [
+        {
+            "exists": "#pandectes-banner"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": ".pd-cookie-banner-window"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "#pandectes-banner .cc-allow"
+        }
+    ],
+    "optOut": [
+        {
+            "if": { "visible": "#pandectes-banner .cc-deny" },
+            "then": [{ "click": "#pandectes-banner .cc-deny" }],
+            "else": [
+                { "click": "#pandectes-banner .cc-settings" },
+                { "waitForThenClick": ".pd-cp-ui-rejectAll" },
+                { "click": ".pd-cp-ui-save" }
+            ]
+        }
+    ],
+    "test": [
+        {
+            "eval": "EVAL_PANDECTES_TEST"
+        }
+    ]
+}

--- a/rules/autoconsent/pandectes.json
+++ b/rules/autoconsent/pandectes.json
@@ -24,7 +24,8 @@
             "else": [
                 { "click": "#pandectes-banner .cc-settings" },
                 { "waitForThenClick": ".pd-cp-ui-rejectAll" },
-                { "click": ".pd-cp-ui-save" }
+                { "click": ".pd-cp-ui-save" },
+                { "wait": 200 }
             ]
         }
     ],

--- a/rules/autoconsent/pandectes.json
+++ b/rules/autoconsent/pandectes.json
@@ -9,7 +9,7 @@
     ],
     "detectPopup": [
         {
-            "visible": ".pd-cookie-banner-window"
+            "visible": "#pandectes-banner"
         }
     ],
     "optIn": [

--- a/rules/autoconsent/pandectes.json
+++ b/rules/autoconsent/pandectes.json
@@ -24,14 +24,9 @@
             "else": [
                 { "click": "#pandectes-banner .cc-settings" },
                 { "waitForThenClick": ".pd-cp-ui-rejectAll" },
-                { "click": ".pd-cp-ui-save" },
-                { "wait": 200 }
+                { "click": ".pd-cp-ui-save" }
             ]
         }
     ],
-    "test": [
-        {
-            "eval": "EVAL_PANDECTES_TEST"
-        }
-    ]
+    "test": [{ "wait": 500 }, { "eval": "EVAL_PANDECTES_TEST" }]
 }

--- a/tests/pandectes.spec.ts
+++ b/tests/pandectes.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('pandectes', ['https://hollandscountryclothing.co.uk/', 'https://cluse.com/', 'https://www.parent.com/']);


### PR DESCRIPTION
https://app.asana.com/0/1203268166580279/1207386274532820
https://app.asana.com/0/1203268166580279/1206854778035229

Pandectes seems to be built off of Complianz so there’s an argument that we could update e.g. `complianz-optin` to work with Pandectes cookie popups. I decided to write a new rule, though, because Pandectes has a completely custom Settings modal.