### PR TITLE
Update cookie-law-info rule to hide .cli-popup-overlay

### DIFF
--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -79,7 +79,12 @@ export const snippets = {
     EVAL_COINBASE_0: () =>
         JSON.parse(decodeURIComponent(document.cookie.match(/cm_(eu|default)_preferences=([0-9a-zA-Z\\{\\}\\[\\]%:]*);?/)[2])).consent
             .length <= 1,
-    EVAL_COOKIE_LAW_INFO_0: () => CLI.disableAllCookies() || CLI.reject_close() || true,
+    EVAL_COOKIE_LAW_INFO_0: () => {
+        if (CLI.disableAllCookies) CLI.disableAllCookies();
+        if (CLI.reject_close) CLI.reject_close();
+        document.body.classList.remove('cli-barmodal-open');
+        return true;
+    },
     EVAL_COOKIE_LAW_INFO_DETECT: () => !!window.CLI,
     EVAL_COOKIE_MANAGER_POPUP_0: () =>
         JSON.parse(

--- a/rules/autoconsent/cookie-law-info.json
+++ b/rules/autoconsent/cookie-law-info.json
@@ -1,14 +1,25 @@
 {
     "name": "cookie-law-info",
-    "prehideSelectors": ["#cookie-law-info-bar, #cookie-law-bg"],
+    "prehideSelectors": ["#cookie-law-info-bar, #cookie-law-bg, .cli-popupbar-overlay"],
     "detectCmp": [{ "exists": "#cookie-law-info-bar" }, { "eval": "EVAL_COOKIE_LAW_INFO_DETECT" }],
-    "detectPopup": [{ "visible": "#cookie-law-info-bar, #cookie-law-bg", "check": "any" }],
-    "optIn": [{ "click": "[data-cli_action=\"accept\"]" }],
+    "detectPopup": [{ "visible": "#cookie-law-info-bar" }],
+    "optIn": [
+        {
+            "click": "[data-cli_action=\"accept\"]"
+        }
+    ],
     "optOut": [
-        { "hide": "#cookie-law-info-bar, #cookie-law-bg" },
+        {
+            "hide": "#cookie-law-info-bar, #cookie-law-bg, .cli-popupbar-overlay"
+        },
         {
             "eval": "EVAL_COOKIE_LAW_INFO_0"
         }
     ],
-    "test": [{ "cookieContains": "cookielawinfo-checkbox-non-necessary=yes", "negated": true }]
+    "test": [
+        {
+            "cookieContains": "cookielawinfo-checkbox-non-necessary=yes",
+            "negated": true
+        }
+    ]
 }

--- a/tests/cookie-law-info.spec.ts
+++ b/tests/cookie-law-info.spec.ts
@@ -4,4 +4,7 @@ generateCMPTests('cookie-law-info', ['https://www.omas-gegen-rechts.org/', 'http
     skipRegions: ['US', 'GB'],
 });
 
-generateCMPTests('cookie-law-info', ['https://www.sbid.org/']);
+generateCMPTests('cookie-law-info', [
+    'https://www.sbid.org/',
+    'https://diroots.com/revit-plugins/renumber-revit-elements-using-a-prefix-a-suffix-and-a-multiplier-with-reordering/',
+]);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209121419454298/task/1210458695605807?focus=true

## Description:
Lots of websites hide the `id` from the overlay which causes breakage. Fix is to target `.cli-popupbar-overlay` as well. I've also including a fix for scrolling by removing `cli-barmodal-open` from `body`.

## Steps to test this PR:
```
npm run test -- tests/cookie-law-info.spec.ts
```

And test on:

- https://diroots.com/revit-plugins/renumber-revit-elements-using-a-prefix-a-suffix-and-a-multiplier-with-reordering/
- https://www.boerse-aktuell.de/
- https://newsforkids.net/