### PR TITLE
Add ring CMP rule

### DIFF
--- a/rules/autoconsent/ring.json
+++ b/rules/autoconsent/ring.json
@@ -1,0 +1,41 @@
+{
+    "name": "ring",
+    "vendorUrl": "https://ring.com",
+    "prehideSelectors": [".consent-banner"],
+    "detectCmp": [
+        {
+            "exists": ".consent-banner .consent-banner-copy"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": ".consent-banner .consent-banner-copy"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": ".consent-banner .consent--accept"
+        }
+    ],
+    "optOut": [
+        {
+            "if": { "exists": ".consent-banner .consent--reject" },
+            "then": [{ "waitForThenClick": ".consent-banner .consent--reject" }],
+            "else": [
+                { "waitForThenClick": ".consent-banner .consent--manage" },
+                { "waitForVisible": ".consent-modal .consent-bucket" },
+                {
+                    "click": ".consent-modal input[type=checkbox]:checked",
+                    "all": true,
+                    "optional": true
+                },
+                { "waitForThenClick": ".consent-modal .consent-save" }
+            ]
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "privacy-banner-clicked"
+        }
+    ]
+}

--- a/tests/ring.spec.ts
+++ b/tests/ring.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('ring', ['https://nl-nl.ring.com/', 'https://community.ring.com/', 'https://ring.com/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL:

## Description:

Adds an autoconsent rule for the cookie consent popup served by Ring's custom consent manager (`consent-manager-*.js` from `d39xvdj9d5ntm1.cloudfront.net`). The banner is rendered with stable `.consent-banner` / `.consent-modal` class names across regions.

- In GDPR regions (`region=EU`) the banner exposes a direct `.consent--reject` button — `optOut` clicks it.
- Elsewhere the banner only offers Accept and Manage, so the rule falls back to opening the modal (`.consent--manage`), unchecking every active bucket checkbox, and clicking `.consent-save`.
- `optIn` clicks the `.consent--accept` button.
- The selfTest checks for the `privacy-banner-clicked` cookie that the consent manager writes after either action.

`prehideSelectors` is narrowed to `.consent-banner` to avoid prehiding the modal we later need to interact with.

## Steps to test this PR:

```
npm run build-rules
npm run rule-syntax-check
npm run lint
npm run test:lib
npx playwright test tests/ring.spec.ts --project=chrome
```

All 6 chrome tests (optIn / optOut for `nl-nl.ring.com`, `community.ring.com`, `ring.com`) pass locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffbf9839-7edf-4a25-bb41-cc783a5f162b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffbf9839-7edf-4a25-bb41-cc783a5f162b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

