### PR TITLE
Fix on1.com rule

### DIFF
--- a/rules/generated/auto_GB_on1.com_0.json
+++ b/rules/generated/auto_GB_on1.com_0.json
@@ -10,18 +10,18 @@
     "prehideSelectors": [],
     "detectCmp": [
         {
-            "exists": "body:not([id]) > div#on1-cookie-banner > div:not([id]) > div:not([id]) > div:nth-child(1):not([id]) > p:not([id]) > a:nth-child(3):not([id])"
+            "exists": "#on1-cookie-banner"
         }
     ],
     "detectPopup": [
         {
-            "visible": "body:not([id]) > div#on1-cookie-banner > div:not([id]) > div:not([id]) > div:nth-child(1):not([id]) > p:not([id]) > a:nth-child(3):not([id])"
+            "visible": "#on1-cookie-banner"
         }
     ],
     "optIn": [],
     "optOut": [
         {
-            "waitForThenClick": "body:not([id]) > div#on1-cookie-banner > div:not([id]) > div:not([id]) > div:nth-child(1):not([id]) > p:not([id]) > a:nth-child(3):not([id])",
+            "waitForThenClick": "#on1-cookie-banner a[onclick=\"declineCookieBanner();\"]",
             "comment": "Decline"
         }
     ]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1210938432408214?focus=true

## Description:
The original rule clicked the 'privacy-policy' button, causing an infinite loop. I've updated the selectors to unabiguously target the decline button.

## Steps to test this PR:

