### PR TITLE
Add weathertech.com Osano CMP rule

### DIFF
--- a/rules/autoconsent/weathertech-com.json
+++ b/rules/autoconsent/weathertech-com.json
@@ -1,0 +1,27 @@
+{
+    "name": "weathertech.com",
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?weathertech\\."
+    },
+    "prehideSelectors": [".osano-cm-window"],
+    "detectCmp": [{ "exists": ".osano-cm-window .osano-cm-dialog" }],
+    "detectPopup": [{ "visible": ".osano-cm-window .osano-cm-dialog" }],
+    "optIn": [{ "waitForThenClick": ".osano-cm-window .osano-cm-manage" }, { "waitForThenClick": ".osano-cm-info .osano-cm-save" }],
+    "optOut": [
+        { "waitForThenClick": ".osano-cm-window .osano-cm-manage" },
+        { "waitForVisible": ".osano-cm-info" },
+        {
+            "click": ".osano-cm-info input.osano-cm-input--checked:not(.osano-cm-input--disabled)",
+            "all": true,
+            "optional": true
+        },
+        {
+            "click": ".osano-cm-info input#osano-cm-drawer-toggle--category_OPT_OUT:not(.osano-cm-input--checked)",
+            "optional": true
+        },
+        { "waitForThenClick": ".osano-cm-info .osano-cm-save" }
+    ],
+    "test": [{ "exists": ".osano-cm-window .osano-cm-dialog--hidden" }]
+}

--- a/tests/weathertech-com.spec.ts
+++ b/tests/weathertech-com.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('weathertech.com', ['https://www.weathertech.com/'], {
+    skipRegions: ['US'],
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL:

## Description:

Adds an autoconsent rule for the cookie consent popup on https://www.weathertech.com/.

The site uses an Osano-branded CMP rendered as `.osano-cm-window` / `.osano-cm-dialog`. The default banner does not expose a "Reject all" button — only "Manage Preferences". The opt-out flow:

1. Click `.osano-cm-window .osano-cm-manage` to open the Storage Preferences drawer.
2. Wait for the `.osano-cm-info` drawer to be visible.
3. Uncheck every enabled, non-disabled toggle (`input.osano-cm-input--checked:not(.osano-cm-input--disabled)`). This leaves the disabled "Essential" category checked.
4. Enable the "Do Not Sell or Share My Personal Information" toggle (`#osano-cm-drawer-toggle--category_OPT_OUT`) when present and not already on.
5. Click `.osano-cm-info .osano-cm-save` to persist preferences.

After save, Osano adds the `osano-cm-dialog--hidden` class to the dialog, which is what `test` checks for.

The rule is scoped via `runContext.urlPattern` to `weathertech.*` so the generic-looking selectors do not accidentally match other Osano-using sites that already work via existing rules or filterlist entries.

## Steps to test this PR:

```bash
npm ci
npm run prepublish
REGION=DE npx playwright test tests/weathertech-com.spec.ts --project chrome
```

Both the `optIn` and `optOut` Playwright tests should pass; the opt-out self-test should also pass (the post-save dialog ends up with the `osano-cm-dialog--hidden` class).

The test spec skips the `US` region because the US-served banner is geo-gated and behaves differently than the GDPR variant the rule targets.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0ebec57-3201-4aeb-8eeb-8a902a7ff67b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0ebec57-3201-4aeb-8eeb-8a902a7ff67b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

