### PR TITLE
Add verizon.com cosmetic autoconsent rule

### DIFF
--- a/rules/autoconsent/verizon-com.json
+++ b/rules/autoconsent/verizon-com.json
@@ -1,0 +1,29 @@
+{
+    "name": "verizon.com",
+    "vendorUrl": "https://www.verizon.com/",
+    "cosmetic": true,
+    "runContext": {
+        "urlPattern": "^https://(www\\.)?verizon\\.com/"
+    },
+    "prehideSelectors": ["#transcend-consent-manager"],
+    "detectCmp": [
+        {
+            "exists": ["#transcend-consent-manager", "#consentManagerMainDialog"]
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": ["#transcend-consent-manager", "#consentManagerMainDialog"]
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": ["#transcend-consent-manager", "#consentManagerMainDialog button.button"]
+        }
+    ],
+    "optOut": [
+        {
+            "hide": "#transcend-consent-manager"
+        }
+    ]
+}

--- a/tests/verizon-com.spec.ts
+++ b/tests/verizon-com.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('verizon.com', ['https://www.verizon.com/support/account-pin-faqs/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL:

## Description:

Adds a new `verizon.com` rule covering the cookie consent banner shown on Verizon support pages such as https://www.verizon.com/support/account-pin-faqs/.

The banner is rendered inside the open shadow root of `#transcend-consent-manager` (Verizon's Transcend-based consent manager build). In the US it only exposes a single "Close" button — there is no Reject/Decline action — so the rule is `cosmetic` and uses a `hide` step on the host element. The shadow-piercing array selector `["#transcend-consent-manager", "#consentManagerMainDialog"]` is used for `detectCmp` / `detectPopup`, and `optIn` clicks the Close button inside the shadow root.

## Steps to test this PR:

- `npm run build-rules`
- `npm run rule-syntax-check`
- `npm run lint`
- `npm run test:lib`
- `npx playwright test tests/verizon-com.spec.ts --project=chrome`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-489d1eac-2c59-4377-bb5f-23e96af5b8b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-489d1eac-2c59-4377-bb5f-23e96af5b8b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

