### PR TITLE
Ensure release npm version bump doesn't clear other deps

### DIFF
--- a/.github/workflows/ddg-release.yml
+++ b/.github/workflows/ddg-release.yml
@@ -182,12 +182,14 @@ jobs:
             - name: Update iOS autoconsent reference
               run: |
                   cd apple-monorepo/iOS
+                  npm ci --include-workspace-root
                   npm install @duckduckgo/autoconsent@${{ env.TAG }}
                   npm run rebuild-autoconsent
                   cd ..
             - name: Update macOS autoconsent reference
               run: |
                   cd apple-monorepo/macOS
+                  npm ci --include-workspace-root
                   npm install @duckduckgo/autoconsent@${{ env.TAG }}
                   npm run rebuild-autoconsent
                   cd ..


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201844467387842/task/1211044706370759?focus=true

## Description:
There are now other npm dependencies in the apple repo, so we should install those before updating the autoconsent repo when preparing a release PR.