### PR TITLE
🤖 Add autoconsent rules for 1 sites (0 requiring review)

### DIFF
--- a/rules/generated/auto_CA_worldelectricsupply.com_f0d.json
+++ b/rules/generated/auto_CA_worldelectricsupply.com_f0d.json
@@ -1,0 +1,38 @@
+{
+    "name": "auto_CA_worldelectricsupply.com_f0d",
+    "vendorUrl": "https://www.worldelectricsupply.com/product/detail/74131/hubbell-wiring-device-ss8",
+    "cosmetic": false,
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?worldelectricsupply\\.com/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "body > div#cookie-consent-container > div#cookie-consent-banner > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(3)#btn-reject-all"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "body > div#cookie-consent-container > div#cookie-consent-banner > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(3)#btn-reject-all"
+        }
+    ],
+    "optIn": [],
+    "optOut": [
+        {
+            "wait": 500
+        },
+        {
+            "waitForThenClick": "body > div#cookie-consent-container > div#cookie-consent-banner > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(3)#btn-reject-all",
+            "comment": "Reject All"
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "body > div#cookie-consent-container > div#cookie-consent-banner > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(3)#btn-reject-all",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/tests/generated/auto_CA_worldelectricsupply.com_f0d.spec.ts
+++ b/tests/generated/auto_CA_worldelectricsupply.com_f0d.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../../playwright/runner';
+generateCMPTests(
+    'auto_CA_worldelectricsupply.com_f0d',
+    ['https://www.worldelectricsupply.com/product/detail/74131/hubbell-wiring-device-ss8'],
+    { testOptIn: false, testSelfTest: true, onlyRegions: ['CA'] },
+);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1211074121720258?focus=true

This PR includes autoconsent rules for the following sites:


### New rules (1)
<details>
<summary>Show</summary>

- https://www.worldelectricsupply.com/product/detail/74131/hubbell-wiring-device-ss8
  - New rule added
    - `ruleName`: `"auto_CA_worldelectricsupply.com_f0d"`

</details>
