### PR TITLE
🤖 Add autoconsent rules for 1 sites (1 need review)

### DIFF
--- a/rules/generated/auto_AU_cam.start.canon_3x5.json
+++ b/rules/generated/auto_AU_cam.start.canon_3x5.json
@@ -1,0 +1,40 @@
+{
+    "name": "auto_AU_cam.start.canon_3x5",
+    "cosmetic": false,
+    "_metadata": {
+        "vendorUrl": "https://cam.start.canon/en/C011/manual/html/UG-05_Shooting-1_0030.html"
+    },
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?cam\\.start\\.canon/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "body > div#cookieAreaBase > div#cookieArea > p:nth-child(1):not([id]) > a:nth-child(3):not([id])"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "body > div#cookieAreaBase > div#cookieArea > p:nth-child(1):not([id]) > a:nth-child(3):not([id])"
+        }
+    ],
+    "optIn": [],
+    "optOut": [
+        {
+            "wait": 500
+        },
+        {
+            "waitForThenClick": "body > div#cookieAreaBase > div#cookieArea > p:nth-child(1):not([id]) > a:nth-child(3):not([id])",
+            "comment": "Not Accept"
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "body > div#cookieAreaBase > div#cookieArea > p:nth-child(1):not([id]) > a:nth-child(3):not([id])",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/rules/generated/auto_AU_cam.start.canon_z06.json
+++ b/rules/generated/auto_AU_cam.start.canon_z06.json
@@ -1,0 +1,40 @@
+{
+    "name": "auto_AU_cam.start.canon_z06",
+    "cosmetic": false,
+    "_metadata": {
+        "vendorUrl": "https://cam.start.canon/en/C011/manual/html/UG-05_Shooting-1_0030.html"
+    },
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?cam\\.start\\.canon/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "body > div#cookieAreaBase > div#cookieArea > div:nth-child(2):not([id]) > a:nth-child(2):not([id])"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "body > div#cookieAreaBase > div#cookieArea > div:nth-child(2):not([id]) > a:nth-child(2):not([id])"
+        }
+    ],
+    "optIn": [],
+    "optOut": [
+        {
+            "wait": 500
+        },
+        {
+            "waitForThenClick": "body > div#cookieAreaBase > div#cookieArea > div:nth-child(2):not([id]) > a:nth-child(2):not([id])",
+            "comment": "Not Accept"
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "body > div#cookieAreaBase > div#cookieArea > div:nth-child(2):not([id]) > a:nth-child(2):not([id])",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/tests/generated/auto_AU_cam.start.canon_3x5.spec.ts
+++ b/tests/generated/auto_AU_cam.start.canon_3x5.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../../playwright/runner';
+generateCMPTests('auto_AU_cam.start.canon_3x5', ['https://cam.start.canon/en/C011/manual/html/UG-05_Shooting-1_0030.html'], {
+    testOptIn: false,
+    testSelfTest: true,
+    onlyRegions: ['AU'],
+});

--- a/tests/generated/auto_AU_cam.start.canon_z06.spec.ts
+++ b/tests/generated/auto_AU_cam.start.canon_z06.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../../playwright/runner';
+generateCMPTests('auto_AU_cam.start.canon_z06', ['https://cam.start.canon/en/C011/manual/html/UG-05_Shooting-1_0030.html'], {
+    testOptIn: false,
+    testSelfTest: true,
+    onlyRegions: ['AU'],
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1206513679037471?focus=true

This PR includes autoconsent rules for the following sites:


### Sites requiring review (1)
<details>
<summary>Show</summary>

- https://cam.start.canon/en/C011/manual/html/UG-05_Shooting-1_0030.html
  - Multiple popups or reject buttons found
    - `url`: `"https://cam.start.canon/en/C011/manual/html/UG-05_Shooting-1_0030.html"`
    - `region`: `"AU"`

  - New rule added
    - `ruleName`: `"auto_AU_cam.start.canon_z06"`

  - New rule added
    - `ruleName`: `"auto_AU_cam.start.canon_3x5"`

  - **Multiple new rules generated**
    - `ruleNames`: `["auto_AU_cam.start.canon_z06","auto_AU_cam.start.canon_3x5"]`

</details>

### New rules (1)
<details>
<summary>Show</summary>

- https://cam.start.canon/en/C011/manual/html/UG-05_Shooting-1_0030.html
  - Multiple popups or reject buttons found
    - `url`: `"https://cam.start.canon/en/C011/manual/html/UG-05_Shooting-1_0030.html"`
    - `region`: `"AU"`

  - New rule added
    - `ruleName`: `"auto_AU_cam.start.canon_z06"`

  - New rule added
    - `ruleName`: `"auto_AU_cam.start.canon_3x5"`

  - **Multiple new rules generated**
    - `ruleNames`: `["auto_AU_cam.start.canon_z06","auto_AU_cam.start.canon_3x5"]`

</details>
