### PR TITLE
🤖 Add autoconsent rules for 1 sites (0 need review)

### DIFF
--- a/rules/generated/auto_GB_moneysupermarket.com_0.json
+++ b/rules/generated/auto_GB_moneysupermarket.com_0.json
@@ -9,12 +9,12 @@
     "prehideSelectors": [],
     "detectCmp": [
         {
-            "exists": "body > div:not([id]) > dialog:nth-child(2):not([id]) > div:nth-child(4):not([id]) > button:nth-child(2)#banner-reject > span:nth-child(1):not([id])"
+            "exists": "body > div:not([id]) > div:nth-child(2):not([id]) > dialog:not([id]) > div:nth-child(4):not([id]) > button:nth-child(2)#banner-reject > span:nth-child(1):not([id])"
         }
     ],
     "detectPopup": [
         {
-            "visible": "body > div:not([id]) > dialog:nth-child(2):not([id]) > div:nth-child(4):not([id]) > button:nth-child(2)#banner-reject > span:nth-child(1):not([id])"
+            "visible": "body > div:not([id]) > div:nth-child(2):not([id]) > dialog:not([id]) > div:nth-child(4):not([id]) > button:nth-child(2)#banner-reject > span:nth-child(1):not([id])"
         }
     ],
     "optIn": [],
@@ -23,13 +23,13 @@
             "wait": 500
         },
         {
-            "waitForThenClick": "body > div:not([id]) > dialog:nth-child(2):not([id]) > div:nth-child(4):not([id]) > button:nth-child(2)#banner-reject > span:nth-child(1):not([id])",
+            "waitForThenClick": "body > div:not([id]) > div:nth-child(2):not([id]) > dialog:not([id]) > div:nth-child(4):not([id]) > button:nth-child(2)#banner-reject > span:nth-child(1):not([id])",
             "comment": "Reject all"
         }
     ],
     "test": [
         {
-            "waitForVisible": "body > div:not([id]) > dialog:nth-child(2):not([id]) > div:nth-child(4):not([id]) > button:nth-child(2)#banner-reject > span:nth-child(1):not([id])",
+            "waitForVisible": "body > div:not([id]) > div:nth-child(2):not([id]) > dialog:not([id]) > div:nth-child(4):not([id]) > button:nth-child(2)#banner-reject > span:nth-child(1):not([id])",
             "timeout": 1000,
             "check": "none"
         }

--- a/tests/generated/auto_GB_moneysupermarket.com_0.spec.ts
+++ b/tests/generated/auto_GB_moneysupermarket.com_0.spec.ts
@@ -1,5 +1,5 @@
 import generateCMPTests from '../../playwright/runner';
-generateCMPTests('auto_GB_moneysupermarket.com_0', ['https://www.moneysupermarket.com/'], {
+generateCMPTests('auto_GB_moneysupermarket.com_0', ['https://www.moneysupermarket.com/?feature=headerSearch'], {
     testOptIn: false,
     testSelfTest: true,
     onlyRegions: ['GB'],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1207386274532812?focus=true

This PR includes autoconsent rules for the following sites:


### Updated rules (1)
<details>
<summary>Show</summary>

- https://www.moneysupermarket.com/?feature=headerSearch
  - Overriding existing rule
    - `ruleName`: `"auto_GB_moneysupermarket.com_0"`
    - `existingRules`: `["auto_GB_moneysupermarket.com_0"]`
    - `region`: `"GB"`

</details>
