### PR TITLE
expand existing bbc rule to another dubdomains

### DIFF
--- a/rules/generated/auto_GB_genome.ch.bbc.co.uk_0.json
+++ b/rules/generated/auto_GB_genome.ch.bbc.co.uk_0.json
@@ -5,7 +5,7 @@
     "runContext": {
         "main": true,
         "frame": false,
-        "urlPattern": "^https?://(www\\.)?genome\\.ch\\.bbc\\.co\\.uk/"
+        "urlPattern": "^https?://([.a-zA-Z0-9-]+\\.)?bbc\\.co\\.uk/"
     },
     "prehideSelectors": [],
     "detectCmp": [

--- a/tests/generated/auto_GB_genome.ch.bbc.co.uk_0.spec.ts
+++ b/tests/generated/auto_GB_genome.ch.bbc.co.uk_0.spec.ts
@@ -1,5 +1,5 @@
 import generateCMPTests from '../../playwright/runner';
-generateCMPTests('auto_GB_genome.ch.bbc.co.uk_0', ['https://genome.ch.bbc.co.uk/'], {
+generateCMPTests('auto_GB_genome.ch.bbc.co.uk_0', ['https://genome.ch.bbc.co.uk/', 'https://www.bbc.co.uk/iplayer'], {
     testOptIn: false,
     testSelfTest: false,
     onlyRegions: ['GB'],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1210733903879680?focus=true

## Description:
Expands existing generated rule to cover other BBC subdomains

## Steps to test this PR:
Test on https://www.bbc.co.uk/iplayer
