### PR TITLE
🤖 Add autoconsent rules for 1 sites (0 requiring review)

### DIFF
--- a/rules/generated/auto_AU_revolut.com_vea.json
+++ b/rules/generated/auto_AU_revolut.com_vea.json
@@ -1,0 +1,38 @@
+{
+    "name": "auto_AU_revolut.com_vea",
+    "vendorUrl": "https://www.revolut.com/en-FI/discover-our-company/",
+    "cosmetic": false,
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?revolut\\.com/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "body > div:not([id]) > div:not([id]) > div:not([id]) > button:nth-child(5):not([id])"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "body > div:not([id]) > div:not([id]) > div:not([id]) > button:nth-child(5):not([id])"
+        }
+    ],
+    "optIn": [],
+    "optOut": [
+        {
+            "wait": 500
+        },
+        {
+            "waitForThenClick": "body > div:not([id]) > div:not([id]) > div:not([id]) > button:nth-child(5):not([id])",
+            "comment": "Reject non-essential cookies"
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "body > div:not([id]) > div:not([id]) > div:not([id]) > button:nth-child(5):not([id])",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/tests/generated/auto_AU_revolut.com_vea.spec.ts
+++ b/tests/generated/auto_AU_revolut.com_vea.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../../playwright/runner';
+generateCMPTests('auto_AU_revolut.com_vea', ['https://www.revolut.com/en-FI/discover-our-company/'], {
+    testOptIn: false,
+    testSelfTest: true,
+    onlyRegions: ['AU'],
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1208516470053140?focus=true

This PR includes autoconsent rules for the following sites:


### New rules (1)
<details>
<summary>Show</summary>

- https://www.revolut.com/en-FI/discover-our-company/
  - New region-specific popup
    - `ruleName`: `"auto_AU_revolut.com_vea"`
    - `existingRules`: `["auto_GB_revolut.com_0"]`
    - `region`: `"AU"`

</details>
