### PR TITLE
Add a flag to mark generated rules requiring review

### DIFF
--- a/lib/rules.ts
+++ b/lib/rules.ts
@@ -18,6 +18,7 @@ export type AutoConsentCMPRule = {
     readonly test?: AutoConsentRuleStep[];
     readonly comment?: string;
     readonly minimumRuleStepVersion?: number;
+    readonly reviewUpdates?: boolean;
 };
 
 export type RunContext = {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201844467387842/task/1210936834089610?focus=true

## Description:
Adds an optional `reviewUpdates` flag to the rule format. When true, any automatic updates to the rule will require manual review.
Intended use-case:
- set it to true on auto-generated rules that have been manually edited. Requiring review will flag any attempts of the generation script to override the edits.

## Steps to test this PR:
Use it in combination with https://dub.duckduckgo.com/duckduckgo/tracker-radar-internal/pull/578
