### PR TITLE
Fix: Exclude rules from detection if they have a urlPattern and it does not match.

### DIFF
--- a/lib/web.ts
+++ b/lib/web.ts
@@ -257,9 +257,10 @@ export default class AutoConsent {
             // first filter out rules that don't run in this frame-type.
             if (cmp.checkFrameContext(isTop)) {
                 // Pull out any rule that has a urlPattern that matches here to be prioritized.
+                const isSiteSpecific = !!cmp.runContext.urlPattern;
                 if (cmp.hasMatchingUrlPattern()) {
                     siteSpecificRules.push(cmp);
-                } else {
+                } else if (!isSiteSpecific) {
                     otherRules.push(cmp);
                 }
             }

--- a/tests-wtr/lifecycle/find-cmp.html
+++ b/tests-wtr/lifecycle/find-cmp.html
@@ -1,0 +1,18 @@
+<html>
+    <body>
+        <script type="module">
+            import { runTests } from '@web/test-runner-mocha';
+
+            runTests(async () => {
+                await import('./find-cmp');
+            });
+        </script>
+        <input type="text" id="pre-focused-input" />
+        <p id="privacy-test-page-cmp-test">
+            This is a fake consent popup:
+            <input type="text" id="popup-input" />
+            <button id="reject-all">Reject all</button>
+            <button id="accept-all">Accept all</button>
+        </p>
+    </body>
+</html>

--- a/tests-wtr/lifecycle/find-cmp.ts
+++ b/tests-wtr/lifecycle/find-cmp.ts
@@ -1,0 +1,128 @@
+import { expect } from '@esm-bundle/chai';
+import Autoconsent from '../../lib/web';
+
+describe('Autoconsent.findCmp', () => {
+    let autoconsent: Autoconsent;
+
+    beforeEach(() => {
+        // Given
+        autoconsent = new Autoconsent((msg) => Promise.resolve(), {
+            enabled: false, // bypass initialization
+            autoAction: null,
+        });
+    });
+
+    it('should detect a CMP in a page', async () => {
+        autoconsent.addDeclarativeCMP({
+            name: 'test',
+            detectCmp: [{ exists: '#privacy-test-page-cmp-test' }],
+            detectPopup: [],
+            optIn: [],
+            optOut: [],
+        });
+        const found = await autoconsent.findCmp(0);
+        expect(found).to.have.length(1);
+        expect(found[0].name).to.equal('test');
+    });
+
+    it('can return more than 1 match', async () => {
+        autoconsent.addDeclarativeCMP({
+            name: 'test',
+            detectCmp: [{ exists: '#privacy-test-page-cmp-test' }],
+            detectPopup: [],
+            optIn: [],
+            optOut: [],
+        });
+        autoconsent.addDeclarativeCMP({
+            name: 'test2',
+            detectCmp: [{ exists: '#reject-all' }],
+            detectPopup: [],
+            optIn: [],
+            optOut: [],
+        });
+        const found = await autoconsent.findCmp(0);
+        expect(found).to.have.length(2);
+    });
+
+    it('returns empty if no rules match', async () => {
+        autoconsent.addDeclarativeCMP({
+            name: 'test',
+            detectCmp: [{ exists: '#privacy-test-page-cmp-test2' }],
+            detectPopup: [],
+            optIn: [],
+            optOut: [],
+        });
+        autoconsent.addDeclarativeCMP({
+            name: 'test2',
+            detectCmp: [{ exists: '#reject-all2' }],
+            detectPopup: [],
+            optIn: [],
+            optOut: [],
+        });
+        const found = await autoconsent.findCmp(0);
+        expect(found).to.have.length(0);
+    });
+
+    it('does not return a rule if the runContext does not match: frame-only rule', async () => {
+        autoconsent.addDeclarativeCMP({
+            name: 'runContextRule',
+            runContext: { main: false, frame: true },
+            detectCmp: [{ exists: '#privacy-test-page-cmp-test' }],
+            detectPopup: [],
+            optIn: [],
+            optOut: [],
+        });
+        autoconsent.addDeclarativeCMP({
+            name: 'test',
+            detectCmp: [{ exists: '#reject-all' }],
+            detectPopup: [],
+            optIn: [],
+            optOut: [],
+        });
+        const found = await autoconsent.findCmp(0);
+        expect(found).to.have.length(1);
+        expect(found[0].name).to.equal('test');
+    });
+
+    it('does not return a rule if the runContext does not match: urlPattern', async () => {
+        autoconsent.addDeclarativeCMP({
+            name: 'runContextRule',
+            runContext: { urlPattern: '^https://(www\\.)?example\\.com/' },
+            detectCmp: [{ exists: '#privacy-test-page-cmp-test' }],
+            detectPopup: [],
+            optIn: [],
+            optOut: [],
+        });
+        autoconsent.addDeclarativeCMP({
+            name: 'test',
+            detectCmp: [{ exists: '#reject-all' }],
+            detectPopup: [],
+            optIn: [],
+            optOut: [],
+        });
+        const found = await autoconsent.findCmp(0);
+        expect(found).to.have.length(1);
+        expect(found[0].name).to.equal('test');
+    });
+
+    it('only matches the site-specific rule if urlPattern matches', async () => {
+        autoconsent.addDeclarativeCMP({
+            name: 'runContextRule',
+            runContext: { urlPattern: '^http://localhost' },
+            detectCmp: [{ exists: '#privacy-test-page-cmp-test' }],
+            detectPopup: [],
+            optIn: [],
+            optOut: [],
+        });
+        autoconsent.addDeclarativeCMP({
+            name: 'test',
+            detectCmp: [{ exists: '#reject-all' }],
+            detectPopup: [],
+            optIn: [],
+            optOut: [],
+        });
+        const found = await autoconsent.findCmp(0);
+        expect(found).to.have.length(1);
+        expect(found[0].name).to.equal('runContextRule');
+    });
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201844467387842/task/1210174209301482?focus=true

## Description:
Fixes a bug introduced in #720 where we didn't remove rules from consideration if they have a urlPattern that doesn't match.

Also adds unit-tests for the `findCmp` step.

## Steps to test this PR:
 1. Visit https://www.snapchat.com/
 2. leafy.com rule should not trigger.
