### PR TITLE
Add transcend CMP rule for verizon.com cookie banner

### DIFF
--- a/rules/autoconsent/transcend.json
+++ b/rules/autoconsent/transcend.json
@@ -1,0 +1,28 @@
+{
+    "name": "transcend",
+    "vendorUrl": "https://transcend.io/",
+    "cosmetic": true,
+    "minimumRuleStepVersion": 2,
+    "prehideSelectors": ["#transcend-consent-manager"],
+    "detectCmp": [
+        {
+            "exists": "#transcend-consent-manager"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#transcend-consent-manager"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": ["#transcend-consent-manager", "#consentManagerMainDialog .inner-container button"]
+        }
+    ],
+    "optOut": [
+        {
+            "setStyle": "display: none !important; z-index: -1 !important; pointer-events: none !important;",
+            "selector": "#transcend-consent-manager"
+        }
+    ]
+}

--- a/tests/transcend.spec.ts
+++ b/tests/transcend.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('transcend', ['https://www.verizon.com/support/account-pin-faqs/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new generic `transcend` CMP rule covering the cookie consent popup at https://www.verizon.com/support/account-pin-faqs/ and other sites using Transcend's Consent Manager.

## Identification

The popup at the requested URL is rendered inside a shadow root attached to `#transcend-consent-manager`, with the inner dialog id `consentManagerMainDialog` and a "Powered by Transcend" footer link to https://transcend.io/. Transcend is a widely deployed CMP (~700 sites in `data/coverage.json`), so a generic rule is preferable to a site-specific one.

## Rule design

In the US region the popup only exposes a "Close" button — there is no reject/refuse option in the DOM. As required by the rule guidelines, this means the rule must be cosmetic. Mirroring the pattern used for similar shadow-DOM cosmetic rules:

- `prehideSelectors` / `detectCmp` / `detectPopup` target `#transcend-consent-manager` (the host element, which uses `position: fixed` so visibility detection works).
- `optIn` clicks the dialog button via a shadow-piercing array selector.
- `optOut` uses `setStyle` on the host with `display: none !important; z-index: -1 !important; pointer-events: none !important;` — `minimumRuleStepVersion: 2` is set accordingly.

## Verification

- `npm run build-rules` ✓
- `npm run rule-syntax-check` ✓
- `npm run lint` ✓
- `npm run test:lib` ✓ (2946 passed)
- `npx playwright test --project=chrome -- tests/transcend.spec.ts` ✓ (optIn + optOut both pass against verizon.com)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce97b783-1911-47a4-a24c-2e249d59344e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce97b783-1911-47a4-a24c-2e249d59344e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

