### PR TITLE
Fix Didomi selfTest under CCPA/CPRA (newrepublic.com)

### DIFF
--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -12,10 +12,10 @@ export const snippets = {
         return false;
     },
     EVAL_DIDOMI_TEST: () => {
-        if (window.Didomi) {
-            return window.Didomi.getUserConsentStatusForAll().purposes.disabled.length > 0;
-        }
-        return false;
+        // getCurrentUserStatus() works under both GDPR and CCPA/CPRA, unlike the legacy
+        // getUserConsentStatusForAll() which returns empty arrays in CCPA/CPRA mode.
+        const purposes = window.Didomi?.getCurrentUserStatus?.()?.purposes;
+        return !!purposes && Object.values(purposes).some((p) => !p.enabled);
     },
     EVAL_CONSENTMANAGER_1: () => window.__cmp && typeof __cmp('getCMPData') === 'object',
     EVAL_CONSENTMANAGER_2: () => !__cmp('consentStatus').userChoiceExists,

--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -14,8 +14,12 @@ export const snippets = {
     EVAL_DIDOMI_TEST: () => {
         // getCurrentUserStatus() works under both GDPR and CCPA/CPRA, unlike the legacy
         // getUserConsentStatusForAll() which returns empty arrays in CCPA/CPRA mode.
+        // Falls back to the legacy API for older Didomi SDK versions.
         const purposes = window.Didomi?.getCurrentUserStatus?.()?.purposes;
-        return !!purposes && Object.values(purposes).some((p) => !p.enabled);
+        if (purposes) {
+            return Object.values(purposes).some((p) => !p.enabled);
+        }
+        return window.Didomi?.getUserConsentStatusForAll?.().purposes.disabled.length > 0;
     },
     EVAL_CONSENTMANAGER_1: () => window.__cmp && typeof __cmp('getCMPData') === 'object',
     EVAL_CONSENTMANAGER_2: () => !__cmp('consentStatus').userChoiceExists,

--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -19,7 +19,8 @@ export const snippets = {
         if (purposes) {
             return Object.values(purposes).some((p) => !p.enabled);
         }
-        return window.Didomi?.getUserConsentStatusForAll?.().purposes.disabled.length > 0;
+        const disabled = window.Didomi?.getUserConsentStatusForAll?.()?.purposes?.disabled;
+        return Array.isArray(disabled) && disabled.length > 0;
     },
     EVAL_CONSENTMANAGER_1: () => window.__cmp && typeof __cmp('getCMPData') === 'object',
     EVAL_CONSENTMANAGER_2: () => !__cmp('consentStatus').userChoiceExists,

--- a/tests/didomi.spec.ts
+++ b/tests/didomi.spec.ts
@@ -12,7 +12,18 @@ generateCMPTests(
     ],
     {
         testOptIn: true,
+        // Self-test is disabled because some sites (e.g. planet.fr) navigate away
+        // after clicking the disagree button, which destroys the Didomi state.
         testSelfTest: false,
         skipRegions: ['US'],
     },
 );
+
+// US-specific Didomi sites where the CMP runs in CCPA/CPRA mode.
+// In CCPA mode there is no explicit reject button, so the rule relies on the
+// Didomi JS API (EVAL_DIDOMI_OPT_OUT) instead of clicking a DOM element.
+generateCMPTests('didomi', ['https://newrepublic.com/article/162247/andreas-malm-blow-up-pipeline-climate-direct-action'], {
+    testOptIn: false,
+    testSelfTest: true,
+    onlyRegions: ['US'],
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Asana task: https://app.asana.com/1/137249556945/project/1203268166580279/task/1214094206098826?focus=true

## Summary

The Didomi rule already opted out the cookie banner on https://newrepublic.com/article/162247/andreas-malm-blow-up-pipeline-climate-direct-action successfully (the `EVAL_DIDOMI_OPT_OUT` snippet calls `window.Didomi.setUserDisagreeToAll()` which is the only opt-out path on this site since it has no explicit reject button — only an `X` close icon and a "Cookie Preferences" link). However, the rule's selfTest (`EVAL_DIDOMI_TEST`) always returned `false` in CCPA/CPRA mode, because the legacy `Didomi.getUserConsentStatusForAll()` API returns empty `purposes` arrays under that regulation.

This change:

- Rewrites `EVAL_DIDOMI_TEST` to prefer the modern `Didomi.getCurrentUserStatus()` API (which exposes per-purpose / per-vendor `enabled` status under both GDPR and CCPA/CPRA), and falls back to the legacy API for older Didomi SDK versions.
- Adds a US-region test case for `newrepublic.com` so the CCPA/CPRA opt-out path is covered in CI alongside the existing EU-region test sites.

The existing `skipRegions: ['US']` is preserved on the EU-region test list, since most of those sites don't show a Didomi popup from a US IP.

## Verification

`npm run lint`, `npm run rule-syntax-check`, `npm run test:lib` (unit tests), and the Didomi Playwright suite all pass:

- `REGION=NA npx playwright test --project=chrome tests/didomi.spec.ts` → 12 passed
- `REGION=US npx playwright test --project=chrome tests/didomi.spec.ts` → 1 passed (newrepublic.com optOut + selfTest)
- `REGION=US npx playwright test --project=iphoneSE tests/didomi.spec.ts` → 1 passed (mobile selfTest also true)

(`nothing.tech` failures observed under `webkit` are pre-existing on this branch and unrelated to this change — they reproduce on the previous commit too.)

### Before the fix (popup visible)

iOS Safari WebKit, US region:

[Before fix - cookie banner visible at the bottom of the page](https://cursor.com/agents/bc-ad3f37e2-5593-48bd-8346-ddea1ded3dce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_fix_popup_visible.png)

Desktop Chrome:

[Before fix - cookie banner visible at the bottom of the page (desktop)](https://cursor.com/agents/bc-ad3f37e2-5593-48bd-8346-ddea1ded3dce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_fix_popup_chrome.png)

### After the fix (popup dismissed, selfTest passes)

iOS Safari WebKit, US region:

[After fix - banner dismissed by autoconsent (iOS Safari, US region)](https://cursor.com/agents/bc-ad3f37e2-5593-48bd-8346-ddea1ded3dce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_fix_popup_dismissed.png)

Desktop Chrome:

[After fix - banner dismissed by autoconsent (desktop)](https://cursor.com/agents/bc-ad3f37e2-5593-48bd-8346-ddea1ded3dce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_fix_popup_chrome.png)

Console messages observed in WebKit iOS:

```
{"type":"cmpDetected","cmp":"didomi"}
{"type":"popupFound","cmp":"didomi"}
{"type":"optOutResult","cmp":"didomi","result":true}
{"type":"autoconsentDone","cmp":"didomi"}
{"type":"selfTestResult","cmp":"didomi","result":true}
```

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad3f37e2-5593-48bd-8346-ddea1ded3dce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad3f37e2-5593-48bd-8346-ddea1ded3dce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

