### PR TITLE
Jenkins CI: Use GIT_COMMIT when notifying GitHub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,12 +137,11 @@ pipeline {
                         }
                     }
 
-                    def prHeadSha = env.CHANGE_ID ? sh(script: "git rev-parse HEAD^2", returnStdout: true).trim() : env.GIT_COMMIT
                     githubNotify(
                             account: 'duckduckgo',
                             repo: 'autoconsent',
                             context: 'Tests / Changed files',
-                            sha: "${prHeadSha}",
+                            sha: "${env.GIT_COMMIT}",
                             description: description,
                             status: status,
                             credentialsId: 'autoconsent-rw'


### PR DESCRIPTION
I noticed Jenkins failed in https://github.com/duckduckgo/autoconsent/pull/712:

https://jenkins.duckduckgo.com/job/cookie%20prompt%20management/job/autoconsent-ci/view/change-requests/job/PR-712/1/

Just using `GIT_COMMIT` when notifying GitHub of the status seems to fix it:

https://jenkins.duckduckgo.com/job/cookie%20prompt%20management/job/autoconsent-ci/view/change-requests/job/PR-712/2/