### PR TITLE
🤖 Add autoconsent rules for 1 sites (0 requiring review)

### DIFF
--- a/rules/generated/auto_AU_lemonde.fr_jgt.json
+++ b/rules/generated/auto_AU_lemonde.fr_jgt.json
@@ -10,12 +10,12 @@
     "prehideSelectors": [],
     "detectCmp": [
         {
-            "exists": "body#js-body > div:not([id]) > div:not([id]) > a:nth-child(1):not([id])"
+            "exists": "body > div:not([id]) > div:not([id]) > a:nth-child(1):not([id])"
         }
     ],
     "detectPopup": [
         {
-            "visible": "body#js-body > div:not([id]) > div:not([id]) > a:nth-child(1):not([id])"
+            "visible": "body > div:not([id]) > div:not([id]) > a:nth-child(1):not([id])"
         }
     ],
     "optIn": [],
@@ -24,13 +24,13 @@
             "wait": 500
         },
         {
-            "waitForThenClick": "body#js-body > div:not([id]) > div:not([id]) > a:nth-child(1):not([id])",
+            "waitForThenClick": "body > div:not([id]) > div:not([id]) > a:nth-child(1):not([id])",
             "comment": "Reject all cookies"
         }
     ],
     "test": [
         {
-            "waitForVisible": "body#js-body > div:not([id]) > div:not([id]) > a:nth-child(1):not([id])",
+            "waitForVisible": "body > div:not([id]) > div:not([id]) > a:nth-child(1):not([id])",
             "timeout": 1000,
             "check": "none"
         }

--- a/tests/generated/auto_AU_lemonde.fr_jgt.spec.ts
+++ b/tests/generated/auto_AU_lemonde.fr_jgt.spec.ts
@@ -2,5 +2,5 @@ import generateCMPTests from '../../playwright/runner';
 generateCMPTests(
     'auto_AU_lemonde.fr_jgt',
     ['https://www.lemonde.fr/en/opinion/article/2024/03/21/will-china-really-become-the-world-s-leading-economic-power_6640185_23.html'],
-    { testOptIn: false, testSelfTest: false, onlyRegions: ['AU'] },
+    { testOptIn: false, testSelfTest: true, onlyRegions: ['AU'] },
 );


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1209069125090669?focus=true

This PR includes autoconsent rules for the following sites:


### Updated rules (1)
<details>
<summary>Show</summary>

- https://www.lemonde.fr/en/opinion/article/2024/03/21/will-china-really-become-the-world-s-leading-economic-power_6640185_23.html
  - Overriding existing rule
    - `ruleName`: `"auto_AU_lemonde.fr_jgt"`
    - `existingRules`: `["auto_AU_lemonde.fr_jgt"]`
    - `region`: `"AU"`

</details>
