### PR TITLE
Add autoconsent rule for Gallup cookie banner

### DIFF
--- a/rules/autoconsent/gallup.json
+++ b/rules/autoconsent/gallup.json
@@ -1,8 +1,5 @@
 {
     "name": "gallup",
-    "runContext": {
-        "urlPattern": "^https://([a-z0-9-]+\\.)?gallup\\.com/"
-    },
     "prehideSelectors": ["[class*=\"gcb-modal-overlay\"]"],
     "detectCmp": [{ "exists": "[data-gcb-modal-show-prefs]" }],
     "detectPopup": [{ "visible": "[data-gcb-modal-show-prefs]" }],

--- a/rules/autoconsent/gallup.json
+++ b/rules/autoconsent/gallup.json
@@ -1,0 +1,12 @@
+{
+    "name": "gallup",
+    "runContext": {
+        "urlPattern": "^https://([a-z0-9-]+\\.)?gallup\\.com/"
+    },
+    "prehideSelectors": ["[class*=\"gcb-modal-overlay\"]"],
+    "detectCmp": [{ "exists": "[data-gcb-modal-show-prefs]" }],
+    "detectPopup": [{ "visible": "[data-gcb-modal-show-prefs]" }],
+    "optOut": [{ "waitForThenClick": "[data-gcb-modal-show-prefs]" }, { "wait": 500 }, { "waitForThenClick": "[data-gcb-modal-save]" }],
+    "optIn": [{ "waitForThenClick": "[data-gcb-modal-accept]" }],
+    "test": [{ "cookieContains": "gcbcl=a3|m3" }]
+}

--- a/tests/gallup.spec.ts
+++ b/tests/gallup.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('gallup', ['https://www.gallup.com/analytics/651674/gen-z-research.aspx']);

--- a/tests/gallup.spec.ts
+++ b/tests/gallup.spec.ts
@@ -1,3 +1,6 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('gallup', ['https://www.gallup.com/analytics/651674/gen-z-research.aspx']);
+generateCMPTests('gallup', [
+    'https://www.gallup.com/analytics/651674/gen-z-research.aspx',
+    'https://www.gallupstudentpoll.com.au/home.aspx',
+]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1213992712279763?focus=true

## Description:

Adds a new JSON rule for the **Gallup Cookie Banner (gcb)**, a custom CMP used across Gallup-owned domains. This is not a known third-party CMP provider.

**Affected domains** (confirmed via [PublicWWW](https://publicwww.com/) search for the `content.gallup.com/ux/gcb/` script):
- `gallup.com` — main site
- `gallupstudentpoll.com.au` — Gallup Student Poll Australia
- `gallupatwork.uk` — Gallup At Work UK events
- `gallupatwork.sg` — Gallup At Work Singapore events
- `nic.gallup` — Gallup registry

The rule uses `data-gcb-modal-*` data attributes (not CSS Module hashed class names like `gcb-modal_0f2c2` which change per build), so no `runContext` URL restriction is needed — the selectors are specific enough to avoid false positives.

**Popup behavior:**
- Shows a modal with "ACCEPT ALL" and "MANAGE PREFERENCES" buttons
- No direct "Reject All" button on the initial popup
- In the preferences panel, Analytics and Marketing cookies are **unchecked by default**

**Opt-out flow:**
1. Click "Manage Preferences" (`[data-gcb-modal-show-prefs]`)
2. Click "Save Preferences" (`[data-gcb-modal-save]`) — saves with only essential cookies

**Self-test:** Verifies `gcbcl=a3|m3` cookie is set (Analytics=`a3`, Marketing=`m3` both declined).

### Manual test — Chromium with extension loaded

[Chromium with extension — popup auto-dismissed, page fully accessible](https://cursor.com/agents/bc-e5144cce-860b-4d1c-8503-0240607ff296/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgallup_chromium_extension_working.png)

Cookie verified via CDP: `gcbcl=a3|m3` (analytics and marketing declined).

### Playwright test screenshots

**Before (popup detected):**

[Gallup cookie popup detected by Playwright](https://cursor.com/agents/bc-e5144cce-860b-4d1c-8503-0240607ff296/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgallup_popup_found.jpg)

**After (opt-out complete):**

[Gallup page after opt-out with Cookie Preferences Saved toast](https://cursor.com/agents/bc-e5144cce-860b-4d1c-8503-0240607ff296/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgallup_optout_done.jpg)

## Steps to test this PR:

1. `npm run lint` — validates rule schema and formatting
2. `npm run test:lib` — unit tests pass
3. `npx playwright test tests/gallup.spec.ts --project webkit` — 4/4 E2E tests pass (optOut + optIn on both gallup.com and gallupstudentpoll.com.au, all with selfTest: true)
4. Manual test with Chromium extension confirms popup auto-dismissed and `gcbcl=a3|m3` cookie set

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5144cce-860b-4d1c-8503-0240607ff296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5144cce-860b-4d1c-8503-0240607ff296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

