### PR TITLE
Handle alternative reject text on substack sites

### DIFF
--- a/rules/autoconsent/substack.json
+++ b/rules/autoconsent/substack.json
@@ -20,12 +20,12 @@
     ],
     "optIn": [
         {
-            "waitForThenClick": [".pencraft", "xpath///button[contains(., 'Accept All')]"]
+            "waitForThenClick": [".pencraft", "xpath///button[contains(., 'Accept All')] or contains(., 'Accept')]"]
         }
     ],
     "optOut": [
         {
-            "waitForThenClick": [".pencraft", "xpath///button[contains(., 'Only Necessary')]"]
+            "waitForThenClick": [".pencraft", "xpath///button[contains(., 'Only Necessary') or contains(., 'Reject')]"]
         }
     ],
     "test": [

--- a/tests/substack.spec.ts
+++ b/tests/substack.spec.ts
@@ -1,3 +1,3 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('substack', ['https://substack.com/']);
+generateCMPTests('substack', ['https://substack.com/', 'https://www.marketingideas.com/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1210420480461379?focus=true

## Description:
Some substack sites have different text for the accept and reject buttons. We can add those to the xpath selector to handle those cases.

## Steps to test this PR:

