### PR TITLE
Fix Sourcepoint opt-out on carwow.co.uk

### DIFF
--- a/lib/cmps/sourcepoint-frame.ts
+++ b/lib/cmps/sourcepoint-frame.ts
@@ -129,11 +129,11 @@ export default class SourcePoint extends AutoConsentCMPBase {
                 return false;
             }
 
-            // If a one-click reject button (sp_choice_type_13) is present on the initial
-            // notice, prefer it over opening the manage flow. This avoids picking the
-            // wrong element when multiple sp_choice_type_12 buttons coexist on a notice
-            // (e.g. an informational link plus a separate "Manage settings" button), and
-            // also covers the "do not sell" case where only sp_choice_type_13 is present.
+            // If a one-click reject button (sp_choice_type_13) is visible on the notice,
+            // prefer it over opening the manage flow. This avoids picking the wrong
+            // element when multiple sp_choice_type_12 buttons coexist (e.g. an
+            // informational link alongside a "Manage settings" button), and also covers
+            // the CCPA "do not sell" case where sp_choice_type_13 is the only action.
             if (this.elementVisible('.sp_choice_type_13', 'any')) {
                 return await this.click('.sp_choice_type_13');
             }

--- a/lib/cmps/sourcepoint-frame.ts
+++ b/lib/cmps/sourcepoint-frame.ts
@@ -132,13 +132,9 @@ export default class SourcePoint extends AutoConsentCMPBase {
             // If a one-click reject button (sp_choice_type_13) is present on the initial
             // notice, prefer it over opening the manage flow. This avoids picking the
             // wrong element when multiple sp_choice_type_12 buttons coexist on a notice
-            // (e.g. an informational link plus a separate "Manage settings" button).
+            // (e.g. an informational link plus a separate "Manage settings" button), and
+            // also covers the "do not sell" case where only sp_choice_type_13 is present.
             if (this.elementVisible('.sp_choice_type_13', 'any')) {
-                return await this.click('.sp_choice_type_13');
-            }
-
-            if (!this.elementExists(manageSelector)) {
-                // do not sell button
                 return await this.click('.sp_choice_type_13');
             }
 

--- a/lib/cmps/sourcepoint-frame.ts
+++ b/lib/cmps/sourcepoint-frame.ts
@@ -129,6 +129,14 @@ export default class SourcePoint extends AutoConsentCMPBase {
                 return false;
             }
 
+            // If a one-click reject button (sp_choice_type_13) is present on the initial
+            // notice, prefer it over opening the manage flow. This avoids picking the
+            // wrong element when multiple sp_choice_type_12 buttons coexist on a notice
+            // (e.g. an informational link plus a separate "Manage settings" button).
+            if (this.elementVisible('.sp_choice_type_13', 'any')) {
+                return await this.click('.sp_choice_type_13');
+            }
+
             if (!this.elementExists(manageSelector)) {
                 // do not sell button
                 return await this.click('.sp_choice_type_13');

--- a/tests/sourcepoint.spec.ts
+++ b/tests/sourcepoint.spec.ts
@@ -1,6 +1,11 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('Sourcepoint-frame', ['https://www.theguardian.com/', 'https://news.sky.com/', 'https://www.economist.com/']);
+generateCMPTests('Sourcepoint-frame', [
+    'https://www.theguardian.com/',
+    'https://news.sky.com/',
+    'https://www.economist.com/',
+    'https://www.carwow.co.uk/',
+]);
 
 generateCMPTests(
     'Sourcepoint-frame',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1214136953699918?focus=true

## Description:

The Sourcepoint cookie notice on https://www.carwow.co.uk/ renders two buttons with the `sp_choice_type_12` class on the initial notice — an informational "What we track using cookies >" link and a separate "Manage settings" button — plus a direct one-click reject button "Essential cookies only" with the `sp_choice_type_13` class.

The current `SourcePoint` code-based CMP prefers the manage flow via `sp_choice_type_12`, but `this.click('.sp_choice_type_12')` picks the first match — which on this page is the "What we track" info button rather than "Manage settings". Opt-out therefore never progressed past the initial notice and the popup stayed visible. The existing `sp_choice_type_13` branch was only reached as a fallback when no `sp_choice_type_12` existed at all.

This change prefers the direct `sp_choice_type_13` reject button when it is visible on the current notice. That button performs a single-step reject, so we don't need to open the privacy-manager dialog at all on sites that expose it. Sites that don't render a visible `sp_choice_type_13` on the initial notice keep their existing manage flow.

## Steps to test this PR:

1. From a GDPR region (GB / DE / NL / FR), load https://www.carwow.co.uk/ with autoconsent's opt-out action enabled.
2. Verify the Sourcepoint cookie popup is dismissed and `optOutResult: true`.
3. Also verify existing Sourcepoint sites (e.g. https://www.theguardian.com/, https://news.sky.com/, https://www.economist.com/) still work as before.

Verified with BrightData across GB, DE, FR, NL — all PASS after the fix (NL previously failed with `ACTION FAILED`).

[carwow.co.uk clean after opt-out from NL](https://cursor.com/agents/bc-c62e024b-7972-4222-82d7-fd324b4b3b9b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcarwow_nl_after_fix.jpg)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c62e024b-7972-4222-82d7-fd324b4b3b9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c62e024b-7972-4222-82d7-fd324b4b3b9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

