### PR TITLE
Add cosmetic rule for americangreetings.com

### DIFF
--- a/rules/autoconsent/americangreetings-com.json
+++ b/rules/autoconsent/americangreetings-com.json
@@ -1,0 +1,12 @@
+{
+    "name": "americangreetings-com",
+    "runContext": {
+        "urlPattern": "^https://(www\\.)?americangreetings\\.com/"
+    },
+    "cosmetic": true,
+    "prehideSelectors": ["#__tealiumGDPRecModal #privacy_manager"],
+    "detectCmp": [{ "exists": "#__tealiumGDPRecModal #privacy_manager .pm-site-americangreetings" }],
+    "detectPopup": [{ "visible": "#__tealiumGDPRecModal #privacy_manager .pm-site-americangreetings" }],
+    "optIn": [{ "waitForThenClick": "#__tealiumGDPRecModal #privacy_manager #accept_cookies" }],
+    "optOut": [{ "hide": "#__tealiumGDPRecModal #privacy_manager" }]
+}

--- a/tests/americangreetings-com.spec.ts
+++ b/tests/americangreetings-com.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('americangreetings-com', ['https://www.americangreetings.com/'], {});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds an autoconsent rule for the cookie consent popup on https://www.americangreetings.com/.

## Background

The popup at americangreetings.com is rendered inside a Tealium-built modal (`#__tealiumGDPRecModal > #privacy_manager.privacy_prompt.explicit_consent`). The dialog text reads:

> "AmericanGreetings.com uses cookies to personalize your experience. Your personal data may be collected in accordance with our privacy policy. To learn more visit our cookies policy page."

The only action button is `#accept_cookies` ("Ok"). There is no reject/decline option.

## Approach

Per the agent guide, popups with no reject button should be handled with a **cosmetic rule** that hides the popup via CSS. After click, the popup just goes to zero size but keeps `display: block`, so a `hide` step is the cleanest opt-out.

- `prehideSelectors` and `optOut` target the inner `#privacy_manager` (scoped under `#__tealiumGDPRecModal`) to avoid hiding any unrelated future Tealium content.
- `detectCmp` / `detectPopup` additionally require the `.pm-site-americangreetings` inner class so this rule only matches the AG-themed Tealium prompt, not the generic Tealium GDPR modal used by other sites already covered by separate generated rules.
- `optIn` clicks the "Ok" button.
- The popup does not lock scrolling and is positioned `fixed`, so no breakage-fix steps are needed after hiding.

## Testing

- `npm run lint` passes (ESLint, Prettier, JSON schema check).
- A Playwright test spec was added at `tests/americangreetings-com.spec.ts`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6f571a9-7cf3-49c7-9e85-11e269d7b32a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6f571a9-7cf3-49c7-9e85-11e269d7b32a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

