### PR TITLE
🤖 Add autoconsent rules for 1 sites (0 need review)

### DIFF
--- a/rules/generated/auto_AU_fareham.gov.uk_x1a.json
+++ b/rules/generated/auto_AU_fareham.gov.uk_x1a.json
@@ -1,0 +1,40 @@
+{
+    "name": "auto_AU_fareham.gov.uk_x1a",
+    "cosmetic": false,
+    "_metadata": {
+        "vendorUrl": "https://www.fareham.gov.uk/"
+    },
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?fareham\\.gov\\.uk/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "body > section#cookieControl > a:nth-child(5):not([id])"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "body > section#cookieControl > a:nth-child(5):not([id])"
+        }
+    ],
+    "optIn": [],
+    "optOut": [
+        {
+            "wait": 500
+        },
+        {
+            "waitForThenClick": "body > section#cookieControl > a:nth-child(5):not([id])",
+            "comment": "Reject non-essential cookies"
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "body > section#cookieControl > a:nth-child(5):not([id])",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/tests/generated/auto_AU_fareham.gov.uk_x1a.spec.ts
+++ b/tests/generated/auto_AU_fareham.gov.uk_x1a.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../../playwright/runner';
+generateCMPTests('auto_AU_fareham.gov.uk_x1a', ['https://www.fareham.gov.uk/'], {
+    testOptIn: false,
+    testSelfTest: true,
+    onlyRegions: ['AU'],
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1211441868417304?focus=true

This PR includes autoconsent rules for the following sites:


### New rules (1)
<details>
<summary>Show</summary>

- https://www.fareham.gov.uk/
  - New region-specific popup
    - `ruleName`: `"auto_AU_fareham.gov.uk_x1a"`
    - `existingRules`: `["auto_GB_fareham.gov.uk_0"]`
    - `region`: `"AU"`

</details>
