### PR TITLE
🤖 Add autoconsent rules for 1 sites (0 need review)

### DIFF
--- a/rules/generated/auto_AU_eandt.theiet.org_6zf.json
+++ b/rules/generated/auto_AU_eandt.theiet.org_6zf.json
@@ -1,0 +1,40 @@
+{
+    "name": "auto_AU_eandt.theiet.org_6zf",
+    "cosmetic": false,
+    "_metadata": {
+        "vendorUrl": "https://eandt.theiet.org/noindex/rscc/verification-failed?destination=/2022/11/21/rights-campaigner-sues-meta-over-advertising-practices"
+    },
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?eandt\\.theiet\\.org/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "body > div:not([id]) > div#page-wrapper > footer:nth-child(6):not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:nth-child(2)#block-cookiesui > div:not([id]) > div#cookiesjsr > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "body > div:not([id]) > div#page-wrapper > footer:nth-child(6):not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:nth-child(2)#block-cookiesui > div:not([id]) > div#cookiesjsr > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])"
+        }
+    ],
+    "optIn": [],
+    "optOut": [
+        {
+            "wait": 500
+        },
+        {
+            "waitForThenClick": "body > div:not([id]) > div#page-wrapper > footer:nth-child(6):not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:nth-child(2)#block-cookiesui > div:not([id]) > div#cookiesjsr > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
+            "comment": "REJECT ALL"
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "body > div:not([id]) > div#page-wrapper > footer:nth-child(6):not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:nth-child(2)#block-cookiesui > div:not([id]) > div#cookiesjsr > div:not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/tests/generated/auto_AU_eandt.theiet.org_6zf.spec.ts
+++ b/tests/generated/auto_AU_eandt.theiet.org_6zf.spec.ts
@@ -1,0 +1,8 @@
+import generateCMPTests from '../../playwright/runner';
+generateCMPTests(
+    'auto_AU_eandt.theiet.org_6zf',
+    [
+        'https://eandt.theiet.org/noindex/rscc/verification-failed?destination=/2022/11/21/rights-campaigner-sues-meta-over-advertising-practices',
+    ],
+    { testOptIn: false, testSelfTest: true, onlyRegions: ['AU'] },
+);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1211186845367306?focus=true

This PR includes autoconsent rules for the following sites:


### New rules (1)
<details>
<summary>Show</summary>

- https://eandt.theiet.org/noindex/rscc/verification-failed?destination=/2022/11/21/rights-campaigner-sues-meta-over-advertising-practices
  - Multiple popups or reject buttons found
    - `url`: `"https://eandt.theiet.org/noindex/rscc/verification-failed?destination=/2022/11/21/rights-campaigner-sues-meta-over-advertising-practices"`
    - `region`: `"AU"`

  - New rule added
    - `ruleName`: `"auto_AU_eandt.theiet.org_6zf"`

</details>
