### PR TITLE
Add autoconsent rule for alaskaair.com

### DIFF
--- a/rules/autoconsent/alaskaair.json
+++ b/rules/autoconsent/alaskaair.json
@@ -1,0 +1,34 @@
+{
+    "name": "alaskaair.com",
+    "_metadata": {
+        "vendorUrl": "https://www.alaskaair.com/"
+    },
+    "cosmetic": true,
+    "comment": "alaskaair.com uses orestbida cookieconsent v3 with only a single 'Dismiss' button (no reject option), so we hide the banner cosmetically. Site-specific overrides the generic cookieconsent3 rule, which would otherwise look for a non-existent [data-role=necessary] button.",
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https://(www\\.)?alaskaair\\.com/"
+    },
+    "prehideSelectors": ["#cc-main"],
+    "detectCmp": [
+        {
+            "exists": "#cc-main"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#cc-main .cm-wrapper"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "#cc-main .cm__btn[data-role=all]"
+        }
+    ],
+    "optOut": [
+        {
+            "hide": "#cc-main"
+        }
+    ]
+}

--- a/tests/alaskaair.spec.ts
+++ b/tests/alaskaair.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('alaskaair.com', ['https://www.alaskaair.com/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a site-specific autoconsent rule for the cookie notice on https://www.alaskaair.com/.

## Why

Alaska Airlines uses the orestbida `cookieconsent` v3 library (loaded via Tealium from `tags.tiqcdn.com/libs/cookieconsent/v3.1.0/cookieconsent.umd.js`), but configures it as a notice-only banner: a single "Dismiss" button with `data-role="all"` and an empty `categories: {}` map. There is no "Reject" / "Necessary only" option.

This means the existing generic `cookieconsent3` rule (which expects `[data-role=necessary]` for opt-out) cannot opt out of this banner — its `optOut` selector never matches.

## How

- **Cosmetic rule** — per the project guide, popups without a reject option should be hidden via CSS rather than a click.
- `optOut` hides `#cc-main` (the library's wrapper element).
- `optIn` clicks the single Dismiss button (`[data-role=all]`).
- A `urlPattern` (`^https://(www\.)?alaskaair\.com/`) makes the rule site-specific so it is prioritized over the generic `cookieconsent3` rule.
- `prehideSelectors: ["#cc-main"]` prevents flicker.

The library's empty categories config means the popup is purely an informational notice — there are no tracking categories that would have been gated by a reject click anyway, so a cosmetic hide does not change the consent behavior compared to dismissing.

## Verification

- `npm run lint` ✅ (ESLint, Prettier, JSON schema validation)
- Verified the popup structure live in a real browser (Chromium, DE locale): `#cc-main .cm-wrapper` containing a single `<button class="cm__btn" data-role="all"><span>Dismiss</span></button>`.
- Verified `Dismiss` click writes the `cc_cookie` cookie set by the library.

A test spec is added at `tests/alaskaair.spec.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-005ee7f3-510a-4da1-ac88-a718e92d057e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-005ee7f3-510a-4da1-ac88-a718e92d057e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

