### PR TITLE
Add autoconsent rule for ring.com

### DIFF
--- a/rules/autoconsent/ring-com.json
+++ b/rules/autoconsent/ring-com.json
@@ -1,0 +1,30 @@
+{
+    "name": "ring.com",
+    "_metadata": {
+        "vendorUrl": "https://ring.com/"
+    },
+    "runContext": {
+        "urlPattern": "^https?://([\\w-]+\\.)?ring\\.com/"
+    },
+    "prehideSelectors": [".consent-banner"],
+    "detectCmp": [{ "exists": ".consent-banner" }],
+    "detectPopup": [{ "visible": ".consent-banner" }],
+    "optIn": [{ "waitForThenClick": ".consent-banner button.consent--accept" }],
+    "optOut": [
+        {
+            "if": { "exists": ".consent-banner button.consent--reject" },
+            "then": [{ "waitForThenClick": ".consent-banner button.consent--reject" }],
+            "else": [
+                { "waitForThenClick": ".consent-banner button.consent--manage" },
+                { "waitForVisible": ".consent-modal .consent-bucket" },
+                {
+                    "click": ".consent-modal .consent-bucket:not([data-bucket=\"essential\"]) .third-party.active .check-icon",
+                    "all": true,
+                    "optional": true
+                },
+                { "waitForThenClick": ".consent-modal .consent-save" }
+            ]
+        }
+    ],
+    "test": [{ "cookieContains": "privacy-banner-clicked=true" }]
+}

--- a/tests/ring-com.spec.ts
+++ b/tests/ring-com.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('ring.com', ['https://ring.com/', 'https://en-uk.ring.com/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a site-specific autoconsent rule for `ring.com` (and country sub-sites such as `en-uk.ring.com`).

## CMP

Ring uses a custom in-house consent manager loaded from
`d39xvdj9d5ntm1.cloudfront.net/common/.../consent-manager*.js`. The banner DOM is
identifiable by the `.consent-banner` container, with buttons:

- `button.consent--accept` – accept all
- `button.consent--reject` – reject all (only rendered in EU/GDPR variant)
- `button.consent--manage` – open settings modal

In the US (and other non-GDPR regions) the banner only shows "Got it" + "Manage Settings",
so opt-out has to go through the modal: open settings, toggle off the per-third-party
`.check-icon` rows in non-essential buckets, then click `.consent-save`.

The CMP writes a `privacy-banner-clicked=true` cookie on any decision (accept, reject, or
save), used as the self-test signal.

## Rule flow

- `prehideSelectors` / `detectCmp` / `detectPopup` use `.consent-banner`.
- `optIn` clicks `button.consent--accept`.
- `optOut`:
  - If a `button.consent--reject` is present (GDPR), click it.
  - Otherwise open the manage modal, click each `.third-party.active .check-icon`
    inside non-essential `.consent-bucket` rows (optional, in case the modal arrives
    pre-toggled-off), then click `.consent-save`.
- `runContext.urlPattern` scopes the rule to `*.ring.com`.

## Verification

- `npm run rule-syntax-check` – passed
- `npm run build-rules` – passed
- `npm run test:lib` – 2946 passed
- `npm run lint-fix` – clean
- `npx playwright test --project=chrome tests/ring-com.spec.ts` – all 4 tests passed
  (US + UK, optIn + optOut, with `selfTestResult: true`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae85dc44-2de3-43c0-a75a-92498d96bcf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae85dc44-2de3-43c0-a75a-92498d96bcf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

