### PR TITLE
Support do not sell version of Didomi

### DIFF
--- a/lib/web.ts
+++ b/lib/web.ts
@@ -336,9 +336,12 @@ export default class AutoConsent {
         if (foundCMPs.length === 0 && retries > 0) {
             // if we didn't find a CMP, try again
             // We wait 500ms, and also for some kind of dom mutation to happen before
-            // rerunning the findCmp check
+            // rerunning the findCmp check. We use Promise.race so that a 500ms delay
+            // is the minimum wait, but we don't block forever if the mutation observer
+            // never fires (e.g. in isolated worlds where main-world DOM changes may
+            // not trigger the observer).
             try {
-                await Promise.all([this.domActions.wait(500), mutationObserver]);
+                await Promise.any([Promise.all([this.domActions.wait(500), mutationObserver]), this.domActions.wait(2000)]);
             } catch (e) {
                 // timeout waiting for mutation - break out of detection
                 return [];

--- a/rules/autoconsent/didomi.json
+++ b/rules/autoconsent/didomi.json
@@ -3,7 +3,7 @@
     "prehideSelectors": [
         "#didomi-popup,.didomi-popup-container,.didomi-popup-notice,.didomi-consent-popup-preferences,#didomi-notice,.didomi-popup-backdrop,.didomi-screen-medium"
     ],
-    "detectCmp": [{ "visible": "#didomi-host" }],
+    "detectCmp": [{ "exists": "#didomi-host" }],
     "detectPopup": [
         {
             "visible": "#didomi-popup, #didomi-notice, .didomi-popup-notice, .didomi-notice-banner",

--- a/rules/autoconsent/didomi.json
+++ b/rules/autoconsent/didomi.json
@@ -15,7 +15,13 @@
         {
             "if": { "exists": "#didomi-notice-disagree-button,.didomi-continue-without-agreeing" },
             "then": [{ "waitForThenClick": "#didomi-notice-disagree-button,.didomi-continue-without-agreeing" }],
-            "else": [{ "eval": "EVAL_DIDOMI_OPT_OUT" }]
+            "else": [
+                {
+                    "if": { "exists": "#didomi-notice-do-not-sell-button" },
+                    "then": [{ "waitForThenClick": "#didomi-notice-do-not-sell-button" }],
+                    "else": [{ "eval": "EVAL_DIDOMI_OPT_OUT" }]
+                }
+            ]
         }
     ],
     "test": [{ "eval": "EVAL_DIDOMI_TEST" }]

--- a/tests/didomi.spec.ts
+++ b/tests/didomi.spec.ts
@@ -16,3 +16,7 @@ generateCMPTests(
         skipRegions: ['US'],
     },
 );
+
+generateCMPTests('didomi', ['https://us.sandro-paris.com/en/womens/thanksgiving-event/see-all/'], {
+    testSelfTest: false,
+});

--- a/tests/didomi.spec.ts
+++ b/tests/didomi.spec.ts
@@ -3,12 +3,12 @@ import generateCMPTests from '../playwright/runner';
 generateCMPTests(
     'didomi',
     [
-        'https://nothing.tech/',
+        'https://www.visitcalifornia.com/',
         'https://www.planet.fr/',
         'http://www.allocine.fr/',
         'https://www.boursorama.com/',
-        'https://www.theoriginalshotels.com/en/hotels/la-villa-vicha',
-        'https://support.didomi.io/set-up-the-absence-of-interaction-as-a-cookie-denial',
+        'https://www.leparisien.fr/',
+        'https://www.elconfidencial.com/',
     ],
     {
         testOptIn: true,

--- a/tests/didomi.spec.ts
+++ b/tests/didomi.spec.ts
@@ -3,7 +3,7 @@ import generateCMPTests from '../playwright/runner';
 generateCMPTests(
     'didomi',
     [
-        'https://www.visitcalifornia.com/',
+        'https://nothing.tech/',
         'https://www.planet.fr/',
         'http://www.allocine.fr/',
         'https://www.boursorama.com/',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1212070258656427?focus=true

## Description:

### 1. CCPA "Do not Sell" button support

The Didomi CMP shows a CCPA-specific "Do not Share or Sell my Personal Information" button (`#didomi-notice-do-not-sell-button`) on US sites like `us.sandro-paris.com`, instead of the standard GDPR disagree button. Added explicit click support for this button in the opt-out flow.

**Opt-out flow (updated):**
1. Click `#didomi-notice-disagree-button` / `.didomi-continue-without-agreeing` (GDPR variant)
2. **NEW:** Click `#didomi-notice-do-not-sell-button` (CCPA/US variant)
3. Fall back to `EVAL_DIDOMI_OPT_OUT` API call

### 2. Fix detection retry for isolated-world MutationObserver

The CMP detection retry mechanism uses `MutationObserver` on `<html>` to wait for DOM changes before retrying. In isolated execution worlds (used by the browser extension and BrightData testing), `MutationObserver` may not fire for DOM changes made by main-world scripts. This caused detection to stall after 1-2 attempts, missing late-loading CMPs like Didomi on `nothing.tech` (which loads ~5-8s after navigation).

**Root cause:** `Promise.all([wait(500), mutationObserver])` requires both a 500ms delay AND a DOM mutation. When the mutation observer never fires in the isolated world, detection gets stuck indefinitely.

**Fix:** Use `Promise.any` with a 2-second fallback timeout alongside the existing mutation+500ms wait:
```js
await Promise.any([
    Promise.all([this.domActions.wait(500), mutationObserver]),
    this.domActions.wait(2000),
]);
```
This ensures retries continue at a 2-second polling interval even when `MutationObserver` doesn't fire, while preserving the fast path (~500ms) when mutations are observed.

Also changed Didomi `detectCmp` from `visible` to `exists` since `#didomi-host` can have 0x0 dimensions on some sites. Visibility is already checked by `detectPopup`.

### 3. Update test URLs

- Restored `nothing.tech` (now works reliably with the detection fix)
- Replaced 2 broken URLs (`theoriginalshotels.com`, `support.didomi.io`) with working alternatives (`leparisien.fr`, `elconfidencial.com`)
- Added `us.sandro-paris.com` for CCPA variant coverage

### BrightData Regional Testing

**nothing.tech** — 5/5 pass from GB after fix (was ~1/5 before):

| Run | Result |
|-----|--------|
| 1 | PASS (9.6s) |
| 2 | PASS (23.0s) |
| 3 | PASS (15.7s) |
| 4 | PASS (18.9s) |
| 5 | PASS (8.9s) |

**us.sandro-paris.com** — all regions:

| Region | Result | OptOut | SelfTest |
|--------|--------|--------|----------|
| US (NY) | PASS | true | false |
| US (LA) | PASS | true | false |
| DE | PASS | true | true |
| FR | PASS | true | true |
| GB | PASS | true | true |
| NL | PASS | true | true |
| CA | PASS | true | true |
| AU | NO CMP | — | — |

[Didomi CCPA popup on sandro-paris.com](https://cursor.com/agents/bc-3f603a3f-f42d-4c47-9ae9-dfd98a032f85/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcookie_popup_before.webp)
[Page loaded with no popup after fix](https://cursor.com/agents/bc-3f603a3f-f42d-4c47-9ae9-dfd98a032f85/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsandro_paris_no_popup.webp)

## Steps to test this PR:

1. `npm run prepublish`
2. Load the extension from `dist/addon-mv3/` in Chrome
3. Visit https://nothing.tech/ — the Didomi popup should be automatically dismissed
4. Visit https://us.sandro-paris.com/en/womens/thanksgiving-event/see-all/ — the Didomi CCPA popup should be automatically dismissed
5. Check DevTools console for "didomi done" message
6. Verify existing Didomi test URLs still work (e.g. https://www.boursorama.com/)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f603a3f-f42d-4c47-9ae9-dfd98a032f85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f603a3f-f42d-4c47-9ae9-dfd98a032f85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

