### PR TITLE
Add autoconsent rule for ring.com

### DIFF
--- a/rules/autoconsent/ring.com.json
+++ b/rules/autoconsent/ring.com.json
@@ -1,0 +1,34 @@
+{
+    "name": "ring.com",
+    "_metadata": {
+        "vendorUrl": "https://ring.com/"
+    },
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https://([a-z0-9-]+\\.)?ring\\.com/"
+    },
+    "prehideSelectors": [".consent-banner", ".consent-modal"],
+    "detectCmp": [
+        {
+            "exists": "script#consent-script[src*=\"consent-manager\"]"
+        },
+        {
+            "exists": ".consent-banner"
+        }
+    ],
+    "detectPopup": [{ "visible": ".consent-banner" }],
+    "optIn": [{ "waitForThenClick": ".consent-banner .consent--accept" }],
+    "optOut": [
+        {
+            "if": { "exists": ".consent-banner .consent--reject" },
+            "then": [{ "waitForThenClick": ".consent-banner .consent--reject" }],
+            "else": [
+                { "waitForThenClick": ".consent-banner .consent--manage" },
+                { "waitForVisible": ".consent-modal .consent-save" },
+                { "waitForThenClick": ".consent-modal .consent-save" }
+            ]
+        }
+    ],
+    "test": [{ "cookieContains": "privacy-banner-clicked=true" }]
+}

--- a/tests/ring.com.spec.ts
+++ b/tests/ring.com.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('ring.com', ['https://ring.com/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a new JSON rule for the cookie consent popup on https://ring.com/.

## CMP details

Ring uses a custom-built consent manager loaded via `https://d39xvdj9d5ntm1.cloudfront.net/common/js/consent-manager-*.js` (referenced as `script#consent-script`). The script renders:

- A banner with class `.consent-banner` (gets the additional class `.consent-banner--gdpr` in EU regions).
- Buttons inside the banner: `.consent--manage`, `.consent--accept`, and (only in the GDPR variant) `.consent--reject`.
- A settings modal `.consent-modal` containing per-vendor toggles (`.third-party.active`) and a `.consent-save` button.
- After clicking accept/reject/save, the cookie `privacy-banner-clicked=true` is set.

## Rule behaviour

- **detectCmp / detectPopup**: matches when both the consent-manager script and the rendered `.consent-banner` exist and the banner is visible.
- **optIn**: clicks `.consent--accept` on the banner.
- **optOut**:
  - In GDPR regions, clicks the `.consent--reject` button directly.
  - In non-GDPR regions (no reject button on the banner), opens the settings modal via `.consent--manage` and saves with all categories untoggled by clicking `.consent-save` — the modal is initialized with all third parties off, so saving immediately rejects everything.
- **test**: verifies the `privacy-banner-clicked=true` cookie is set.

## Tests

Added `tests/ring.com.spec.ts` covering `https://ring.com/`. `npm run lint` and `npm run rule-syntax-check` pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78fe21c4-a529-453d-912b-1de395e1ae2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78fe21c4-a529-453d-912b-1de395e1ae2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

