### PR TITLE
Fix cookieconsent2 false-positive blocking didomi opt-out on Evite

### DIFF
--- a/rules/autoconsent/cookieconsent2.json
+++ b/rules/autoconsent/cookieconsent2.json
@@ -10,7 +10,7 @@
     ],
     "detectPopup": [
         {
-            "visible": "#cm"
+            "exists": "html.show--consent #cm"
         },
         {
             "exists": "#s-all-bn"

--- a/rules/autoconsent/cookieconsent2.json
+++ b/rules/autoconsent/cookieconsent2.json
@@ -25,7 +25,7 @@
         {
             "if": { "exists": "#s-rall-bn" },
             "then": [{ "waitForThenClick": "#s-rall-bn" }],
-            "else": [{ "waitForThenClick": "#c-s-bn" }, { "waitForThenClick": "#s-sv-bn" }]
+            "else": [{ "waitForThenClick": "#c-s-bn" }, { "wait": 500 }, { "waitForThenClick": "#s-sv-bn" }]
         }
     ],
     "test": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1214074223746047?focus=true

## Description:

Fixes popup handling on `evite.com` event pages (and similar sites) where the cookie banner was not being dismissed.

### Root cause

Evite ships the `orestbida/cookieconsent` v2 library globally and leaves its modal (`#cc--main` / `#cm`) in the DOM even when no banner is being shown. The modal element has `style="visibility: hidden"` and `position: fixed`, but autoconsent's internal `isElementVisible` helper treats any fixed-position element with `display !== 'none'` as visible — `visibility: hidden` is ignored. Combined with the previous `cookieconsent2` rule's `detectPopup: { "visible": "#cm" }` step, the rule was matching on Evite even though no banner was open.

In US/CA regions this caused the rule to "win" the popup-detection race ahead of the real `didomi` banner and then fail at opt-out (`#s-rall-bn` doesn't exist). In FR it produced a `Found multiple CMPs` warning while didomi happened to also fire. In DE/GB the timing worked out so didomi handled it, but the false `cookieconsent2` detection was still happening.

### Fix

Detect the `cookieconsent2` popup via `html.show--consent #cm`. The orestbida/cookieconsent v2 library (since v2.1) toggles the `show--consent` class on the `<html>` element to actually show the modal (CSS in the library applies `visibility: visible !important` based on this class). Using `exists` rather than `visible` avoids the fixed-position visibility quirk, and the class is the canonical signal that the banner is actually open.

The existing `{ "exists": "#s-all-bn" }` step is preserved so the rule still confirms the accept button is mounted before attempting to interact.

### Verification

Tested via BrightData remote browsers across geographic regions.

Before the fix:

- `de` / `gb`: `didomi` opt-out worked but `cookieconsent2` was incorrectly co-detected
- `fr`: `Found multiple CMPs` warning (`cookieconsent2` + `didomi`)
- `us-losangeles` / `ca`: `cookieconsent2` won the popup race → `optOutResult: false` (no `#s-rall-bn`), didomi never tried

After the fix:

- `de` / `gb` / `nl` / `us-newyork` / `us-losangeles` / `fr`: only `didomi` detected, `optOut: true`, popup dismissed (no more multi-CMP warning)
- `ca`: only `didomi` detected; popup handling now occasionally flaky because the didomi notice on Evite-CA appears at ~6s while autoconsent's `waitForPopup` retries for ~5s — this is a pre-existing engine timing issue independent of this rule fix, previously masked by the cookieconsent2 false-positive.

Smoke-tested the rule still works on real cookieconsent v2 sites (`fashionnetwork.com`, `officeshoes.ro`): `optOut: true`, `autoconsentDone`.

`npm run build-rules`, `npm run rule-syntax-check`, and `npm run lint` all pass.

Evite event page after autoconsent opt-out (FR region, popup gone):

[Evite FR after fix](https://cursor.com/agents/bc-f345be75-92d8-4deb-8a0d-8514c00c8998/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevite_fr_after_fix_no_popup.jpg)

Evite DE after opt-out (didomi flow, full page rendered):

[Evite DE after opt-out](https://cursor.com/agents/bc-f345be75-92d8-4deb-8a0d-8514c00c8998/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevite_de_after_optout.jpg)

Reference: didomi popup that needs to be opted out (CA region, no autoconsent):

[Didomi popup on Evite CA](https://cursor.com/agents/bc-f345be75-92d8-4deb-8a0d-8514c00c8998/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevite_didomi_popup_before_fix.jpg)

## Steps to test this PR:

1. Build the extension: `npm run prepublish`
2. Load `dist/addon-mv3/` as an unpacked extension in Chrome
3. Open the reported Evite URL: https://www.evite.com/event/02B0IIAE4SKDAA5GCEPRGRRIX4OKRA?gid=008FIIAE4SKDAAWUOEPRG2GTQQBCKQ
4. Verify the didomi banner is dismissed and the page is usable
5. Verify the devtools console reports `Found CMP: didomi` and `optOutResult: true` (only one CMP, no `Found multiple CMPs` warning)
6. Optionally retest in EU and US regions via VPN / BrightData to confirm no `cookieconsent2` is co-detected
7. Optionally verify on a real cookieconsent v2 site (e.g. `fashionnetwork.com`) that the rule still detects, opts out, and dismisses the banner


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f345be75-92d8-4deb-8a0d-8514c00c8998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f345be75-92d8-4deb-8a0d-8514c00c8998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

