### PR TITLE
Remove 'hide' step from eu-cookie-compliance-banner

### DIFF
--- a/rules/autoconsent/eu-cookie-compliance.json
+++ b/rules/autoconsent/eu-cookie-compliance.json
@@ -2,19 +2,20 @@
     "name": "eu-cookie-compliance-banner",
     "detectCmp": [{ "exists": "body.eu-cookie-compliance-popup-open" }],
     "detectPopup": [{ "exists": "body.eu-cookie-compliance-popup-open" }],
-    "optIn": [{ "click": ".agree-button" }],
+    "optIn": [
+        {
+            "click": ".eu-cookie-compliance-banner .agree-button, .eu-cookie-compliance-banner .accept-all"
+        }
+    ],
     "optOut": [
         {
-            "if": {
-                "visible": ".decline-button,.eu-cookie-compliance-save-preferences-button"
-            },
-            "then": [
-                {
-                    "click": ".decline-button,.eu-cookie-compliance-save-preferences-button"
-                }
-            ]
-        },
-        { "hide": ".eu-cookie-compliance-banner-info, #sliding-popup" }
+            "click": ".eu-cookie-compliance-banner .decline-button, .eu-cookie-compliance-banner .accept-necessary, .eu-cookie-compliance-save-preferences-button"
+        }
     ],
-    "test": [{ "cookieContains": "cookie-agreed=2", "negated": true }]
+    "test": [
+        {
+            "cookieContains": "cookie-agreed=2",
+            "negated": true
+        }
+    ]
 }

--- a/tests/eu-cookie-compliance-banner.spec.ts
+++ b/tests/eu-cookie-compliance-banner.spec.ts
@@ -1,3 +1,3 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('eu-cookie-compliance-banner', ['https://www.theposh.com/table/226', 'https://publichealth.jhu.edu/']);
+generateCMPTests('eu-cookie-compliance-banner', ['https://publichealth.jhu.edu/', 'https://bibliotheek.be/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209121419454298/task/1210479928917562?focus=true

## Description:
This CMP is very frequently customised by the website. The `’hide’` step in this rule is causing a lot of breakage. Let’s scale back the rule so that we only click on a reject button if it exists.

## Steps to test this PR:
```
npm run test -- tests/eu-cookie-compliance-banner.spec.ts
```