### PR TITLE
🤖 Add autoconsent rules for 1 sites (0 need review)

### DIFF
--- a/rules/generated/auto_AU_cutterbuck.com_ko7.json
+++ b/rules/generated/auto_AU_cutterbuck.com_ko7.json
@@ -1,0 +1,40 @@
+{
+    "name": "auto_AU_cutterbuck.com_ko7",
+    "cosmetic": false,
+    "_metadata": {
+        "vendorUrl": "https://cutterbuck.com/men/polos/?tab=products#/productsFilter:ss_colors:black"
+    },
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?cutterbuck\\.com/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "body > div#cookieConsentModal > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:not([id]) > button:nth-child(2):not([id])"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "body > div#cookieConsentModal > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:not([id]) > button:nth-child(2):not([id])"
+        }
+    ],
+    "optIn": [],
+    "optOut": [
+        {
+            "wait": 500
+        },
+        {
+            "waitForThenClick": "body > div#cookieConsentModal > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:not([id]) > button:nth-child(2):not([id])",
+            "comment": "Got It"
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "body > div#cookieConsentModal > div:not([id]) > div:not([id]) > div:not([id]) > div:nth-child(3):not([id]) > div:not([id]) > button:nth-child(2):not([id])",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/tests/generated/auto_AU_cutterbuck.com_ko7.spec.ts
+++ b/tests/generated/auto_AU_cutterbuck.com_ko7.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../../playwright/runner';
+generateCMPTests('auto_AU_cutterbuck.com_ko7', ['https://cutterbuck.com/men/polos/?tab=products'], {
+    testOptIn: false,
+    testSelfTest: true,
+    onlyRegions: ['AU'],
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1207883246806575?focus=true

This PR includes autoconsent rules for the following sites:


### New rules (1)
<details>
<summary>Show</summary>

- https://cutterbuck.com/men/polos/?tab=products
  - New rule added
    - `ruleName`: `"auto_AU_cutterbuck.com_ko7"`

</details>
