### PR TITLE
Cookie Information Banner: only hide if banner is actually left open

### DIFF
--- a/rules/autoconsent/cookieinformation.json
+++ b/rules/autoconsent/cookieinformation.json
@@ -1,12 +1,42 @@
 {
     "name": "Cookie Information Banner",
     "prehideSelectors": ["#cookie-information-template-wrapper"],
-    "detectCmp": [{ "exists": "#cookie-information-template-wrapper" }],
-    "detectPopup": [{ "visible": "#cookie-information-template-wrapper" }],
-    "optIn": [{ "eval": "EVAL_COOKIEINFORMATION_1" }],
-    "optOut": [
-        { "hide": "#cookie-information-template-wrapper", "comment": "some templates don't hide the banner automatically" },
-        { "eval": "EVAL_COOKIEINFORMATION_0" }
+    "detectCmp": [
+        {
+            "exists": "#cookie-information-template-wrapper"
+        }
     ],
-    "test": [{ "cookieContains": "CookieInformationConsent=" }]
+    "detectPopup": [
+        {
+            "visible": "#cookie-information-template-wrapper"
+        }
+    ],
+    "optIn": [
+        {
+            "eval": "EVAL_COOKIEINFORMATION_1"
+        }
+    ],
+    "optOut": [
+        {
+            "eval": "EVAL_COOKIEINFORMATION_0"
+        },
+        {
+            "wait": 1000
+        },
+        {
+            "if": {
+                "visible": "#CcpaWrapper"
+            },
+            "then": [
+                {
+                    "hide": "#cookie-information-template-wrapper"
+                }
+            ]
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "CookieInformationConsent="
+        }
+    ]
 }


### PR DESCRIPTION
Task/Issue URL:

## Description:
On https://www.dm-jobs.com/Germany/content/klingt-nach-dir/?locale=de_DE, to open the embedded video, the page asks the user to allow cookies, which triggers the CMP to re-open. However, because our rule hides that element, this doesn't work.

This PR updates the rule so the hide is only applied on sites where it is actually needed (e.g. https://www.yourhearing.com/).
