### PR TITLE
Add autoconsent rule for HubSpot cookie banner

### DIFF
--- a/rules/autoconsent/hubspot.json
+++ b/rules/autoconsent/hubspot.json
@@ -1,0 +1,7 @@
+{
+    "name": "hubspot",
+    "detectCmp": [{ "exists": "#hs-eu-cookie-confirmation" }],
+    "detectPopup": [{ "visible": "#hs-eu-cookie-confirmation" }],
+    "optIn": [{ "click": "#hs-eu-confirmation-button" }],
+    "optOut": [{ "click": "#hs-eu-decline-button" }]
+}

--- a/tests/hubspot.spec.ts
+++ b/tests/hubspot.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('hubspot', ['https://blog.hubspot.com/', 'https://www.hubspot.de/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL:

## Description:

Adds an autoconsent rule for the HubSpot cookie consent banner that appears on `blog.hubspot.com` and other HubSpot-managed properties.

The banner is rendered by HubSpot's compliance script (`https://www.hubspot.com/wt-assets/static-files/compliance/index.js`) and uses stable IDs:

- `#hs-eu-cookie-confirmation` — banner container (used for `detectCmp` / `detectPopup`)
- `#hs-eu-confirmation-button` — accept-all button (used for `optIn`)
- `#hs-eu-decline-button` — decline-all button (used for `optOut`)

These selectors are present and unchanged in the live compliance bundle, so a one-click rule covers the popup without needing prehide CSS or a `test` step.

## Steps to test this PR:

1. `npm run build-rules`
2. `npm run rule-syntax-check`
3. `npm run lint`
4. `npm run test:lib`
5. `npx playwright test tests/hubspot.spec.ts`
6. Load the extension (`dist/addon-mv3/`) in a browser and visit https://blog.hubspot.com/ from an EU region — the cookie banner should be auto-declined.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8de045f-fa85-46b4-aa2f-8dae86fd8d31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8de045f-fa85-46b4-aa2f-8dae86fd8d31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

