### PR TITLE
Handle some alternative variants of the tarteaucitron popup

### DIFF
--- a/rules/autoconsent/tarteaucitron-deny.json
+++ b/rules/autoconsent/tarteaucitron-deny.json
@@ -1,0 +1,17 @@
+{
+    "name": "tarteaucitron deny",
+    "prehideSelectors": ["#tarteaucitronRoot"],
+    "detectCmp": [{ "exists": "#tarteaucitronRoot" }],
+    "detectPopup": [
+        {
+            "visible": "#tarteaucitronAllDenied2"
+        }
+    ],
+    "optIn": [{ "click": "#tarteaucitronPersonalize2" }],
+    "optOut": [{ "click": "#tarteaucitronAllDenied2" }],
+    "test": [
+        {
+            "eval": "EVAL_TARTEAUCITRON_2"
+        }
+    ]
+}

--- a/rules/autoconsent/tarteaucitron.json
+++ b/rules/autoconsent/tarteaucitron.json
@@ -4,16 +4,31 @@
     "detectCmp": [{ "exists": "#tarteaucitronRoot" }],
     "detectPopup": [
         {
-            "visible": "#tarteaucitronRoot #tarteaucitronAlertBig",
-            "check": "any"
+            "visible": "#tarteaucitronCloseAlert"
+        },
+        {
+            "exists": "#tarteaucitronAllDenied2",
+            "negated": true
         }
     ],
-    "optIn": [{ "eval": "EVAL_TARTEAUCITRON_1" }],
-    "optOut": [{ "eval": "EVAL_TARTEAUCITRON_0" }],
+    "optIn": [{ "click": "#tarteaucitronPersonalize" }],
+    "optOut": [
+        {
+            "if": { "exists": ".dsgvoaio-checkbox" },
+            "then": [
+                { "click": ".dsgvoaio-checkbox > input:checked", "all": true, "optional": true },
+                { "click": "#tarteaucitronCloseAlert" }
+            ],
+            "else": [
+                { "click": "#tarteaucitronPersonalize" },
+                { "waitForThenClick": "#tarteaucitronAllDenied" },
+                { "click": "#tarteaucitronClosePanel" }
+            ]
+        }
+    ],
     "test": [
         {
-            "eval": "EVAL_TARTEAUCITRON_2",
-            "comment": "sometimes there are required categories, so we check that at least something is false"
+            "eval": "EVAL_TARTEAUCITRON_2"
         }
     ]
 }

--- a/tests/tarteaucitron-deny.spec.ts
+++ b/tests/tarteaucitron-deny.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('tarteaucitron deny', ['https://www.powellflutes.com/en/', 'https://www.planetside2.com/home'], {});

--- a/tests/tarteaucitron.spec.ts
+++ b/tests/tarteaucitron.spec.ts
@@ -1,12 +1,3 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests(
-    'tarteaucitron.js',
-    [
-        'https://planetside2.com',
-        'https://marseille.intercontinental.com/',
-        'https://www.powellflutes.com/en/',
-        'https://www.neweuropetours.eu/',
-    ],
-    {},
-);
+generateCMPTests('tarteaucitron.js', ['https://www.meingehalt.net/', 'https://www.sg-akustik.de/'], {});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206670747178362/task/1211072398409324?focus=true

## Description:
Handles different variants of the tarteaucitron popup:
- With direct reject-all button, e.g. https://www.planetside2.com/home
- With only 'accept selected' with top-level checkboxes: https://www.sg-akustik.de/
- With only 'personalize', and a sub-menu to deny: https://www.meingehalt.net/

## Steps to test this PR:

