### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,3 +355,12 @@ E2E tests hit live sites and are inherently flaky due to site changes, regional 
 | Unit tests | `npm run test:lib` |
 | Single CMP E2E test | `npx playwright test tests/<cmp>.spec.ts --project webkit` |
 | Full E2E suite | `npm run test` |
+
+## Cursor Cloud specific instructions
+
+- **Build before lint/test:** `npm ci` triggers the `prepublish` script automatically, which compiles the filterlist, builds rules, and bundles everything. No separate build step is needed after install.
+- **Playwright browsers:** After `npm ci`, run `npx playwright install --with-deps` to install browser binaries (WebKit, Chromium, Firefox) and their OS-level dependencies. This is required for both E2E tests (`npm run test`) and unit tests (`npm run test:lib`, which uses `@web/test-runner-playwright`).
+- **E2E tests hit live websites:** Playwright E2E tests navigate to real sites and are inherently flaky. "No CMP detected" failures are common when running without a geographic proxy (most cookie popups only appear in EU regions). Use `REGION` and `PROXY_SERVER` env vars for region-specific testing — see the "Testing Across Regions" section above.
+- **Unit tests are the reliable CI gate:** `npm run lint` and `npm run test:lib` are the two checks that GitHub Actions CI runs on every push/PR. These should always pass.
+- **No backend services required:** This is a client-side library with no databases, APIs, or Docker dependencies. The full dev environment is Node.js + npm dependencies + Playwright browsers.
+- **Watch mode:** `npm run watch` auto-rebuilds on changes to `lib/`, `addon/`, `rules/`. Use this during active development. It runs the full `prepublish` pipeline on each file change.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with non-obvious development environment caveats for future cloud agents, including:

- Build pipeline behavior (npm ci triggers prepublish automatically)
- Playwright browser installation requirements
- E2E test flakiness context (region/proxy dependency)
- CI gate clarification (lint + test:lib are the reliable checks)
- Confirmation that no backend services are needed

## Steps to test this PR

1. Run `npm ci` — should install dependencies and build successfully
2. Run `npm run lint` — should pass
3. Run `npm run test:lib` — should pass (2947 tests)
4. Run `npx playwright install --with-deps` — should install browser binaries
5. Run `npx playwright test tests/<cmp>.spec.ts --project webkit` — Playwright infrastructure works (E2E tests may fail without geographic proxy)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0b2a62a-971c-440e-8e9d-cf77ed57dca8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0b2a62a-971c-440e-8e9d-cf77ed57dca8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

