### PR TITLE
Add cosmetic autoconsent rule for americangreetings.com

### DIFF
--- a/rules/autoconsent/americangreetings.json
+++ b/rules/autoconsent/americangreetings.json
@@ -1,0 +1,29 @@
+{
+    "name": "americangreetings.com",
+    "vendorUrl": "https://www.americangreetings.com/",
+    "cosmetic": true,
+    "runContext": {
+        "urlPattern": "^https?://(www\\.)?americangreetings\\.com/"
+    },
+    "prehideSelectors": ["#__tealiumGDPRecModal:has(.pm-site-americangreetings)"],
+    "detectCmp": [
+        {
+            "exists": "#__tealiumGDPRecModal #privacy_manager .pm-site-americangreetings"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#__tealiumGDPRecModal #privacy_manager .pm-site-americangreetings"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "#__tealiumGDPRecModal #privacy_manager #accept_cookies"
+        }
+    ],
+    "optOut": [
+        {
+            "hide": "#__tealiumGDPRecModal:has(.pm-site-americangreetings)"
+        }
+    ]
+}

--- a/tests/americangreetings.spec.ts
+++ b/tests/americangreetings.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('americangreetings.com', ['https://www.americangreetings.com/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a new cosmetic autoconsent rule for the cookie consent popup on https://www.americangreetings.com/.

## Why cosmetic?

The popup, served by a Tealium-based consent prompt customised for AmericanGreetings (markup `#__tealiumGDPRecModal > #privacy_manager.privacy_prompt > .pm-inner.pm-site-americangreetings`), only exposes a single **"Ok"** accept button (`#accept_cookies`). There is no reject / decline / manage option, so the rule hides the popup via CSS instead of attempting to opt out through a click.

## Rule

- `prehideSelectors` / `optOut` `hide`: `#__tealiumGDPRecModal:has(.pm-site-americangreetings)` — scoped to the AmericanGreetings-customised variant so it won't accidentally hide other Tealium consent prompts on sister sites (Blue Mountain, Jacquie Lawson, etc.).
- `optIn`: clicks the `#accept_cookies` "Ok" button.
- The page does not lock scroll or add an overlay, so no extra cosmetic-breakage fixes are needed.

## Verification

- `npm run build-rules`
- `npm run rule-syntax-check`
- `npm run lint-fix`
- `npm run test:lib` (all unit tests pass)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81af0802-9275-4256-833d-b17c2cf655da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81af0802-9275-4256-833d-b17c2cf655da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

