### PR TITLE
Make detection logs toggleable

### DIFF
--- a/addon/popup.html
+++ b/addon/popup.html
@@ -92,6 +92,10 @@
                 <label for="logs-rulesteps">Rule steps</label>
             </div>
             <div>
+                <input type="checkbox" id="logs-detectionsteps" name="logs-detectionsteps" checked />
+                <label for="logs-detectionsteps">Include detection steps</label>
+            </div>
+            <div>
                 <input type="checkbox" id="logs-waits" name="logs-waits" checked />
                 <label for="logs-waits">Include wait steps</label>
             </div>

--- a/addon/popup.ts
+++ b/addon/popup.ts
@@ -17,6 +17,7 @@ async function init() {
     const retriesInput = document.querySelector('input#retries') as HTMLInputElement;
     const logsLifecycleCheckbox = document.querySelector('input#logs-lifecycle') as HTMLInputElement;
     const logsRulestepsCheckbox = document.querySelector('input#logs-rulesteps') as HTMLInputElement;
+    const logsDetectionstepsCheckbox = document.querySelector('input#logs-detectionsteps') as HTMLInputElement;
     const logsWaitsCheckbox = document.querySelector('input#logs-waits') as HTMLInputElement;
     const logsEvalsCheckbox = document.querySelector('input#logs-evals') as HTMLInputElement;
     const logsErrorsCheckbox = document.querySelector('input#logs-errors') as HTMLInputElement;
@@ -62,6 +63,7 @@ async function init() {
     enabledCheckbox.checked = autoconsentConfig.enabled && enabledForCurrentDomain;
     logsLifecycleCheckbox.checked = autoconsentConfig.logs.lifecycle;
     logsRulestepsCheckbox.checked = autoconsentConfig.logs.rulesteps;
+    logsDetectionstepsCheckbox.checked = autoconsentConfig.logs.detectionsteps;
     logsWaitsCheckbox.checked = autoconsentConfig.logs.waits;
     logsEvalsCheckbox.checked = autoconsentConfig.logs.evals;
     logsErrorsCheckbox.checked = autoconsentConfig.logs.errors;
@@ -131,6 +133,7 @@ async function init() {
         autoconsentConfig.logs = {
             lifecycle: logsLifecycleCheckbox.checked,
             rulesteps: logsRulestepsCheckbox.checked,
+            detectionsteps: logsDetectionstepsCheckbox.checked,
             evals: logsEvalsCheckbox.checked,
             errors: logsErrorsCheckbox.checked,
             messages: logsMessagesCheckbox.checked,
@@ -143,6 +146,9 @@ async function init() {
         updateLogsConfig();
     });
     logsRulestepsCheckbox.addEventListener('change', () => {
+        updateLogsConfig();
+    });
+    logsDetectionstepsCheckbox.addEventListener('change', () => {
         updateLogsConfig();
     });
     logsWaitsCheckbox.addEventListener('change', () => {

--- a/lib/cmps/base.ts
+++ b/lib/cmps/base.ts
@@ -178,6 +178,10 @@ export default class AutoConsentCMPBase implements AutoCMP, DomActionsProvider {
     elementSelector(selector: ElementSelector) {
         return this.autoconsent.domActions.elementSelector(selector);
     }
+
+    waitForMutation(selector: ElementSelector) {
+        return this.autoconsent.domActions.waitForMutation(selector);
+    }
 }
 
 export class AutoConsentCMP extends AutoConsentCMPBase {
@@ -208,14 +212,14 @@ export class AutoConsentCMP extends AutoConsentCMPBase {
 
     async detectCmp() {
         if (this.rule.detectCmp) {
-            return this._runRulesSequentially(this.rule.detectCmp);
+            return this._runRulesSequentially(this.rule.detectCmp, this.autoconsent.config.logs.detectionsteps);
         }
         return false;
     }
 
     async detectPopup() {
         if (this.rule.detectPopup) {
-            return this._runRulesSequentially(this.rule.detectPopup);
+            return this._runRulesSequentially(this.rule.detectPopup, this.autoconsent.config.logs.detectionsteps);
         }
         return false;
     }
@@ -224,7 +228,7 @@ export class AutoConsentCMP extends AutoConsentCMPBase {
         const logsConfig = this.autoconsent.config.logs;
         if (this.rule.optOut) {
             logsConfig.lifecycle && console.log('Initiated optOut()', this.rule.optOut);
-            return this._runRulesSequentially(this.rule.optOut);
+            return this._runRulesSequentially(this.rule.optOut, this.autoconsent.config.logs.rulesteps);
         }
         return false;
     }
@@ -233,21 +237,21 @@ export class AutoConsentCMP extends AutoConsentCMPBase {
         const logsConfig = this.autoconsent.config.logs;
         if (this.rule.optIn) {
             logsConfig.lifecycle && console.log('Initiated optIn()', this.rule.optIn);
-            return this._runRulesSequentially(this.rule.optIn);
+            return this._runRulesSequentially(this.rule.optIn, this.autoconsent.config.logs.rulesteps);
         }
         return false;
     }
 
     async openCmp() {
         if (this.rule.openCmp) {
-            return this._runRulesSequentially(this.rule.openCmp);
+            return this._runRulesSequentially(this.rule.openCmp, this.autoconsent.config.logs.rulesteps);
         }
         return false;
     }
 
     async test() {
         if (this.hasSelfTest) {
-            return this._runRulesSequentially(this.rule.test);
+            return this._runRulesSequentially(this.rule.test, this.autoconsent.config.logs.rulesteps);
         }
         return super.test();
     }
@@ -334,12 +338,11 @@ export class AutoConsentCMP extends AutoConsentCMPBase {
         return detections.every((r) => !!r);
     }
 
-    async _runRulesSequentially(rules: AutoConsentRuleStep[]): Promise<boolean> {
-        const logsConfig = this.autoconsent.config.logs;
+    async _runRulesSequentially(rules: AutoConsentRuleStep[], logSteps = true): Promise<boolean> {
         for (const rule of rules) {
-            logsConfig.rulesteps && console.log('Running rule...', rule);
+            logSteps && console.log('Running rule...', rule);
             const result = await this.evaluateRuleStep(rule);
-            logsConfig.rulesteps && console.log('...rule result', result);
+            logSteps && console.log('...rule result', result);
             if (!result && !rule.optional) {
                 return false;
             }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -60,6 +60,7 @@ export type Config = {
     logs: {
         lifecycle: boolean;
         rulesteps: boolean;
+        detectionsteps: boolean;
         evals: boolean;
         errors: boolean;
         messages: boolean;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -82,6 +82,7 @@ export function normalizeConfig(providedConfig: any): Config {
         logs: {
             lifecycle: false,
             rulesteps: false,
+            detectionsteps: false,
             evals: false,
             errors: true,
             messages: false,


### PR DESCRIPTION
Task/Issue URL:

## Description:
Quick fix to work around noisy logs after merging https://github.com/duckduckgo/autoconsent/pull/719


## Steps to test this PR:

- compile the test extension
- test the new debug log checkbox: it should toggle logs for the rules in detectCmp and detectPopup