### PR TITLE
transcend: add cosmetic rule for verizon.com cookie consent popup

### DIFF
--- a/rules/autoconsent/transcend.json
+++ b/rules/autoconsent/transcend.json
@@ -1,0 +1,26 @@
+{
+    "name": "transcend",
+    "vendorUrl": "https://transcend.io/",
+    "cosmetic": true,
+    "prehideSelectors": ["#transcend-consent-manager"],
+    "detectCmp": [
+        {
+            "exists": "#transcend-consent-manager"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#transcend-consent-manager"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": ["#transcend-consent-manager", "#consentManagerMainDialog .inner-container button"]
+        }
+    ],
+    "optOut": [
+        {
+            "hide": "#transcend-consent-manager"
+        }
+    ]
+}

--- a/tests/transcend.spec.ts
+++ b/tests/transcend.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('transcend', ['https://www.verizon.com/support/account-pin-faqs/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL:

## Description:

Adds an autoconsent rule for the Transcend Consent Manager popup at https://www.verizon.com/support/account-pin-faqs/.

The popup is rendered as `#transcend-consent-manager` (a host element with a closed shadow root containing the dialog `#consentManagerMainDialog`). The dialog only has a single "Close" button — no reject/decline option — so this is implemented as a cosmetic rule that hides the host element. Hiding it does not break page scrolling (no scroll-lock class or inline overflow on `body`/`html`).

For `optIn`, the rule pierces the shadow DOM via an array selector to click the dialog's "Close" button.

## Steps to test this PR:

```bash
npm ci
npm run prepublish
npx playwright test tests/transcend.spec.ts --project chrome
```

Both opt-out and opt-in pass locally on Chrome.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bef3fb37-a7fd-4d09-bfd0-e8d0568f0229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bef3fb37-a7fd-4d09-bfd0-e8d0568f0229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

