### PR TITLE
Add autoconsent rule for alaskaair.com

### DIFF
--- a/rules/autoconsent/alaskaair.com.json
+++ b/rules/autoconsent/alaskaair.com.json
@@ -1,0 +1,34 @@
+{
+    "name": "alaskaair.com",
+    "vendorUrl": "https://www.alaskaair.com/",
+    "comment": "Alaska Airlines uses CookieConsent v3 (orestbida) configured with no categories - only a single 'Dismiss' button. The generic cookieconsent3 rule does not apply because there is no [data-role=necessary] reject button.",
+    "runContext": {
+        "urlPattern": "^https://(www\\.)?alaskaair\\.com/"
+    },
+    "prehideSelectors": ["#cc-main"],
+    "detectCmp": [
+        {
+            "exists": "#cc-main .cm__btn[data-role=all]"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#cc-main .cm"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "#cc-main .cm__btn[data-role=all]"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "#cc-main .cm__btn[data-role=all]"
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "cc_cookie="
+        }
+    ]
+}

--- a/tests/alaskaair.com.spec.ts
+++ b/tests/alaskaair.com.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('alaskaair.com', ['https://www.alaskaair.com/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a site-specific autoconsent rule for the cookie consent popup on https://www.alaskaair.com/.

## Summary

Alaska Airlines uses CookieConsent v3 (orestbida) for its cookie banner, but configures it with **no categories** — the only available action is a single "Dismiss" button (`[data-role=all]`). This means the existing generic `cookieconsent3` rule does not work on this site, because that rule clicks `[data-role=necessary]` (a reject-only button) which doesn't exist here.

The new site-specific rule (`alaskaair.com`) takes priority over the generic `cookieconsent3` rule (site-specific rules are run first by `findCmp`) and clicks the only available "Dismiss" button. This dismisses the banner and stores the consent state in the `cc_cookie` cookie.

Since the popup has no real reject option, the `optIn` and `optOut` flows both click "Dismiss" — there is nothing else to opt into or out of in the UI.

## Why not cosmetic?

The popup has a button that, when clicked, sets the consent cookie and removes the banner without any user-visible side effects (no scroll lock, no overlays). A click-based rule is preferable to a cosmetic hide because it persists the dismissal across page loads via the `cc_cookie`.

## Files

- `rules/autoconsent/alaskaair.com.json` — the new rule
- `tests/alaskaair.com.spec.ts` — Playwright test spec

## Verification

- `npm run lint` passes (ESLint, Prettier, JSON schema validation).
- `npm run prepublish` builds successfully.
- Manually verified the selectors against https://www.alaskaair.com/ in a real browser session:
  - `#cc-main .cm__btn[data-role=all]` exists (detectCmp).
  - `#cc-main .cm` is visible at the bottom of the viewport (detectPopup).
  - Clicking the button sets the `cc_cookie` cookie and slides the banner off-screen.

## Note on Playwright tests

The Playwright test for this rule fails the same way the existing `cookieconsent3` test fails: CookieConsent v3 has `hideFromBots: true` enabled, which detects `navigator.webdriver` and refuses to render the banner inside automated browsers. This is a known limitation of the upstream library and is not specific to this rule. In real browsers (and inside the DuckDuckGo extension where `navigator.webdriver` is `false`), the banner renders normally and the rule operates correctly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f8b5713-2c55-4ccf-bc5e-627671ef5aea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f8b5713-2c55-4ccf-bc5e-627671ef5aea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

