### PR TITLE
🤖 Add autoconsent rules for 1 sites (0 need review)

### DIFF
--- a/rules/generated/auto_AU_account.ubisoft.com_93p.json
+++ b/rules/generated/auto_AU_account.ubisoft.com_93p.json
@@ -1,0 +1,40 @@
+{
+    "name": "auto_AU_account.ubisoft.com_93p",
+    "cosmetic": false,
+    "_metadata": {
+        "vendorUrl": "https://account.ubisoft.com/"
+    },
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?account\\.ubisoft\\.com/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "body > div#privacy_modal > div:nth-child(2)#privacy__modal__only > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(1)#privacy__modal__close"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "body > div#privacy_modal > div:nth-child(2)#privacy__modal__only > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(1)#privacy__modal__close"
+        }
+    ],
+    "optIn": [],
+    "optOut": [
+        {
+            "wait": 500
+        },
+        {
+            "waitForThenClick": "body > div#privacy_modal > div:nth-child(2)#privacy__modal__only > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(1)#privacy__modal__close",
+            "comment": "I REFUSE COOKIES"
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "body > div#privacy_modal > div:nth-child(2)#privacy__modal__only > div:not([id]) > div:nth-child(3):not([id]) > button:nth-child(1)#privacy__modal__close",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/tests/generated/auto_AU_account.ubisoft.com_93p.spec.ts
+++ b/tests/generated/auto_AU_account.ubisoft.com_93p.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../../playwright/runner';
+generateCMPTests('auto_AU_account.ubisoft.com_93p', ['https://account.ubisoft.com/'], {
+    testOptIn: false,
+    testSelfTest: true,
+    onlyRegions: ['AU'],
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1210246497708732?focus=true

This PR includes autoconsent rules for the following sites:


### New rules (1)
<details>
<summary>Show</summary>

- https://account.ubisoft.com/
  - New rule added
    - `ruleName`: `"auto_AU_account.ubisoft.com_93p"`

</details>
