### PR TITLE
Update Asana sync action

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -15,10 +15,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - uses: sammacbeth/action-asana-sync@v6
+            - uses: sammacbeth/action-asana-sync@v9
               with:
                   ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
                   ASANA_WORKSPACE_ID: ${{ secrets.ASANA_WORKSPACE_ID }}
                   ASANA_PROJECT_ID: '1203409672862476'
                   move_to_section_id: '1203409672862480'
-                  USER_MAP: ${{ vars.USER_MAP }}
+                  GITHUB_PAT: ${{ secrets.GH_RO_PAT }}
+                  ASSIGN_PR_AUTHOR: 'true'


### PR DESCRIPTION
- Now uses internal github <-> Asana user map.
- Automatically assigns PR tasks to the PR author on Github.