### PR TITLE
Delay reruns of the detectCmp phase until there is a dom mutation.

### DIFF
--- a/lib/dom-actions.ts
+++ b/lib/dom-actions.ts
@@ -157,4 +157,21 @@ export class DomActions implements DomActionsProvider {
         }
         return this.querySelectorChain(selector);
     }
+
+    waitForMutation(selector: ElementSelector): Promise<boolean> {
+        const node = this.elementSelector(selector);
+        if (node.length === 0) {
+            throw new Error(`${selector} did not match any elements`);
+        }
+        return new Promise((resolve) => {
+            const observer = new MutationObserver(() => {
+                observer.disconnect();
+                resolve(true);
+            });
+            observer.observe(node[0], {
+                subtree: true,
+                childList: true,
+            });
+        });
+    }
 }

--- a/lib/dom-actions.ts
+++ b/lib/dom-actions.ts
@@ -158,19 +158,25 @@ export class DomActions implements DomActionsProvider {
         return this.querySelectorChain(selector);
     }
 
-    waitForMutation(selector: ElementSelector): Promise<boolean> {
+    waitForMutation(selector: ElementSelector, timeout = 60000): Promise<boolean> {
         const node = this.elementSelector(selector);
         if (node.length === 0) {
             throw new Error(`${selector} did not match any elements`);
         }
-        return new Promise((resolve) => {
+        return new Promise((resolve, reject) => {
+            const timer = setTimeout(() => {
+                reject(new Error('Timed out waiting for mutation'));
+                observer.disconnect();
+            }, timeout);
             const observer = new MutationObserver(() => {
+                clearTimeout(timer);
                 observer.disconnect();
                 resolve(true);
             });
             observer.observe(node[0], {
                 subtree: true,
                 childList: true,
+                attributes: true,
             });
         });
     }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -34,6 +34,7 @@ export interface DomActionsProvider {
     querySingleReplySelector(selector: string, parent?: any): HTMLElement[];
     querySelectorChain(selectors: string[]): HTMLElement[];
     elementSelector(selector: ElementSelector): HTMLElement[];
+    waitForMutation(selector: ElementSelector): Promise<boolean>;
 }
 
 export type RuleBundle = {

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -274,7 +274,12 @@ export default class AutoConsent {
         if (foundCMPs.length === 0 && retries > 0) {
             // We wait 500ms, and also for some kind of dom mutation to happen before
             // rerunning the findCmp check
-            await Promise.all([this.domActions.wait(500), this.domActions.waitForMutation('html')]);
+            try {
+                await Promise.all([this.domActions.wait(500), this.domActions.waitForMutation('html')]);
+            } catch (e) {
+                // timeout waiting for mutation - break out of detection
+                return []
+            }
 
             return this.findCmp(retries - 1);
         }

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -278,7 +278,7 @@ export default class AutoConsent {
                 await Promise.all([this.domActions.wait(500), this.domActions.waitForMutation('html')]);
             } catch (e) {
                 // timeout waiting for mutation - break out of detection
-                return []
+                return [];
             }
 
             return this.findCmp(retries - 1);

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -272,7 +272,10 @@ export default class AutoConsent {
         this.detectHeuristics();
 
         if (foundCMPs.length === 0 && retries > 0) {
-            await this.domActions.wait(500);
+            // We wait 500ms, and also for some kind of dom mutation to happen before
+            // rerunning the findCmp check
+            await Promise.all([this.domActions.wait(500), this.domActions.waitForMutation('html')]);
+
             return this.findCmp(retries - 1);
         }
 

--- a/tests-wtr/dom-actions/dom-actions.wait-for-mutation.html
+++ b/tests-wtr/dom-actions/dom-actions.wait-for-mutation.html
@@ -1,0 +1,15 @@
+<html>
+    <body>
+        <script type="module">
+            import { runTests } from '@web/test-runner-mocha';
+
+            runTests(async () => {
+                await import('./dom-actions.wait-for-mutation');
+            });
+        </script>
+
+        <h1>Hello test</h1>
+        <p id="already-present">This element is present from the start</p>
+        <div id="target-for-delayed-element"></div>
+    </body>
+</html>

--- a/tests-wtr/dom-actions/dom-actions.wait-for-mutation.ts
+++ b/tests-wtr/dom-actions/dom-actions.wait-for-mutation.ts
@@ -1,0 +1,75 @@
+import { expect } from '@esm-bundle/chai';
+import { instantiateDomActions } from './utils';
+
+// must be run from dom-actions.wait-for-element.html
+describe('waitForMutation', () => {
+    it('should resolve if the DOM is modified', async () => {
+        // Given
+        const domActions = instantiateDomActions();
+
+        // When
+        const resultPromise = domActions.waitForMutation('html');
+        const el = document.createElement('p');
+        document.body.appendChild(el);
+
+        // Then
+        expect(await resultPromise).to.be.true;
+    });
+
+    it('should throw if the dom does not change by timeout', async () => {
+        // Given
+        const domActions = instantiateDomActions();
+
+        // When
+        const resultPromise = domActions.waitForMutation('html', 10);
+
+        // Then
+        try {
+            await resultPromise;
+            expect.fail('Expected Error');
+        } catch (e) {
+            expect(e).to.be.an('Error');
+        }
+    });
+
+    it('should limit mutation detector to the provided selector', async () => {
+        // Given
+        const domActions = instantiateDomActions();
+
+        // When
+        const resultPromise = domActions.waitForMutation('#already-present', 10);
+        const el = document.createElement('p');
+        document.body.appendChild(el);
+
+        // Then
+        try {
+            await resultPromise;
+            expect.fail('Expected Error');
+        } catch (e) {
+            expect(e).to.be.an('Error');
+        }
+    });
+
+    it('should still resolve for a mutation within the provided selector', async () => {
+        // Given
+        const domActions = instantiateDomActions();
+
+        // When
+        const resultPromise = domActions.waitForMutation('#already-present', 10);
+        document.getElementById('already-present').innerText = 'foo';
+
+        // Then
+        expect(await resultPromise).to.be.true;
+    });
+
+    it('should throw if selector does not match anything in the page', async () => {
+        const domActions = instantiateDomActions();
+
+        try {
+            await domActions.waitForMutation('#not-present', 10);
+            expect.fail('Expected Error');
+        } catch (e) {
+            expect(e).to.be.an('Error');
+        }
+    });
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201844467387842/task/1210000215861314?focus=true

## Description:
Prevents unnecessary CMP checks when the page hasn't changed since the last check.

## Steps to test this PR:

