### PR TITLE
Add americangreetings cookie consent rule

### DIFF
--- a/rules/autoconsent/americangreetings.json
+++ b/rules/autoconsent/americangreetings.json
@@ -1,0 +1,19 @@
+{
+    "name": "americangreetings",
+    "vendorUrl": "https://www.americangreetings.com/",
+    "runContext": {
+        "urlPattern": "^https?://(www\\.)?(americangreetings|jacquielawson|bluemountain)\\.com/"
+    },
+    "prehideSelectors": ["#__tealiumGDPRecModal", "#privacy_manager.privacy_prompt"],
+    "detectCmp": [{ "exists": "#privacy_manager.privacy_prompt" }],
+    "detectPopup": [{ "visible": "#privacy_manager.privacy_prompt #accept_cookies" }],
+    "optIn": [{ "waitForThenClick": "#privacy_manager.privacy_prompt #accept_cookies" }],
+    "optOut": [
+        {
+            "if": { "exists": "#privacy_manager.privacy_prompt #decline_cookies" },
+            "then": [{ "waitForThenClick": "#privacy_manager.privacy_prompt #decline_cookies" }],
+            "else": [{ "hide": "#__tealiumGDPRecModal, #privacy_manager.privacy_prompt" }]
+        }
+    ],
+    "test": [{ "visible": "#__tealiumGDPRecModal, #privacy_manager.privacy_prompt", "check": "none" }]
+}

--- a/tests/americangreetings.spec.ts
+++ b/tests/americangreetings.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('americangreetings', ['https://www.americangreetings.com/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an autoconsent rule for the cookie consent popup on https://www.americangreetings.com/.

## CMP investigation

The popup is rendered by an inline script (`#__tealiumGDPRecScript`) that injects an `#__tealiumGDPRecModal` wrapper containing `<div id="privacy_manager" class="privacy_prompt explicit_consent">`. The script is shared across three sister sites — americangreetings.com, jacquielawson.com, bluemountain.com — and explicitly branches on `document.domain.match('jacquielawson')` / `'bluemountain'`. It is custom code that uses `utag.gdpr` (Tealium's GDPR helper) but is not the generic Tealium consent UI, so a site-specific rule scoped to those three domains is the right fit.

The popup logic produces three variants:

- **US (no GPC):** single `Ok` button (`#accept_cookies`) — no reject available.
- **Non-US:** `Accept All` (`#accept_cookies`) + `Decline All` (`#decline_cookies`).
- **GPC honored:** single `Ok` button (`#gpc_button`); consent has already been auto-set to refuse.

## Rule

- `detectCmp` / `detectPopup` look for `#privacy_manager.privacy_prompt`'s accept button.
- `optOut` clicks `#decline_cookies` if it exists (non-US) and otherwise hides the modal (US/GPC where no reject control is offered).
- `optIn` clicks `#accept_cookies`.
- `prehideSelectors` are scoped to the modal containers only.

## Verification

- `npm run rule-syntax-check`
- `npm run build-rules`
- `npm run lint`
- `npm run test:lib` (2946 passed)
- `npm run prepublish`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45d8b6de-cc88-4529-b2fb-844d62e5cb93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45d8b6de-cc88-4529-b2fb-844d62e5cb93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

