### PR TITLE
[test] Add autoconsent rules for 1 sites (0 requiring review)

### DIFF
--- a/rules/generated/auto_AU_beanwealth.com_avt.json
+++ b/rules/generated/auto_AU_beanwealth.com_avt.json
@@ -1,0 +1,38 @@
+{
+    "name": "auto_AU_beanwealth.com_avt",
+    "vendorUrl": "https://beanwealth.com/p/warren-buffett-s-favorite-investment-metric",
+    "cosmetic": false,
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?beanwealth\\.com/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "body > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:nth-child(2):not([id]) > button:nth-child(3):not([id])"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "body > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:nth-child(2):not([id]) > button:nth-child(3):not([id])"
+        }
+    ],
+    "optIn": [],
+    "optOut": [
+        {
+            "wait": 500
+        },
+        {
+            "waitForThenClick": "body > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:nth-child(2):not([id]) > button:nth-child(3):not([id])",
+            "comment": "Decline"
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "body > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:nth-child(2):not([id]) > button:nth-child(3):not([id])",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/tests/generated/auto_AU_beanwealth.com_avt.spec.ts
+++ b/tests/generated/auto_AU_beanwealth.com_avt.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../../playwright/runner';
+generateCMPTests('auto_AU_beanwealth.com_avt', ['https://beanwealth.com/p/warren-buffett-s-favorite-investment-metric'], {
+    testOptIn: false,
+    testSelfTest: true,
+    onlyRegions: ['AU'],
+});


### PR DESCRIPTION
This PR includes autoconsent rules for the following sites:


### New rules (1)
<details>
<summary>Show</summary>

- https://beanwealth.com/p/warren-buffett-s-favorite-investment-metric
  - New rule added
    - `ruleName`: `"auto_AU_beanwealth.com_avt"`

</details>
