### PR TITLE
Fix evaluateRuleStep

### DIFF
--- a/lib/cmps/base.ts
+++ b/lib/cmps/base.ts
@@ -335,9 +335,9 @@ export class AutoConsentCMP extends AutoConsentCMPBase {
             const condition = await this.evaluateRuleStep(rule.if);
             logsConfig.rulesteps && console.log('Condition is', condition);
             if (condition) {
-                results.push(this._runRulesSequentially(rule.then), logsConfig.rulesteps);
+                results.push(this._runRulesSequentially(rule.then, logsConfig.rulesteps));
             } else if (rule.else) {
-                results.push(this._runRulesSequentially(rule.else), logsConfig.rulesteps);
+                results.push(this._runRulesSequentially(rule.else, logsConfig.rulesteps));
             } else {
                 results.push(true);
             }


### PR DESCRIPTION
Introduced by https://github.com/duckduckgo/autoconsent/commit/a74a1bc85fa075e5ab3ff68ab13289f880731966

We didn't notice the bug as it was not affecting the add-on when the logging was enabled.


fixes https://github.com/ghostery/broken-page-reports/issues/1952