### PR TITLE
Add autoconsent rule for time.com

### DIFF
--- a/rules/autoconsent/time.com.json
+++ b/rules/autoconsent/time.com.json
@@ -1,0 +1,39 @@
+{
+    "name": "time.com",
+    "vendorUrl": "https://time.com/",
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https://(www\\.)?time\\.com/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "xpath///footer//button[contains(., 'Do Not Sell or Share My Personal Information')]"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "xpath///footer//button[contains(., 'Do Not Sell or Share My Personal Information')]"
+        }
+    ],
+    "optIn": [
+        { "waitForThenClick": "xpath///footer//button[contains(., 'Do Not Sell or Share My Personal Information')]" },
+        { "waitFor": "#ketch-preferences" },
+        { "waitForThenClick": "#ketch-preferences-navigation-purposes-tab" },
+        { "waitForThenClick": "#ketch-preferences button[aria-label='Accept All']" },
+        { "waitForThenClick": "#ketch-preferences button[aria-label='Submit']" }
+    ],
+    "optOut": [
+        { "waitForThenClick": "xpath///footer//button[contains(., 'Do Not Sell or Share My Personal Information')]" },
+        { "waitFor": "#ketch-preferences" },
+        { "waitForThenClick": "#ketch-preferences-navigation-purposes-tab" },
+        { "waitForThenClick": "#ketch-preferences button[aria-label='Reject All']" },
+        { "waitForThenClick": "#ketch-preferences button[aria-label='Submit']" }
+    ],
+    "test": [
+        {
+            "cookieContains": "usprivacy=1YYN"
+        }
+    ]
+}

--- a/tests/time.com.spec.ts
+++ b/tests/time.com.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('time.com', ['https://time.com/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds an autoconsent rule for [time.com](https://time.com/).

## Findings

time.com uses the **Ketch** consent management platform but does **not** show a cookie banner automatically — the Ketch experience is `userInitiated` only. Instead, the page renders a "Do Not Sell or Share My Personal Information" button in the site footer that opens the Ketch preferences modal (`#ketch-preferences`).

This rule:

1. Detects the in-page footer button as the CMP signal.
2. Clicks the footer button to open the Ketch preferences modal.
3. Switches to the Preferences tab.
4. Clicks "Reject All" (opt-out) or "Accept All" (opt-in), then "Submit".
5. Verifies the consent decision via the `usprivacy=1YYN` cookie set by the CCPA opt-out (Ketch + Time set this cookie to `1YYN` after Reject + Submit).

## Selector strategy

- Footer trigger: `xpath///footer//button[contains(., 'Do Not Sell or Share My Personal Information')]`. The button has only utility-class CSS, no stable id; using XPath text + footer scope keeps it specific without depending on Tailwind class hashes.
- Modal: `#ketch-preferences` (stable Ketch ID).
- Tab: `#ketch-preferences-navigation-purposes-tab` (stable Ketch ID).
- Action buttons: `#ketch-preferences button[aria-label='Reject All' | 'Accept All' | 'Submit']` (stable Ketch `aria-label`s).

## Test

- `tests/time.com.spec.ts` — runs the standard `generateCMPTests` opt-in / opt-out / self-test suite against `https://time.com/`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e8dffa3-8ef4-404b-9fbf-21d202c0540b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e8dffa3-8ef4-404b-9fbf-21d202c0540b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

