### PR TITLE
Add rule for inmobi.com and related websites

### DIFF
--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -140,6 +140,7 @@ export const snippets = {
     EVAL_GOOGLE_0: () => !!document.cookie.match(/SOCS=CAE/),
     EVAL_GRAVITO_TEST: () => document.cookie.includes('gravitoData'),
     EVAL_HEMA_TEST_0: () => document.cookie.includes('cookies_rejected=1'),
+    EVAL_INMOBI_TEST: () => document.cookie.includes('cookie-pref=rejected'),
     EVAL_IUBENDA_0: () =>
         document.querySelectorAll('.purposes-item input[type=checkbox]:not([disabled])').forEach((x) => {
             if (x.checked) x.click();

--- a/rules/autoconsent/inmobi.json
+++ b/rules/autoconsent/inmobi.json
@@ -1,0 +1,29 @@
+{
+    "name": "inmobi",
+    "prehideSelectors": [".accept-cookie"],
+    "detectCmp": [
+        {
+            "exists": ".accept-cookie > .accept-cookie-inner"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": ".accept-cookie > .accept-cookie-inner"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "xpath///*[contains(@class, 'accept-cookie')]//*[contains(text(), 'Accept')]"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "xpath///*[contains(@class, 'accept-cookie')]//*[contains(text(), 'Decline')]"
+        }
+    ],
+    "test": [
+        {
+            "eval": "EVAL_INMOBI_TEST"
+        }
+    ]
+}

--- a/tests/inmobi.spec.ts
+++ b/tests/inmobi.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('inmobi', ['https://www.inmobi.com/', 'https://advertising.inmobi.com/page/opt-out', 'https://wildwestads.top/']);


### PR DESCRIPTION
https://app.asana.com/0/1203268166580279/1209396501521357

Adds a rule for inmobi.com. The cookie popup is custom, but not site specific, since the same markup is found on other properties seemingly related to inmobi. 

Examples:

https://www.inmobi.com/
https://advertising.inmobi.com/page/opt-out
https://wildwestads.top/
https://nostra.gg/
https://calciumobi.top/
https://smartmobi.top/