### PR TITLE
🤖 Add autoconsent rules for 1 sites (0 need review)

### DIFF
--- a/rules/generated/auto_AU_miles-and-more.com_qo7.json
+++ b/rules/generated/auto_AU_miles-and-more.com_qo7.json
@@ -1,0 +1,40 @@
+{
+    "name": "auto_AU_miles-and-more.com_qo7",
+    "cosmetic": false,
+    "_metadata": {
+        "vendorUrl": "https://www.miles-and-more.com/row/en/earn/airlines/mileage-calculator.html"
+    },
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?miles-and-more\\.com/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "body > aside:not([id]) > dialog:nth-child(6):not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > footer:nth-child(3):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id]) > span:not([id])"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "body > aside:not([id]) > dialog:nth-child(6):not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > footer:nth-child(3):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id]) > span:not([id])"
+        }
+    ],
+    "optIn": [],
+    "optOut": [
+        {
+            "wait": 500
+        },
+        {
+            "waitForThenClick": "body > aside:not([id]) > dialog:nth-child(6):not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > footer:nth-child(3):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id]) > span:not([id])",
+            "comment": "Accept necessary"
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "body > aside:not([id]) > dialog:nth-child(6):not([id]) > div:not([id]) > div:not([id]) > div:not([id]) > footer:nth-child(3):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id]) > span:not([id])",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/tests/generated/auto_AU_miles-and-more.com_qo7.spec.ts
+++ b/tests/generated/auto_AU_miles-and-more.com_qo7.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../../playwright/runner';
+generateCMPTests('auto_AU_miles-and-more.com_qo7', ['https://www.miles-and-more.com/row/en/earn/airlines/mileage-calculator.html'], {
+    testOptIn: false,
+    testSelfTest: true,
+    onlyRegions: ['AU'],
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1209084087784941?focus=true

This PR includes autoconsent rules for the following sites:


### New rules (1)
<details>
<summary>Show</summary>

- https://www.miles-and-more.com/row/en/earn/airlines/mileage-calculator.html
  - New region-specific popup
    - `ruleName`: `"auto_AU_miles-and-more.com_qo7"`
    - `existingRules`: `["auto_CH_miles-and-more.com_kxm"]`
    - `region`: `"AU"`

</details>
