### PR TITLE
🤖 Add autoconsent rules for 1 sites (0 need review)

### DIFF
--- a/rules/generated/auto_AU_trendlinehq.com_4e6.json
+++ b/rules/generated/auto_AU_trendlinehq.com_4e6.json
@@ -1,0 +1,40 @@
+{
+    "name": "auto_AU_trendlinehq.com_4e6",
+    "cosmetic": false,
+    "_metadata": {
+        "vendorUrl": "https://www.trendlinehq.com/p/europe-us-stocks-in-2025"
+    },
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?trendlinehq\\.com/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "body > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:nth-child(2):not([id]) > button:nth-child(3):not([id])"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "body > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:nth-child(2):not([id]) > button:nth-child(3):not([id])"
+        }
+    ],
+    "optIn": [],
+    "optOut": [
+        {
+            "wait": 500
+        },
+        {
+            "waitForThenClick": "body > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:nth-child(2):not([id]) > button:nth-child(3):not([id])",
+            "comment": "Decline"
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "body > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:nth-child(2):not([id]) > button:nth-child(3):not([id])",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/tests/generated/auto_AU_trendlinehq.com_4e6.spec.ts
+++ b/tests/generated/auto_AU_trendlinehq.com_4e6.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../../playwright/runner';
+generateCMPTests('auto_AU_trendlinehq.com_4e6', ['https://www.trendlinehq.com/p/europe-us-stocks-in-2025'], {
+    testOptIn: false,
+    testSelfTest: true,
+    onlyRegions: ['AU'],
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1209832986919644?focus=true

This PR includes autoconsent rules for the following sites:


### New rules (1)
<details>
<summary>Show</summary>

- https://www.trendlinehq.com/p/europe-us-stocks-in-2025
  - New rule added
    - `ruleName`: `"auto_AU_trendlinehq.com_4e6"`

</details>
