### PR TITLE
Fix HTML formatting for task list in release notes

### DIFF
--- a/ci/asana-create-tasks.js
+++ b/ci/asana-create-tasks.js
@@ -112,9 +112,9 @@ const processReleaseTasks = async () => {
         return '';
     }
 
-    let taskListHtml = '<strong>Tasks included in this release:</strong>\n<ul>';
+    let taskListHtml = '<strong>Tasks included in this release:</strong>\n<ul>\n';
     for (const task of tasks) {
-        taskListHtml += getLink(task.permalink_url) + '\n';
+        taskListHtml += '<li>' + getLink(task.permalink_url) + '</li>\n';
         await asana.tasks.updateTask(task.gid, { completed: true });
     }
     taskListHtml += '</ul>';


### PR DESCRIPTION
https://app.asana.com/0/1209121419454298/1209781090656240/f

## Description:

https://github.com/duckduckgo/autoconsent/pull/701 included an automation that mentions all tasks in the _Scheduled for release_ section when generating a release task.

Looking at an [example of a release task](https://app.asana.com/0/0/1209781653741305), though, you can see that there must be some invalid HTML.

I think it’s probably just because I’ve forgotten to wrap items with `<li>` tags. This PR adds them.

## Steps to test this PR:

Replace the call to `asanaCreateTasks()` in `ci/asana-create-tasks.js` with this code:

```js
(async () => {
    setupAsana();
    const html = [await processReleaseTasks(), releaseNotes].filter(Boolean).join('\n\n');
    console.log(html);
})();
```

Then obtain an Asana access token e.g. from your dev box or ask me for one.

Then, run:

```bash
export ASANA_ACCESS_TOKEN=<insert token here>
export RELEASE_NOTES="See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v12.16.0/CHANGELOG.md)"
node ci/asana-create-tasks.js
```

When I do this I get:

```html
<strong>Tasks included in this release:</strong>
<ul>
<li><a href="https://app.asana.com/0/1203268166580279/1209676670686348">https://app.asana.com/0/1203268166580279/1209676670686348</a></li>
</ul>

<p>See release notes <a href="https://github.com/duckduckgo/autoconsent/blob/v12.16.0/CHANGELOG.md">here</a></p>
```