### PR TITLE
Add support for non-'reject-all' version of the termsfeed popup.

### DIFF
--- a/rules/autoconsent/termsfeed.json
+++ b/rules/autoconsent/termsfeed.json
@@ -20,7 +20,30 @@
     ],
     "optOut": [
         {
-            "waitForThenClick": ".cc-nb-reject"
+            "if": {
+                "exists": ".cc-nb-reject"
+            },
+            "then": [
+                {
+                    "waitForThenClick": ".cc-nb-reject"
+                }
+            ],
+            "else": [
+                {
+                    "waitForThenClick": ".cc-nb-changep"
+                },
+                {
+                    "waitFor": "input[cookie_consent_toggler=\"true\"]"
+                },
+                {
+                    "click": "input[cookie_consent_toggler=\"true\"]:checked",
+                    "all": true,
+                    "optional": true
+                },
+                {
+                    "click": ".cc-cp-foot-save"
+                }
+            ]
         }
     ]
 }

--- a/tests/termsfeed.spec.ts
+++ b/tests/termsfeed.spec.ts
@@ -1,3 +1,7 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('termsfeed', ['https://ftbwiki.org/Feed_The_Beast_Wiki', 'https://mediamanager.internetvideoarchive.com/']);
+generateCMPTests('termsfeed', [
+    'https://ftbwiki.org/Feed_The_Beast_Wiki',
+    'https://inspirationaladventures.com/',
+    'http://www.campingplatz-suche.com/',
+]);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1210331336303768?focus=true

## Description:

https://inspirationaladventures.com/ has a new variant of this popup without the expected reject-all button.