### PR TITLE
Handle fides alternative without a top-level reject all button.

### DIFF
--- a/rules/autoconsent/fides.json
+++ b/rules/autoconsent/fides.json
@@ -22,7 +22,25 @@
     ],
     "optOut": [
         {
-            "waitForThenClick": "#fides-banner .fides-reject-all-button"
+            "waitFor": ".fides-banner-button"
+        },
+        {
+            "if": {
+                "visible": "#fides-banner .fides-reject-all-button"
+            },
+            "then": [
+                {
+                    "click": "#fides-banner .fides-reject-all-button"
+                }
+            ],
+            "else": [
+                {
+                    "click": "#fides-banner .fides-manage-preferences-button"
+                },
+                {
+                    "waitForThenClick": ".fides-reject-all-button"
+                }
+            ]
         }
     ]
 }

--- a/tests/fides.spec.ts
+++ b/tests/fides.spec.ts
@@ -1,3 +1,3 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('fides', ['https://www.nytimes.com/', 'https://nextjs.org/', 'https://wetransfer.com/']);
+generateCMPTests('fides', ['https://www.nytimes.com/', 'https://nextjs.org/', 'https://wetransfer.com/', 'https://arstechnica.com/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206670747178362/task/1210760057814026?focus=true

## Description:
On arstechnica.com (and some other sites), there is a popup from 'fides'. Previously, all versions of this popup had a top-level 'reject all' button. However, now there seems to be some sites using a version that requires a click through to settings first.

This PR updates the rule to handle this variant.

## Steps to test this PR:
 1. Popup is handled correctly on arstechnica.com
