### PR TITLE
Fail-fast when trying to run incompatible rules

### DIFF
--- a/lib/cmps/validation.ts
+++ b/lib/cmps/validation.ts
@@ -1,0 +1,28 @@
+/**
+ * This is a list of all allowed properties on rule step keys.
+ * We can use this to validate if a given step is supported by
+ * the current library version.
+ */
+export const PERMITTED_STEP_KEYS = [
+    'cookieContains',
+    'negated',
+    'any',
+    'if',
+    'then',
+    'else',
+    'hide',
+    'method',
+    'wait',
+    'waitForThenClick',
+    'timeout',
+    'all',
+    'click',
+    'waitForVisible',
+    'check',
+    'waitFor',
+    'eval',
+    'visible',
+    'exists',
+    'optional',
+    'comment',
+];

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "clean": "rm -r dist",
     "lint": "eslint . && prettier . --check && npm run rule-syntax-check",
     "bundle": "./build.sh",
-    "rule-syntax-check": "node scripts/validate-json-rules.js",
+    "rule-syntax-check": "node scripts/validate-json-rules.js && prettier -w lib/cmps/validation.ts",
     "watch": "npm run prepublish && chokidar \"lib\" \"addon\" \"rules/autoconsent\" \"rules/filterlist.txt\" --ignore 'lib/filterlist-engine.ts' -c \"npm run prepublish\"",
     "create-rule": "node rules/create-rule.mjs",
     "test": "playwright test",

--- a/scripts/validate-json-rules.js
+++ b/scripts/validate-json-rules.js
@@ -43,3 +43,16 @@ for (const ruleFile of ruleFiles) {
 }
 
 console.log('All rules look good!');
+
+// Write out allowed rule keys to lib/cmps/validation.ts
+fs.writeFileSync(
+    path.join(__dirname, '../lib/cmps/validation.ts'),
+    `/**
+ * This is a list of all allowed properties on rule step keys.
+ * We can use this to validate if a given step is supported by
+ * the current library version.
+ */
+export const PERMITTED_STEP_KEYS = ${JSON.stringify(Object.keys(schema.definitions.AutoConsentRuleStep.properties), undefined, 4)}
+`,
+);
+console.log('Written lib/cmps/validation.ts');

--- a/tests-wtr/lifecycle/find-cmp.ts
+++ b/tests-wtr/lifecycle/find-cmp.ts
@@ -125,4 +125,93 @@ describe('Autoconsent.findCmp', () => {
         expect(found).to.have.length(1);
         expect(found[0].name).to.equal('runContextRule');
     });
+
+    it('matches with a known eval rule', async () => {
+        autoconsent.addDeclarativeCMP({
+            name: 'Test page CMP',
+            prehideSelectors: ['#reject-all'],
+            detectCmp: [{ exists: '#privacy-test-page-cmp-test' }],
+            detectPopup: [{ visible: '#privacy-test-page-cmp-test' }],
+            optIn: [],
+            optOut: [{ waitFor: '#reject-all' }, { eval: 'EVAL_TESTCMP_STEP' }, { click: '#reject-all' }],
+            test: [{ eval: 'EVAL_TESTCMP_0' }],
+        });
+        const found = await autoconsent.findCmp(0);
+        expect(found).to.have.length(1);
+        expect(found[0].name).to.equal('Test page CMP');
+    });
+
+    it('Does not match if opt-out step contains unknown eval step', async () => {
+        autoconsent.addDeclarativeCMP({
+            name: 'Test page CMP',
+            prehideSelectors: ['#reject-all'],
+            detectCmp: [{ exists: '#privacy-test-page-cmp-test' }],
+            detectPopup: [{ visible: '#privacy-test-page-cmp-test' }],
+            optIn: [],
+            // @ts-expect-error Testing unknown eval value
+            optOut: [{ waitFor: '#reject-all' }, { eval: 'UNKNOWN_EVAL' }, { click: '#reject-all' }],
+            test: [{ eval: 'EVAL_TESTCMP_0' }],
+        });
+        const found = await autoconsent.findCmp(0);
+        expect(found).to.have.length(0);
+    });
+
+    it('Does not match if detectPopup step contains unknown eval step', async () => {
+        autoconsent.addDeclarativeCMP({
+            name: 'Test page CMP',
+            prehideSelectors: ['#reject-all'],
+            detectCmp: [{ exists: '#privacy-test-page-cmp-test' }],
+            // @ts-expect-error Testing unknown eval value
+            detectPopup: [{ visible: '#privacy-test-page-cmp-test' }, { eval: 'UNKNOWN_EVAL' }],
+            optIn: [],
+            optOut: [{ waitFor: '#reject-all' }, { click: '#reject-all' }],
+            test: [{ eval: 'EVAL_TESTCMP_0' }],
+        });
+        const found = await autoconsent.findCmp(0);
+        expect(found).to.have.length(0);
+    });
+
+    it('Does not match if optOut step contains unknown step property', async () => {
+        autoconsent.addDeclarativeCMP({
+            name: 'Test page CMP',
+            prehideSelectors: ['#reject-all'],
+            detectCmp: [{ exists: '#privacy-test-page-cmp-test' }],
+            detectPopup: [{ visible: '#privacy-test-page-cmp-test' }],
+            optIn: [],
+            // @ts-expect-error Testing unknown rulestep property
+            optOut: [{ waitFor: '#reject-all', newOption: true }, { click: '#reject-all' }],
+        });
+        const found = await autoconsent.findCmp(0);
+        expect(found).to.have.length(0);
+    });
+
+    it('Does not match if detectCmp step contains unknown eval step', async () => {
+        autoconsent.addDeclarativeCMP({
+            name: 'Test page CMP',
+            prehideSelectors: ['#reject-all'],
+            // @ts-expect-error Testing unknown eval value
+            detectCmp: [{ eval: 'UNKNOWN_EVAL' }],
+            detectPopup: [{ visible: '#privacy-test-page-cmp-test' }],
+            optIn: [],
+            optOut: [{ waitFor: '#reject-all' }, { click: '#reject-all' }],
+            test: [{ eval: 'EVAL_TESTCMP_0' }],
+        });
+        const found = await autoconsent.findCmp(0);
+        expect(found).to.have.length(0);
+    });
+
+    it('Does not match if detectCmp step contains unknown eval step', async () => {
+        autoconsent.addDeclarativeCMP({
+            name: 'Test page CMP',
+            prehideSelectors: ['#reject-all'],
+            // @ts-expect-error Testing unknown eval value
+            detectCmp: [{ newAction: 'test' }],
+            detectPopup: [{ visible: '#privacy-test-page-cmp-test' }],
+            optIn: [],
+            optOut: [{ waitFor: '#reject-all' }, { click: '#reject-all' }],
+            test: [{ eval: 'EVAL_TESTCMP_0' }],
+        });
+        const found = await autoconsent.findCmp(0);
+        expect(found).to.have.length(0);
+    });
 });


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1163321984198618/task/1209960043798128?focus=true

## Description:
When rules are provided dynamically, they could include unsupported actions or eval snippets. In this case, we want to silently ignore the rule, but we also don't want to have to validate all rules proactively.

To handle this, we can lazily run validation after `detectCmp` succeeds, checking that `detectPopup` and `optOut` are both runnable before we return from `detectCmp`.

This PR also builds the set of keys for validation dynamically at build time, from the TS definitions. This means that validation will update for any new actions added to `AutoConsentRuleStep`
