### PR TITLE
Add rule for caranddriver.com

### DIFF
--- a/rules/autoconsent/caranddriver.com.json
+++ b/rules/autoconsent/caranddriver.com.json
@@ -1,0 +1,12 @@
+{
+    "name": "caranddriver.com",
+    "cosmetic": true,
+    "runContext": {
+        "urlPattern": "^https://(www\\.)?caranddriver.com"
+    },
+    "prehideSelectors": ["*[aria-label='Privacy Disclosure']"],
+    "detectCmp": [{ "exists": "*[aria-label='Privacy Disclosure']" }],
+    "detectPopup": [{ "visible": "*[aria-label='Privacy Disclosure']" }],
+    "optIn": [{ "hide": "*[aria-label='Privacy Disclosure']" }],
+    "optOut": [{ "hide": "*[aria-label='Privacy Disclosure']" }]
+}

--- a/tests/caranddriver.com.spec.ts
+++ b/tests/caranddriver.com.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('caranddriver.com', ['https://www.caranddriver.com/features/g15377500/plug-in-hybrid-car-suv-vehicles/']);


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1209121419454298/task/1209648518984481?focus=true

Site specific cosmetic rule. Strangely the popup auto-dismisses which I think is making the unit test useless.