### PR TITLE
Update Asana integration to support multiple tasks and ignore tasks not in CPM project

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -12,7 +12,7 @@ jobs:
         steps:
             - name: Find Asana task ID(s)
               id: find-tasks
-              uses: duckduckgo/native-github-asana-sync@v1.5
+              uses: duckduckgo/native-github-asana-sync@c481af86e02402c697e5521278e322ff670d6f44
               with:
                   action: 'find-asana-task-ids'
                   asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
@@ -21,7 +21,7 @@ jobs:
 
             - name: Move task(s) to "Scheduled for release" section
               if: steps.find-tasks.outputs.asanaTaskIds
-              uses: duckduckgo/native-github-asana-sync@v1.5
+              uses: duckduckgo/native-github-asana-sync@c481af86e02402c697e5521278e322ff670d6f44
               with:
                   action: 'add-task-asana-project'
                   asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -12,7 +12,7 @@ jobs:
         steps:
             - name: Find Asana task ID(s)
               id: find-tasks
-              uses: duckduckgo/native-github-asana-sync@c481af86e02402c697e5521278e322ff670d6f44
+              uses: noisysocks/native-github-asana-sync@2ff5d8939713f26e2cafb87742ad883969f53240
               with:
                   action: 'find-asana-task-ids'
                   asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
@@ -21,7 +21,7 @@ jobs:
 
             - name: Move task(s) to "Scheduled for release" section
               if: steps.find-tasks.outputs.asanaTaskIds
-              uses: duckduckgo/native-github-asana-sync@c481af86e02402c697e5521278e322ff670d6f44
+              uses: noisysocks/native-github-asana-sync@2ff5d8939713f26e2cafb87742ad883969f53240
               with:
                   action: 'add-task-asana-project'
                   asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -10,20 +10,21 @@ jobs:
         runs-on: ubuntu-latest
         if: github.event.pull_request.merged == true
         steps:
-            - name: Find Asana task ID
-              id: find-task
+            - name: Find Asana task ID(s)
+              id: find-tasks
               uses: duckduckgo/native-github-asana-sync@v1.5
               with:
-                  action: 'find-asana-task-id'
+                  action: 'find-asana-task-ids'
                   asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
                   trigger-phrase: 'Task/Issue URL:'
+                  asana-project: '1203268166580279' # CPM (Cookie Pop-up Management) Triage project
 
-            - name: Move task to "Scheduled for release" section
-              if: steps.find-task.outputs.asanaTaskId
+            - name: Move task(s) to "Scheduled for release" section
+              if: steps.find-tasks.outputs.asanaTaskIds
               uses: duckduckgo/native-github-asana-sync@v1.5
               with:
                   action: 'add-task-asana-project'
                   asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
                   asana-project: '1203268166580279' # CPM (Cookie Pop-up Management) Triage project
                   asana-section: '1207140808076253' # "Scheduled for release" section ID
-                  asana-task-id: ${{ steps.find-task.outputs.asanaTaskId }}
+                  asana-task-id: ${{ steps.find-tasks.outputs.asanaTaskIds }}

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Add comment to Asana task(s)
-              uses: duckduckgo/native-github-asana-sync@v1.5
+              uses: duckduckgo/native-github-asana-sync@c481af86e02402c697e5521278e322ff670d6f44
               with:
                   action: 'add-asana-comment'
                   asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
@@ -20,7 +20,7 @@ jobs:
 
             - name: Find Asana task ID(s)
               id: find-tasks
-              uses: duckduckgo/native-github-asana-sync@v1.5
+              uses: duckduckgo/native-github-asana-sync@c481af86e02402c697e5521278e322ff670d6f44
               with:
                   action: 'find-asana-task-ids'
                   asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
@@ -29,7 +29,7 @@ jobs:
 
             - name: Move task(s) to "Awaiting review" section
               if: steps.find-tasks.outputs.asanaTaskIds
-              uses: duckduckgo/native-github-asana-sync@v1.5
+              uses: duckduckgo/native-github-asana-sync@c481af86e02402c697e5521278e322ff670d6f44
               with:
                   action: 'add-task-asana-project'
                   asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Add comment to Asana task(s)
-              uses: duckduckgo/native-github-asana-sync@c481af86e02402c697e5521278e322ff670d6f44
+              uses: noisysocks/native-github-asana-sync@2ff5d8939713f26e2cafb87742ad883969f53240
               with:
                   action: 'add-asana-comment'
                   asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
@@ -20,7 +20,7 @@ jobs:
 
             - name: Find Asana task ID(s)
               id: find-tasks
-              uses: duckduckgo/native-github-asana-sync@c481af86e02402c697e5521278e322ff670d6f44
+              uses: noisysocks/native-github-asana-sync@2ff5d8939713f26e2cafb87742ad883969f53240
               with:
                   action: 'find-asana-task-ids'
                   asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
@@ -29,7 +29,7 @@ jobs:
 
             - name: Move task(s) to "Awaiting review" section
               if: steps.find-tasks.outputs.asanaTaskIds
-              uses: duckduckgo/native-github-asana-sync@c481af86e02402c697e5521278e322ff670d6f44
+              uses: noisysocks/native-github-asana-sync@2ff5d8939713f26e2cafb87742ad883969f53240
               with:
                   action: 'add-task-asana-project'
                   asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -10,28 +10,29 @@ jobs:
     process-asana-tasks:
         runs-on: ubuntu-latest
         steps:
-            - name: Add comment to Asana task
+            - name: Add comment to Asana task(s)
               uses: duckduckgo/native-github-asana-sync@v1.5
               with:
                   action: 'add-asana-comment'
                   asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
                   trigger-phrase: 'Task/Issue URL:'
-                  is-pinned: 'false'
+                  asana-project: '1203268166580279' # CPM (Cookie Pop-up Management) Triage project
 
-            - name: Find Asana task ID
-              id: find-task
+            - name: Find Asana task ID(s)
+              id: find-tasks
               uses: duckduckgo/native-github-asana-sync@v1.5
               with:
-                  action: 'find-asana-task-id'
+                  action: 'find-asana-task-ids'
                   asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
                   trigger-phrase: 'Task/Issue URL:'
+                  asana-project: '1203268166580279' # CPM (Cookie Pop-up Management) Triage project
 
-            - name: Move task to "Awaiting review" section
-              if: steps.find-task.outputs.asanaTaskId
+            - name: Move task(s) to "Awaiting review" section
+              if: steps.find-tasks.outputs.asanaTaskIds
               uses: duckduckgo/native-github-asana-sync@v1.5
               with:
                   action: 'add-task-asana-project'
                   asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
                   asana-project: '1203268166580279' # CPM (Cookie Pop-up Management) Triage project
                   asana-section: '1209767000096488' # "Awaiting review" section ID
-                  asana-task-id: ${{ steps.find-task.outputs.asanaTaskId }}
+                  asana-task-id: ${{ steps.find-tasks.outputs.asanaTaskIds }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1209121419454298/1209805344481173/f

## Description:

Iterates on the Asana automations added in https://github.com/duckduckgo/autoconsent/pull/701:

- Mentioned tasks that aren’t in the CPM project are ignored.
- Support moving multiple mentioned tasks to the "Awaiting review" and "Scheduled for release” sections.

This uses functionality added to `native-github-asana-sync` in https://github.com/duckduckgo/native-github-asana-sync/pull/8.