### PR TITLE
Add PublicWWW source code search agent skill for CMP discovery

### DIFF
--- a/.cursor/skills/publicwww-search/SKILL.md
+++ b/.cursor/skills/publicwww-search/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: publicwww-search
+description: Search PublicWWW to find websites using specific HTML/JS/CSS snippets. Use this skill to check if a cookie popup is from a widespread third-party CMP, to find additional test URLs for a CMP rule, or to discover how many sites use a particular consent banner pattern.
+---
+
+# PublicWWW Source Code Search
+
+Search website source code via the [PublicWWW](https://publicwww.com) API. Requires `PUBLICWWW_KEY` env var.
+
+**Caveat:** PublicWWW indexes server-rendered HTML source only. CMPs injected purely via client-side JavaScript (e.g. tag managers, async script loaders) may not appear in results.
+
+## API
+
+Download search results as CSV:
+
+```
+https://publicwww.com/websites/SEARCH_QUERY/?export=csvsnippetsu&key=$PUBLICWWW_KEY
+```
+
+CSV format: `url;rank;snippet` (one site per line, sorted by popularity rank).
+
+Use `export=csv` instead of `csvsnippetsu` to get `domain;rank` without snippets.
+
+## Query Syntax
+
+- Exact phrase: `"onetrust-banner-sdk"`
+- Combine terms: `"cookie-banner" "reject-all"`
+- Exclude: `"cookie-banner" -wordpress`
+- TLD filter: `"sd-cmp" site:de`
+- File type: `"__cmp" filetype:js` (also `filetype:css`)
+- Page depth: `depth:all "math.min.js"` (0–5, default homepage only)
+- Escape inner quotes: `"data-testid=\"cookie-reject\""`
+
+Full syntax: https://publicwww.com/syntax.html
+
+## Examples
+
+Check if a banner ID is from a shared CMP:
+
+```bash
+curl -s "https://publicwww.com/websites/%22sd-cmp%22/?export=csv&key=$PUBLICWWW_KEY" | head -20
+```
+
+Find German sites using OneTrust:
+
+```bash
+curl -s "https://publicwww.com/websites/%22onetrust-banner-sdk%22+site%3Ade/?export=csv&key=$PUBLICWWW_KEY" | head -10
+```
+
+Search JS files for a CMP API:
+
+```bash
+curl -s "https://publicwww.com/js/%22__cmp%22+filetype%3Ajs/?export=csv&key=$PUBLICWWW_KEY" | head -10
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,6 +347,12 @@ E2E tests hit live sites and are inherently flaky due to site changes, regional 
 - Playwright is configured with retries (2 retries in CI)
 - Verify the site still has the same cookie consent popup by visiting it manually
 
+## CMP Discovery with PublicWWW
+
+Use the `/publicwww-search` skill to search website source code for CMP-specific identifiers. This helps determine if a cookie popup is from a shared third-party CMP (warranting a generic rule) or is site-specific. It also helps find additional test URLs for existing rules and region-specific test sites.
+
+Requires `PUBLICWWW_KEY` environment variable.
+
 ## Verification
 
 | Step | Command |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,12 @@ E2E tests hit live sites and are inherently flaky due to site changes, regional 
 - Playwright is configured with retries (2 retries in CI)
 - Verify the site still has the same cookie consent popup by visiting it manually
 
+## CMP Discovery with PublicWWW
+
+Use the `/publicwww-search` skill to search website source code for CMP-specific identifiers. This helps determine if a cookie popup is from a shared third-party CMP (warranting a generic rule) or is site-specific. It also helps find additional test URLs for existing rules and region-specific test sites.
+
+Requires `PUBLICWWW_KEY` environment variable.
+
 ## Verification
 
 | Step | Command |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213974073383731?focus=true

## Description:

Adds a new agent skill at `.cursor/skills/publicwww-search/` documenting how to use the [PublicWWW](https://publicwww.com) CSV API to search website source code for CMP identifiers.

Use cases: checking if a popup is from a shared third-party CMP, finding test URLs for a CMP rule, discovering region-specific test sites by TLD.

Requires `PUBLICWWW_KEY` environment variable.

## Steps to test this PR:

```bash
npm run lint

# Verify the API works
curl -s "https://publicwww.com/websites/%22sd-cmp%22/?export=csv&key=$PUBLICWWW_KEY" | head -5
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16a9b434-e765-4a7f-991a-99edc195dc89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16a9b434-e765-4a7f-991a-99edc195dc89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

