### PR TITLE
Add Osano CMP rule for weathertech.com

### DIFF
--- a/rules/autoconsent/osano.json
+++ b/rules/autoconsent/osano.json
@@ -1,0 +1,70 @@
+{
+    "name": "osano",
+    "_metadata": {
+        "vendorUrl": "https://www.osano.com/"
+    },
+    "prehideSelectors": [".osano-cm-window,.osano-cm-dialog"],
+    "detectCmp": [{ "exists": ".osano-cm-window" }],
+    "detectPopup": [
+        {
+            "visible": ".osano-cm-window .osano-cm-button--type_deny,.osano-cm-window .osano-cm-button--type_accept,.osano-cm-window .osano-cm-manage,.osano-cm-window .osano-cm-denyAll,.osano-cm-window .osano-cm-deny,.osano-cm-window .osano-cm-acceptAll,.osano-cm-window .osano-cm-accept,.osano-cm-window .osano-cm-close",
+            "check": "any"
+        }
+    ],
+    "optIn": [
+        {
+            "if": {
+                "exists": ".osano-cm-window .osano-cm-acceptAll,.osano-cm-window .osano-cm-accept,.osano-cm-window .osano-cm-button--type_accept"
+            },
+            "then": [
+                {
+                    "waitForThenClick": ".osano-cm-window .osano-cm-acceptAll,.osano-cm-window .osano-cm-accept,.osano-cm-window .osano-cm-button--type_accept"
+                }
+            ],
+            "else": [
+                {
+                    "if": { "exists": ".osano-cm-window .osano-cm-manage" },
+                    "then": [
+                        { "waitForThenClick": ".osano-cm-window .osano-cm-manage" },
+                        { "waitForThenClick": ".osano-cm-window .osano-cm-save" }
+                    ],
+                    "else": [{ "waitForThenClick": ".osano-cm-window .osano-cm-close", "optional": true }]
+                }
+            ]
+        }
+    ],
+    "optOut": [
+        {
+            "if": {
+                "exists": ".osano-cm-window .osano-cm-denyAll,.osano-cm-window .osano-cm-deny,.osano-cm-window .osano-cm-button--type_deny"
+            },
+            "then": [
+                {
+                    "waitForThenClick": ".osano-cm-window .osano-cm-denyAll,.osano-cm-window .osano-cm-deny,.osano-cm-window .osano-cm-button--type_deny"
+                }
+            ],
+            "else": [
+                {
+                    "if": { "exists": ".osano-cm-window .osano-cm-manage" },
+                    "then": [
+                        { "waitForThenClick": ".osano-cm-window .osano-cm-manage" },
+                        { "waitForVisible": ".osano-cm-window .osano-cm-toggle__input,.osano-cm-window .osano-cm-save", "check": "any" },
+                        {
+                            "click": ".osano-cm-window .osano-cm-toggle__input.osano-cm-input--checked:not(.osano-cm-input--disabled)",
+                            "all": true,
+                            "optional": true
+                        },
+                        { "waitForThenClick": ".osano-cm-window .osano-cm-save" }
+                    ],
+                    "else": [{ "hide": ".osano-cm-window,.osano-cm-dialog" }]
+                }
+            ]
+        }
+    ],
+    "test": [
+        {
+            "visible": ".osano-cm-window .osano-cm-dialog:not(.osano-cm-dialog--hidden)",
+            "check": "none"
+        }
+    ]
+}

--- a/tests/osano.spec.ts
+++ b/tests/osano.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('osano', ['https://www.weathertech.com/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL:

## Description:

WeatherTech (`https://www.weathertech.com/`) shows a cookie consent bar served by [Osano](https://www.osano.com/) (`cmp.osano.com/.../osano.js`, `.osano-cm-window`/`.osano-cm-dialog` markup, `osano_consentmanager` cookie). The branch had no `osano` rule, so no CMP was detected on this site.

This PR adds a generic Osano CMP rule (`rules/autoconsent/osano.json`) plus a Playwright spec (`tests/osano.spec.ts`) targeting `weathertech.com`. The rule covers three popup variants:

1. **Direct deny** — click `.osano-cm-denyAll` / `.osano-cm-deny` / `.osano-cm-button--type_deny` if present.
2. **Manage Preferences flow** (WeatherTech variant) — click `.osano-cm-manage`, wait for the drawer, click every `.osano-cm-toggle__input.osano-cm-input--checked:not(.osano-cm-input--disabled)` to uncheck enabled categories, then click `.osano-cm-save`.
3. **Close-only fallback** — hide `.osano-cm-window,.osano-cm-dialog` cosmetically.

Opt-in mirrors the structure (accept-all → manage+save → close). The self-test asserts the dialog ends up with `osano-cm-dialog--hidden`. All selectors are scoped to `.osano-cm-window` to avoid colliding with site-defined Osano-prefixed widgets.

## Steps to test this PR:

```
npm ci
npm run prepublish
npx playwright test tests/osano.spec.ts --project chrome
```

Expected: `cmpDetected`, `popupFound`, `optOutResult: true`, `selfTestResult: true` for `weathertech.com` on both opt-in and opt-out runs.

Local verification on this branch:
- `npm run lint` — pass
- `npm run test:lib` — 2946 passed
- `npm run rule-syntax-check` — pass
- `npx playwright test tests/osano.spec.ts --project chrome` — opt-in + opt-out + selfTest all pass on `weathertech.com`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77726667-a23d-455c-99de-34f2eacfb1ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77726667-a23d-455c-99de-34f2eacfb1ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

