### PR TITLE
Add hubspot autoconsent rule

### DIFF
--- a/rules/autoconsent/hubspot.json
+++ b/rules/autoconsent/hubspot.json
@@ -1,0 +1,40 @@
+{
+    "name": "hubspot",
+    "_metadata": {
+        "vendorUrl": "https://www.hubspot.com/data-privacy/cookies"
+    },
+    "prehideSelectors": ["#hs-eu-cookie-confirmation", "#hs-banner-parent"],
+    "detectCmp": [
+        {
+            "exists": "#hs-eu-cookie-confirmation"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#hs-eu-cookie-confirmation"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "#hs-eu-confirmation-button"
+        }
+    ],
+    "optOut": [
+        {
+            "if": { "exists": "#hs-eu-decline-button" },
+            "then": [{ "waitForThenClick": "#hs-eu-decline-button" }],
+            "else": [
+                {
+                    "if": { "exists": "#hs-eu-cookie-settings-button" },
+                    "then": [{ "waitForThenClick": "#hs-eu-cookie-settings-button" }, { "waitForThenClick": "#hs-modal-decline-all" }],
+                    "else": [{ "waitForThenClick": "#hs-eu-close-button" }]
+                }
+            ]
+        }
+    ],
+    "test": [
+        {
+            "any": [{ "cookieContains": "__hs_cookie_cat_pref" }, { "cookieContains": "__hs_opt_out" }]
+        }
+    ]
+}

--- a/tests/hubspot.spec.ts
+++ b/tests/hubspot.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('hubspot', ['https://blog.hubspot.com/', 'https://www.hubspot.com/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a generic autoconsent rule for HubSpot's privacy banner (`https://js.hs-banner.com/v2/.../banner.js`), which is used on `blog.hubspot.com` and many other sites built on HubSpot.

### Selectors

The rule uses the stable IDs that HubSpot's banner script renders:

- Container: `#hs-eu-cookie-confirmation` (inside `#hs-banner-parent`)
- Reject all: `#hs-eu-decline-button` (rendered for `OPT_IN`/`OPT_OUT`/`OPT_OUT_BY_CATEGORY`/`COOKIES_BY_CATEGORY` policy types)
- Accept all: `#hs-eu-confirmation-button`
- Cookie settings: `#hs-eu-cookie-settings-button` → modal with `#hs-modal-decline-all`
- Close: `#hs-eu-close-button` (last-resort fallback)

### Opt-out flow

1. Click `#hs-eu-decline-button` if present (the standard reject-all button).
2. Otherwise, if the banner only exposes a settings button (e.g., `OPT_OUT_BY_CATEGORY` without a top-level decline label), open the modal and click `#hs-modal-decline-all`.
3. Otherwise (notify-only banners with no reject path), dismiss via the close button.

### Test signal

HubSpot stores consent in the `__hs_cookie_cat_pref` cookie (with `__hs_opt_out` retained as a legacy fallback), so the `test` step looks for either of those names.

### Tests

Added `tests/hubspot.spec.ts` with `https://blog.hubspot.com/` and `https://www.hubspot.com/` as example URLs. `data/coverage.json` already has hundreds of additional HubSpot-banner sites under the `hubspot` CMP key.

`npm run lint` and `npm run test:lib` pass locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-704458bd-a168-4d5f-96bb-9698577e6e3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-704458bd-a168-4d5f-96bb-9698577e6e3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

