### PR TITLE
🤖 Add autoconsent rules for 1 sites (0 need review)

### DIFF
--- a/rules/generated/auto_AU_tourismnewbrunswick.ca_bjd.json
+++ b/rules/generated/auto_AU_tourismnewbrunswick.ca_bjd.json
@@ -1,0 +1,40 @@
+{
+    "name": "auto_AU_tourismnewbrunswick.ca_bjd",
+    "cosmetic": false,
+    "_metadata": {
+        "vendorUrl": "https://tourismnewbrunswick.ca/listing/fundy-trail-provincial-park"
+    },
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?tourismnewbrunswick\\.ca/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "body > div#message-banner > div:not([id]) > div:nth-child(2):not([id]) > button:not([id])"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "body > div#message-banner > div:not([id]) > div:nth-child(2):not([id]) > button:not([id])"
+        }
+    ],
+    "optIn": [],
+    "optOut": [
+        {
+            "wait": 500
+        },
+        {
+            "waitForThenClick": "body > div#message-banner > div:not([id]) > div:nth-child(2):not([id]) > button:not([id])",
+            "comment": "OK"
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "body > div#message-banner > div:not([id]) > div:nth-child(2):not([id]) > button:not([id])",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/tests/generated/auto_AU_tourismnewbrunswick.ca_bjd.spec.ts
+++ b/tests/generated/auto_AU_tourismnewbrunswick.ca_bjd.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../../playwright/runner';
+generateCMPTests('auto_AU_tourismnewbrunswick.ca_bjd', ['https://tourismnewbrunswick.ca/listing/fundy-trail-provincial-park'], {
+    testOptIn: false,
+    testSelfTest: true,
+    onlyRegions: ['AU'],
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1210713100607784?focus=true

This PR includes autoconsent rules for the following sites:


### New rules (1)
<details>
<summary>Show</summary>

- https://tourismnewbrunswick.ca/listing/fundy-trail-provincial-park
  - New rule added
    - `ruleName`: `"auto_AU_tourismnewbrunswick.ca_bjd"`

</details>
