### PR TITLE
[test] Add autoconsent rules for 2 sites (0 requiring review)

### DIFF
--- a/rules/generated/auto_CA_epihunter.eu_hd4.json
+++ b/rules/generated/auto_CA_epihunter.eu_hd4.json
@@ -1,0 +1,38 @@
+{
+    "name": "auto_CA_epihunter.eu_hd4",
+    "vendorUrl": "http://epihunter.eu/",
+    "cosmetic": false,
+    "runContext": {
+        "main": false,
+        "frame": true,
+        "urlPattern": "^https?://(www\\.)?combell\\.com/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "body > div#iubenda-cs-banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(5):not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "body > div#iubenda-cs-banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(5):not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])"
+        }
+    ],
+    "optIn": [],
+    "optOut": [
+        {
+            "wait": 500
+        },
+        {
+            "waitForThenClick": "body > div#iubenda-cs-banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(5):not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])",
+            "comment": "Reject"
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "body > div#iubenda-cs-banner > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(5):not([id]) > div:nth-child(2):not([id]) > button:nth-child(1):not([id])",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/rules/generated/auto_CH_gabrielweinberg.com_56i.json
+++ b/rules/generated/auto_CH_gabrielweinberg.com_56i.json
@@ -1,0 +1,38 @@
+{
+    "name": "auto_CH_gabrielweinberg.com_56i",
+    "vendorUrl": "https://gabrielweinberg.com/p/9-ways-duckduckgo-differs-from-google-ai-overviews",
+    "cosmetic": false,
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?gabrielweinberg\\.com/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "body > div#entry > div:nth-child(2)#main > div:nth-child(4):not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "body > div#entry > div:nth-child(2)#main > div:nth-child(4):not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])"
+        }
+    ],
+    "optIn": [],
+    "optOut": [
+        {
+            "wait": 500
+        },
+        {
+            "waitForThenClick": "body > div#entry > div:nth-child(2)#main > div:nth-child(4):not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])",
+            "comment": "Only Necessary"
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "body > div#entry > div:nth-child(2)#main > div:nth-child(4):not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(2):not([id])",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/tests/generated/auto_CA_epihunter.eu_hd4.spec.ts
+++ b/tests/generated/auto_CA_epihunter.eu_hd4.spec.ts
@@ -1,0 +1,2 @@
+import generateCMPTests from '../../playwright/runner';
+generateCMPTests('auto_CA_epihunter.eu_hd4', ['http://epihunter.eu/'], { testOptIn: false, testSelfTest: true, onlyRegions: ['CA'] });

--- a/tests/generated/auto_CH_gabrielweinberg.com_56i.spec.ts
+++ b/tests/generated/auto_CH_gabrielweinberg.com_56i.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../../playwright/runner';
+generateCMPTests('auto_CH_gabrielweinberg.com_56i', ['https://gabrielweinberg.com/p/9-ways-duckduckgo-differs-from-google-ai-overviews'], {
+    testOptIn: false,
+    testSelfTest: true,
+    onlyRegions: ['CH'],
+});


### PR DESCRIPTION
This PR includes autoconsent rules for the following sites:

### New rules (2)
<details>
<summary>Show</summary>
- `http://epihunter.eu/`
  - New rule added
    - `ruleName`: `"auto_CA_epihunter.eu_hd4"`

- `https://gabrielweinberg.com/p/9-ways-duckduckgo-differs-from-google-ai-overviews`
  - New rule added
    - `ruleName`: `"auto_CH_gabrielweinberg.com_56i"`

</details>
