### PR TITLE
Fix cookieconsent3 opt-out on testsieger.de (open preferences modal when no inline reject button)

### DIFF
--- a/rules/autoconsent/cookieconsent3.json
+++ b/rules/autoconsent/cookieconsent3.json
@@ -20,7 +20,20 @@
     ],
     "optOut": [
         {
-            "waitForThenClick": ".cm__btn[data-role=necessary]"
+            "if": { "exists": ".cm__btn[data-role=necessary]" },
+            "then": [
+                {
+                    "waitForThenClick": ".cm__btn[data-role=necessary]"
+                }
+            ],
+            "else": [
+                {
+                    "waitForThenClick": ".cm__btn[data-role=show]"
+                },
+                {
+                    "waitForThenClick": "#cc-main .pm__btn[data-role=necessary]"
+                }
+            ]
         }
     ],
     "test": [

--- a/tests/cookieconsent3.spec.ts
+++ b/tests/cookieconsent3.spec.ts
@@ -1,3 +1,3 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('cookieconsent3', ['https://playground.cookieconsent.orestbida.com/']);
+generateCMPTests('cookieconsent3', ['https://playground.cookieconsent.orestbida.com/', 'https://www.testsieger.de/after-shaves/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1213720516801027?focus=true

## Description:

Reported breakage: https://www.testsieger.de/after-shaves/ (ddg_android, DE).

Reproduced on BrightData (DE region): the page is detected as `cookieconsent3` (orestbida `vanilla-cookieconsent` v3), but opt-out fails. The consent modal on testsieger.de is configured with only **"Alle akzeptieren"** (`.cm__btn[data-role=all]`) and **"Einstellungen"** (`.cm__btn[data-role=show]`) — there is no inline **"Nur notwendige"** (`.cm__btn[data-role=necessary]`) button, which is what the existing rule relies on. The "Nur notwendige" button only appears in the *preferences* modal (`.pm__btn[data-role=necessary]`) once the user clicks "Einstellungen".

This is a valid configuration of the orestbida library (the consent modal layout lets sites omit the inline reject button), so the rule should handle both layouts.

### Fix

Update `rules/autoconsent/cookieconsent3.json` `optOut` to:

- If `.cm__btn[data-role=necessary]` exists in the consent modal → click it directly (existing behaviour).
- Otherwise → click `.cm__btn[data-role=show]` to open the preferences modal, then click `#cc-main .pm__btn[data-role=necessary]`.

Detection / opt-in / test (cookie check) are unchanged.

### Before / after

| Before (popup blocking page) | After (opt-out completed, popup gone) |
|---|---|
| [testsieger.de DE before opt-out](https://cursor.com/agents/bc-7c737810-a8e7-4f2c-929e-ab440b012ee7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftestsieger_de_popup_before_optout.jpg) | [testsieger.de DE after opt-out](https://cursor.com/agents/bc-7c737810-a8e7-4f2c-929e-ab440b012ee7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftestsieger_de_after_optout.jpg) |

## Steps to test this PR:

1. `npm ci && npm run prepublish`
2. Load `dist/addon-mv3/` as an unpacked extension and visit https://www.testsieger.de/after-shaves/ from a DE-region IP — the cookie banner should disappear and `document.cookie` should contain `cc_cookie=` with `categories.analytics=false` / `categories.marketing=false`.
3. Smoke-tested via BrightData in regions DE, FR, GB, NL, US — all PASS with `optOut=true` and `selfTest=true`.
4. Existing `tests/cookieconsent3.spec.ts` URL (`playground.cookieconsent.orestbida.com`) still passes in DE.
5. Spot checks on other cookieconsent3 sites:
   - `mondo-moebel.de` (was passing) — still passes.
   - `primeros.de`, `bmw-berlin-marathon.com` (listed in `data/coverage.json` as `failingSites` for cookieconsent3) — opt-out now succeeds.

### Local CI

- `npm run rule-syntax-check` ✅
- `npm run lint` ✅
- `npm run test:lib` ✅ (2947 passed)
- `npm run prepublish` ✅


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c737810-a8e7-4f2c-929e-ab440b012ee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c737810-a8e7-4f2c-929e-ab440b012ee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

