### PR TITLE
Add autoconsent rule for HubSpot cookie banner

### DIFF
--- a/rules/autoconsent/hubspot.json
+++ b/rules/autoconsent/hubspot.json
@@ -1,0 +1,9 @@
+{
+    "name": "hubspot",
+    "prehideSelectors": ["#hs-eu-cookie-confirmation"],
+    "detectCmp": [{ "exists": "#hs-eu-cookie-confirmation" }],
+    "detectPopup": [{ "visible": "#hs-eu-cookie-confirmation" }],
+    "optIn": [{ "waitForThenClick": "#hs-eu-confirmation-button" }],
+    "optOut": [{ "waitForThenClick": "#hs-eu-decline-button" }],
+    "test": [{ "cookieContains": "__hs_cookie_cat_pref=1:false" }]
+}

--- a/tests/hubspot.spec.ts
+++ b/tests/hubspot.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('hubspot', ['https://blog.hubspot.com/', 'https://www.hubspot.com/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL:

## Description:

Adds a generic CMP rule for HubSpot's first-party cookie consent banner.

The popup appears on `blog.hubspot.com`, `www.hubspot.com`, and many other HubSpot-hosted properties. It's served by HubSpot's compliance script (`https://www.hubspot.com/wt-assets/static-files/compliance/index.js`) and uses a stable set of IDs (`#hs-eu-cookie-confirmation`, `#hs-eu-confirmation-button`, `#hs-eu-decline-button`), so a single CMP-style rule covers all sites that load it. After clicking "Decline all", the cookie `__hs_cookie_cat_pref=1:false_2:false_3:false` is set on `.hubspot.com`, which the rule uses for self-test.

## Steps to test this PR:

1. `npm run build-rules`
2. `npm run rule-syntax-check`
3. `npm run test:lib`
4. `npx playwright test tests/hubspot.spec.ts --project chrome` — should pass on `blog.hubspot.com` and `www.hubspot.com` (optIn + optOut + selfTest).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-476a2fc1-6642-4274-87f8-bfcad1ebf1e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-476a2fc1-6642-4274-87f8-bfcad1ebf1e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

