### PR TITLE
Run detection phase sequentially per CMP.

### DIFF
--- a/lib/cmps/base.ts
+++ b/lib/cmps/base.ts
@@ -200,7 +200,7 @@ export class AutoConsentCMP extends AutoConsentCMPBase {
 
     async detectCmp() {
         if (this.rule.detectCmp) {
-            return this._runRulesParallel(this.rule.detectCmp);
+            return this._runRulesSequentially(this.rule.detectCmp);
         }
         return false;
     }


### PR DESCRIPTION

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201844467387842/task/1210000215861314?focus=true

## Description:
As most rules at this phase are sync, this has no performance cost, but allows us to reduce the total number of steps to run, because for detections with multiple steps, we don't have to run subsequent steps if the first fails.

In the worst case (no CMP on page), reduces total number of check steps from 4515 to 4326 (4% reduction).


