### PR TITLE
cookieconsent2: add fallback opt-out for sites without reject-all button

### DIFF
--- a/rules/autoconsent/cookieconsent2.json
+++ b/rules/autoconsent/cookieconsent2.json
@@ -23,7 +23,9 @@
     ],
     "optOut": [
         {
-            "waitForThenClick": "#s-rall-bn"
+            "if": { "exists": "#s-rall-bn" },
+            "then": [{ "waitForThenClick": "#s-rall-bn" }],
+            "else": [{ "waitForThenClick": "#c-s-bn" }, { "waitForThenClick": "#s-sv-bn" }]
         }
     ],
     "test": [

--- a/tests/cookieconsent2.spec.ts
+++ b/tests/cookieconsent2.spec.ts
@@ -1,8 +1,3 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('cookieconsent2', [
-    'https://www.modular.com/',
-    'https://gls-group.com/NL/nl/home/',
-    'https://en.securevod.eu/',
-    'https://servero.nl/onze-producten/',
-]);
+generateCMPTests('cookieconsent2', ['https://alpha-heidelberg.de/', 'https://antitec.fi/', 'https://servero.nl/onze-producten/']);

--- a/tests/cookieconsent2.spec.ts
+++ b/tests/cookieconsent2.spec.ts
@@ -1,3 +1,8 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('cookieconsent2', ['https://www.modular.com/', 'https://gls-group.com/NL/nl/home/', 'https://en.securevod.eu/']);
+generateCMPTests('cookieconsent2', [
+    'https://www.modular.com/',
+    'https://gls-group.com/NL/nl/home/',
+    'https://en.securevod.eu/',
+    'https://servero.nl/onze-producten/',
+]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1207904504279877?focus=true

## Description:

Some orestbida CookieConsent v2 deployments (e.g. servero.nl) don't include a "Reject All" button (`#s-rall-bn`). The existing `cookieconsent2` rule's opt-out step only tried to click `#s-rall-bn`, which fails on these sites.

This PR adds a fallback path: when `#s-rall-bn` doesn't exist, the rule opens the settings panel (`#c-s-bn`) and clicks "Save" (`#s-sv-bn`). Since non-essential cookies are unchecked by default in these deployments, saving without changes effectively opts out.

Also replaces stale test URLs: `modular.com` switched to Cookiebot, `gls-group.com` switched to consentmanager.net, and `en.securevod.eu` is dead.

**Changes:**
- `rules/autoconsent/cookieconsent2.json`: Added `if`/`then`/`else` in `optOut` to handle both variants
- `tests/cookieconsent2.spec.ts`: Replaced stale URLs with `alpha-heidelberg.de` and `antitec.fi` (reject-all path) + `servero.nl` (fallback path)

**BrightData regional test results:**

servero.nl (fallback path — no reject-all button):
[servero.nl after opt-out — popup dismissed](https://cursor.com/agents/bc-887f6f36-8fe9-4e55-b49b-504f0cbbba87/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fservero_nl_after_optout.jpg)

alpha-heidelberg.de (primary path — has reject-all button):
[alpha-heidelberg.de after opt-out — popup dismissed](https://cursor.com/agents/bc-887f6f36-8fe9-4e55-b49b-504f0cbbba87/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Falpha_heidelberg_after_optout.jpg)

All spec URLs tested across 4 regions:

| URL | NL | DE | GB | US |
|-----|----|----|----|----|
| alpha-heidelberg.de (reject-all) | — | ✅ PASS | — | — |
| antitec.fi (reject-all) | — | ✅ PASS | — | — |
| servero.nl (fallback) | ✅ PASS | ✅ PASS | ✅ PASS | ✅ PASS |

Previous test URLs no longer use CookieConsent v2:

| URL | Issue |
|-----|-------|
| modular.com | Switched to Cookiebot |
| gls-group.com | Switched to consentmanager.net |
| en.securevod.eu | Domain is dead (DNS failure) |

## Steps to test this PR:

1. `npm run lint` — passes
2. `npm run test:lib` — all unit tests pass
3. Test with BrightData across regions for servero.nl (fallback path) and alpha-heidelberg.de (reject-all path)
4. Jenkins CI will test all regions automatically

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-887f6f36-8fe9-4e55-b49b-504f0cbbba87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-887f6f36-8fe9-4e55-b49b-504f0cbbba87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

