### PR TITLE
🤖 Add autoconsent rules for 1 sites (0 need review)

### DIFF
--- a/rules/generated/auto_AU_niwaki.com_w41.json
+++ b/rules/generated/auto_AU_niwaki.com_w41.json
@@ -1,0 +1,40 @@
+{
+    "name": "auto_AU_niwaki.com_w41",
+    "cosmetic": false,
+    "_metadata": {
+        "vendorUrl": "https://www.niwaki.com/cedar-bark-tape/?source=aw&amp;awc=117415_1751929847_9263c63ecafa1f9842d029427e54c402#P00580-1"
+    },
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?niwaki\\.com/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "body > form#trackingConsent > button:nth-child(2):not([id])"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "body > form#trackingConsent > button:nth-child(2):not([id])"
+        }
+    ],
+    "optIn": [],
+    "optOut": [
+        {
+            "wait": 500
+        },
+        {
+            "waitForThenClick": "body > form#trackingConsent > button:nth-child(2):not([id])",
+            "comment": "NO"
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "body > form#trackingConsent > button:nth-child(2):not([id])",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/tests/generated/auto_AU_niwaki.com_w41.spec.ts
+++ b/tests/generated/auto_AU_niwaki.com_w41.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../../playwright/runner';
+generateCMPTests(
+    'auto_AU_niwaki.com_w41',
+    ['https://www.niwaki.com/cedar-bark-tape/?source=aw&amp;awc=117415_1751929847_9263c63ecafa1f9842d029427e54c402'],
+    { testOptIn: false, testSelfTest: true, onlyRegions: ['AU'] },
+);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1210735270206072?focus=true

This PR includes autoconsent rules for the following sites:


### New rules (1)
<details>
<summary>Show</summary>

- https://www.niwaki.com/cedar-bark-tape/?source=aw&amp;awc=117415_1751929847_9263c63ecafa1f9842d029427e54c402
  - New rule added
    - `ruleName`: `"auto_AU_niwaki.com_w41"`

</details>
