### PR TITLE
Add autoconsent rule for ring.com

### DIFF
--- a/rules/autoconsent/ring.json
+++ b/rules/autoconsent/ring.json
@@ -1,0 +1,51 @@
+{
+    "name": "ring",
+    "vendorUrl": "https://ring.com",
+    "prehideSelectors": [".consent-banner"],
+    "detectCmp": [
+        {
+            "exists": ".consent-banner .consent-banner-copy"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": ".consent-banner .consent-banner-copy"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": ".consent-banner .consent--accept"
+        }
+    ],
+    "optOut": [
+        {
+            "if": { "exists": ".consent-banner .consent--reject" },
+            "then": [
+                {
+                    "waitForThenClick": ".consent-banner .consent--reject"
+                }
+            ],
+            "else": [
+                {
+                    "waitForThenClick": ".consent-banner .consent--manage"
+                },
+                {
+                    "waitForVisible": ".consent-modal .consent-bucket"
+                },
+                {
+                    "click": ".consent-modal input[type=checkbox]:checked",
+                    "all": true,
+                    "optional": true
+                },
+                {
+                    "waitForThenClick": ".consent-modal .consent-save"
+                }
+            ]
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "privacy-banner-clicked=true"
+        }
+    ]
+}

--- a/tests/ring.spec.ts
+++ b/tests/ring.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('ring', ['https://nl-nl.ring.com/', 'https://community.ring.com/', 'https://ring.com/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL:

## Description:

Adds a JSON autoconsent rule for the cookie consent popup on ring.com (and its regional / community subdomains).

The popup is rendered by Ring's own consent manager script (`consent-manager-*.js`), which has two regional variants:

- **GDPR (EU)**: shows three buttons — Manage settings, Reject, Accept — directly on the banner.
- **Non-GDPR (US/other)**: shows only Manage settings and Accept. Rejecting requires opening the modal and unchecking each enabled bucket before saving.

The opt-out flow uses `if`/`then`/`else` to take the direct `.consent--reject` path when available, and falls back to the manage → uncheck checkboxes → save flow otherwise. Self-test verifies the `privacy-banner-clicked` cookie that the consent manager always sets after a user action. The rule is essentially the previously shipped `ring` rule, restored here with two improvements:

- a direct reject-button path for the GDPR banner (faster and more reliable than the manage-and-uncheck flow)
- a `cookieContains` self-test (`privacy-banner-clicked=true`) that the previous rule was missing
- a narrow prehide selector (`.consent-banner`) so the banner doesn't flicker on screen before opt-out runs

### Files

- `rules/autoconsent/ring.json` — JSON rule
- `tests/ring.spec.ts` — Playwright spec covering `ring.com`, `nl-nl.ring.com`, and `community.ring.com`

## Steps to test this PR:

1. `npm run lint`
2. `npx playwright test tests/ring.spec.ts --project webkit`
3. Manually load `dist/addon-mv3/` in Chrome, visit `https://ring.com/` and `https://nl-nl.ring.com/`, and verify the consent banner is dismissed and the `privacy-banner-clicked=true` cookie is present.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25d33ee5-1110-4098-906d-86728d1cff0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25d33ee5-1110-4098-906d-86728d1cff0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

