### PR TITLE
Add Osano CMP rule (covers weathertech.com)

### DIFF
--- a/rules/autoconsent/osano.json
+++ b/rules/autoconsent/osano.json
@@ -1,0 +1,51 @@
+{
+    "name": "osano",
+    "vendorUrl": "https://www.osano.com/",
+    "prehideSelectors": [".osano-cm-window"],
+    "detectCmp": [
+        {
+            "exists": ".osano-cm-dialog .osano-cm-manage,.osano-cm-dialog .osano-cm-buttons__button--type_manage,.osano-cm-dialog .osano-cm-denyAll,.osano-cm-dialog .osano-cm-deny-all,.osano-cm-dialog .osano-cm-deny,.osano-cm-dialog .osano-cm-buttons__button--type_deny"
+        }
+    ],
+    "detectPopup": [{ "visible": ".osano-cm-window .osano-cm-dialog" }],
+    "optIn": [
+        {
+            "if": { "exists": ".osano-cm-accept-all,.osano-cm-accept,.osano-cm-buttons__button--type_accept" },
+            "then": [
+                {
+                    "waitForThenClick": ".osano-cm-accept-all,.osano-cm-accept,.osano-cm-buttons__button--type_accept"
+                }
+            ],
+            "else": [{ "waitForThenClick": ".osano-cm-dialog .osano-cm-dialog__close" }]
+        }
+    ],
+    "optOut": [
+        {
+            "if": { "exists": ".osano-cm-denyAll,.osano-cm-deny-all,.osano-cm-deny,.osano-cm-buttons__button--type_deny" },
+            "then": [
+                {
+                    "waitForThenClick": ".osano-cm-denyAll,.osano-cm-deny-all,.osano-cm-deny,.osano-cm-buttons__button--type_deny"
+                }
+            ],
+            "else": [
+                { "waitForThenClick": ".osano-cm-manage,.osano-cm-buttons__button--type_manage" },
+                { "waitForVisible": ".osano-cm-info-dialog input[type=checkbox]" },
+                {
+                    "click": ".osano-cm-info-dialog input[type=checkbox][id^=\"osano-cm-drawer-toggle--category_\"]:checked:not([disabled]):not([id$=\"_ESSENTIAL\"]):not([id$=\"_OPT_OUT\"])",
+                    "all": true,
+                    "optional": true
+                },
+                {
+                    "click": ".osano-cm-info-dialog input[type=checkbox][id$=\"_OPT_OUT\"]:not(:checked):not([disabled])",
+                    "all": true,
+                    "optional": true
+                },
+                {
+                    "waitForThenClick": ".osano-cm-info-dialog .osano-cm-save,.osano-cm-info-dialog .osano-cm-buttons__button--type_save"
+                }
+            ]
+        },
+        { "waitForVisible": ".osano-cm-dialog:not(.osano-cm-dialog--hidden)", "check": "none" }
+    ],
+    "test": [{ "visible": ".osano-cm-dialog:not(.osano-cm-dialog--hidden)", "check": "none" }]
+}

--- a/tests/osano.spec.ts
+++ b/tests/osano.spec.ts
@@ -1,0 +1,8 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('osano', [
+    'https://www.weathertech.com/',
+    'https://www.bigagnes.com/',
+    'https://www.bobsredmill.com/',
+    'https://www.summithealth.com/',
+]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL:

## Description:

Adds a generic autoconsent rule for the [Osano](https://www.osano.com/) Cookie Consent CMP, originally requested for `https://www.weathertech.com/`.

The Osano CMP is loaded from `cmp.osano.com/.../osano.js` and renders inside `.osano-cm-window`, with an initial dialog (`.osano-cm-dialog`) and a preferences drawer (`.osano-cm-info-dialog`). Class prefixes (`osano-cm-`) are stable across sites.

The rule has two paths:
- **Direct deny** — if the banner exposes a `Deny` / `Deny All` button (`.osano-cm-denyAll`, `.osano-cm-deny-all`, `.osano-cm-deny`, `.osano-cm-buttons__button--type_deny`), click it.
- **Manage drawer** (the path used by weathertech.com) — click `.osano-cm-manage`, uncheck every non-essential, non-OPT_OUT category checkbox (`#osano-cm-drawer-toggle--category_*`), tick the `OPT_OUT` (Do Not Sell) toggle when present, then click Save.

`detectCmp` only matches when a deny or manage button exists, so notice-only Osano variants (e.g. comfortcolors.com) are intentionally skipped — the autoconsent engine cannot opt out of those without losing functionality the user expects.

The `test` step asserts `.osano-cm-dialog:not(.osano-cm-dialog--hidden)` is no longer visible. The hidden state is detected via the `osano-cm-dialog--hidden` class because Osano leaves the dialog as `position: fixed; display: flex; visibility: hidden`, which `isElementVisible` would otherwise treat as visible.

## Steps to test this PR:

1. `npm ci && npm run prepublish`
2. `npm run rule-syntax-check` — passes.
3. `npm run lint` — passes.
4. `npm run test:lib` — 2946 unit tests pass (catches compaction round-trip).
5. `npx playwright test tests/osano.spec.ts --project chrome` — all 8 tests pass (4 sites × optIn + optOut, with selfTest).

Tested sites:
- `https://www.weathertech.com/` (the requested target)
- `https://www.bigagnes.com/`
- `https://www.bobsredmill.com/`
- `https://www.summithealth.com/`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53a8e62d-39f8-4d8c-9330-7dc7225a2de0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53a8e62d-39f8-4d8c-9330-7dc7225a2de0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

