### PR TITLE
Add autoconsent rules for https://www.youporn.com/

### DIFF
--- a/rules/generated/auto_GB_youporn.com_0.json
+++ b/rules/generated/auto_GB_youporn.com_0.json
@@ -1,0 +1,28 @@
+{
+    "name": "auto_GB_youporn.com_0",
+    "vendorUrl": "https://www.youporn.com/",
+    "cosmetic": false,
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?youporn\\.com/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "body:not([id]) > div#cookie_consent_wrapper > div:not([id]) > div:nth-child(4):not([id]) > button:nth-child(2)#consent_accept_essential"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "body:not([id]) > div#cookie_consent_wrapper > div:not([id]) > div:nth-child(4):not([id]) > button:nth-child(2)#consent_accept_essential"
+        }
+    ],
+    "optIn": [],
+    "optOut": [
+        {
+            "waitForThenClick": "body:not([id]) > div#cookie_consent_wrapper > div:not([id]) > div:nth-child(4):not([id]) > button:nth-child(2)#consent_accept_essential",
+            "comment": "Accept only essential cookies"
+        }
+    ]
+}

--- a/tests/auto_GB_youporn.com_0.spec.ts
+++ b/tests/auto_GB_youporn.com_0.spec.ts
@@ -1,0 +1,2 @@
+import generateCMPTests from "../playwright/runner";
+generateCMPTests('auto_GB_youporn.com_0', ["https://www.youporn.com/"], {testOptIn: false, testSelfTest: false, onlyRegions: ["GB"]});


### PR DESCRIPTION

                        <details>
                        <summary>Multiple popups or reject buttons found</summary>
                        <br>
                        <pre>
                        {
  "note": "Multiple popups or reject buttons found",
  "url": "https://www.youporn.com/",
  "region": "GB"
}
                        </pre>
                        </details>
                    

                        <details>
                        <summary>Overriding existing rule</summary>
                        <br>
                        <pre>
                        {
  "note": "Overriding existing rule",
  "ruleName": "auto_GB_youporn.com_0",
  "region": "GB"
}
                        </pre>
                        </details>
                    