### PR TITLE
Add cosmetic rule for alaskaair.com

### DIFF
--- a/rules/autoconsent/alaskaair.com.json
+++ b/rules/autoconsent/alaskaair.com.json
@@ -1,0 +1,30 @@
+{
+    "name": "alaskaair.com",
+    "vendorUrl": "https://www.alaskaair.com/",
+    "comment": "Alaska Air uses the orestbida/cookieconsent v3 library, but configured with only a 'Dismiss' button (no reject option), so the rule must be cosmetic.",
+    "cosmetic": true,
+    "runContext": {
+        "urlPattern": "^https://(www\\.)?alaskaair\\.com/"
+    },
+    "prehideSelectors": ["#cc-main"],
+    "detectCmp": [
+        {
+            "exists": "#cc-main .cm__btn[data-role=all]"
+        }
+    ],
+    "detectPopup": [
+        {
+            "exists": "#cc-main .cm__btn[data-role=all]"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "#cc-main .cm__btn[data-role=all]"
+        }
+    ],
+    "optOut": [
+        {
+            "hide": "#cc-main"
+        }
+    ]
+}

--- a/tests/alaskaair.com.spec.ts
+++ b/tests/alaskaair.com.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('alaskaair.com', ['https://www.alaskaair.com/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL:

## Description:

Adds a site-specific cosmetic rule for the cookie banner on `https://www.alaskaair.com/`.

The site uses the `orestbida/cookieconsent` v3 library (loaded via `tags.tiqcdn.com/libs/cookieconsent/v3.1.0/cookieconsent.umd.js`), but Alaska's configuration renders only a single "Dismiss" button (`.cm__btn[data-role=all]`) and no reject/decline option. Because opt-out and opt-in would click the same element, the rule must be cosmetic and hide the banner via CSS instead of clicking through it.

A site-specific rule is needed because the generic `cookieconsent3` rule expects a `[data-role=necessary]` reject button, which Alaska's configuration does not include. The site-specific `urlPattern` ensures this rule is tried before the generic one.

## Steps to test this PR:

1. `npm run build-rules`
2. `npm run rule-syntax-check`
3. Load `dist/addon-mv3/` as an unpacked extension in Chrome.
4. Visit `https://www.alaskaair.com/` (with cookies cleared).
5. Confirm the bottom cookie consent bar is hidden and the devtools panel reports the `alaskaair.com` rule with `optOutResult: true`.

Note: the upstream CookieConsent library has `hideFromBots: true` enabled in Alaska's config, so the popup does not render under default Playwright automation (where `navigator.webdriver` is `true`). Manual verification with `webdriver` overridden confirms the selectors match and the hide step removes the banner.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6aca2549-e227-4c51-9a89-153ea28db893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6aca2549-e227-4c51-9a89-153ea28db893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

