### PR TITLE
Add site specific rule for bbc.com

### DIFF
--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -69,6 +69,7 @@ export const snippets = {
     EVAL_ARBEITSAGENTUR_TEST: () => document.cookie.includes('cookie_consent=denied'),
     EVAL_AXEPTIO_0: () => document.cookie.includes('axeptio_authorized_vendors=%2C%2C'),
     EVAL_BAHN_TEST: () => utag.gdpr.getSelectedCategories().length === 1,
+    EVAL_BBC_TEST: () => document.cookie.includes('ckns_explicit=1'),
     EVAL_BING_0: () => document.cookie.includes('AD=0'),
     EVAL_BLOCKSY_0: () => document.cookie.includes('blocksy_cookies_consent_accepted=no'),
     EVAL_BORLABS_0: () =>

--- a/rules/autoconsent/bbc.com.json
+++ b/rules/autoconsent/bbc.com.json
@@ -1,0 +1,32 @@
+{
+    "name": "bbc.com",
+    "runContext": {
+        "urlPattern": "^https://(www\\.)?bbc\\.com"
+    },
+    "prehideSelectors": ["*[aria-labelledby=\"consent-banner-title\"]"],
+    "detectCmp": [
+        {
+            "exists": "#consent-banner-title"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#consent-banner-title"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "button[data-testid=\"accept-button\"]"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "button[data-testid=\"reject-button\"]"
+        }
+    ],
+    "test": [
+        {
+            "eval": "EVAL_BBC_TEST"
+        }
+    ]
+}

--- a/tests/bbc.com.spec.ts
+++ b/tests/bbc.com.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('bbc.com', ['https://www.bbc.com/sport/formula1']);


### PR DESCRIPTION
https://app.asana.com/0/1203268166580279/1209396155626700

Adds a site specific rule for the cookie popup found on https://www.bbc.com/sport/formula1. 