### PR TITLE
Add autoconsent rules for 1 sites

### DIFF
--- a/rules/generated/auto_AU_lemonde.fr_jgt.json
+++ b/rules/generated/auto_AU_lemonde.fr_jgt.json
@@ -1,0 +1,38 @@
+{
+    "name": "auto_AU_lemonde.fr_jgt",
+    "vendorUrl": "https://www.lemonde.fr/en/opinion/article/2024/03/21/will-china-really-become-the-world-s-leading-economic-power_6640185_23.html",
+    "cosmetic": false,
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?lemonde\\.fr/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "body#js-body > div:not([id]) > div:not([id]) > a:nth-child(1):not([id])"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "body#js-body > div:not([id]) > div:not([id]) > a:nth-child(1):not([id])"
+        }
+    ],
+    "optIn": [],
+    "optOut": [
+        {
+            "wait": 500
+        },
+        {
+            "waitForThenClick": "body#js-body > div:not([id]) > div:not([id]) > a:nth-child(1):not([id])",
+            "comment": "Reject all cookies"
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "body#js-body > div:not([id]) > div:not([id]) > a:nth-child(1):not([id])",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/tests/generated/auto_AU_lemonde.fr_jgt.spec.ts
+++ b/tests/generated/auto_AU_lemonde.fr_jgt.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../../playwright/runner';
+generateCMPTests(
+    'auto_AU_lemonde.fr_jgt',
+    ['https://www.lemonde.fr/en/opinion/article/2024/03/21/will-china-really-become-the-world-s-leading-economic-power_6640185_23.html'],
+    { testOptIn: false, testSelfTest: false, onlyRegions: ['AU'] },
+);


### PR DESCRIPTION
This PR includes autoconsent rules for the following sites:

### New rules (1)
<details>
<summary>Show</summary>
<details open>
<summary>https://www.lemonde.fr/en/opinion/article/2024/03/21/will-china-really-become-the-world-s-leading-economic-power_6640185_23.html</summary>
<br>
<pre>[
  {
    "note": "New rule added",
    "ruleName": "auto_AU_lemonde.fr_jgt"
  }
]</pre>
</details>
</details>
