### PR TITLE
🤖 Add autoconsent rules for 1 sites (0 need review)

### DIFF
--- a/rules/generated/auto_AU_capitoltrades.com_ak9.json
+++ b/rules/generated/auto_AU_capitoltrades.com_ak9.json
@@ -1,0 +1,40 @@
+{
+    "name": "auto_AU_capitoltrades.com_ak9",
+    "cosmetic": false,
+    "_metadata": {
+        "vendorUrl": "https://www.capitoltrades.com/"
+    },
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?capitoltrades\\.com/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "body > div:not([id]) > div:nth-child(4):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "body > div:not([id]) > div:nth-child(4):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])"
+        }
+    ],
+    "optIn": [],
+    "optOut": [
+        {
+            "wait": 500
+        },
+        {
+            "waitForThenClick": "body > div:not([id]) > div:nth-child(4):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
+            "comment": "Only Analytics"
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "body > div:not([id]) > div:nth-child(4):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/tests/generated/auto_AU_capitoltrades.com_ak9.spec.ts
+++ b/tests/generated/auto_AU_capitoltrades.com_ak9.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../../playwright/runner';
+generateCMPTests('auto_AU_capitoltrades.com_ak9', ['https://www.capitoltrades.com/'], {
+    testOptIn: false,
+    testSelfTest: true,
+    onlyRegions: ['AU'],
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1209906337502550?focus=true

This PR includes autoconsent rules for the following sites:


### New rules (1)
<details>
<summary>Show</summary>

- https://www.capitoltrades.com/
  - New rule added
    - `ruleName`: `"auto_AU_capitoltrades.com_ak9"`

</details>
