### PR TITLE
Onetrust: handle CCPA notice-only banner variant (columbia.com)

### DIFF
--- a/lib/cmps/onetrust.ts
+++ b/lib/cmps/onetrust.ts
@@ -41,6 +41,20 @@ export default class Onetrust extends AutoConsentCMPBase {
             if (rejectPatterns.some((pattern) => btnText.includes(pattern))) {
                 return await this.click('.onetrust-close-btn-handler');
             }
+
+            // CCPA notice-only variant: the banner has the `ot-close-btn-link` class and
+            // contains only a Close button (no Accept, Reject, or Settings). There's no
+            // real opt-out path in the DOM, so we click Close to dismiss.
+            // See e.g. columbia.com (US/CCPA region).
+            const banner = document.getElementById('onetrust-banner-sdk');
+            const isCloseOnlyNotice =
+                banner?.classList.contains('ot-close-btn-link') &&
+                !this.elementExists(
+                    '#onetrust-accept-btn-handler,#onetrust-reject-all-handler,#onetrust-pc-btn-handler,.ot-sdk-show-settings,button.js-cookie-settings',
+                );
+            if (isCloseOnlyNotice) {
+                return await this.click('.onetrust-close-btn-handler');
+            }
         }
 
         if (this.elementExists('#onetrust-pc-btn-handler')) {

--- a/tests/onetrust.spec.ts
+++ b/tests/onetrust.spec.ts
@@ -34,3 +34,22 @@ generateCMPTests('Onetrust', ['https://www.newyorker.com/', 'https://www.adobe.c
 generateCMPTests('Onetrust', ['https://eu.icebreaker.com/de-de?country=DE'], {
     skipRegions: ['US'],
 });
+
+// CCPA notice-only banner variant: only a "Close" button, no Accept/Reject/Settings.
+// Only appears in the US (CCPA). The rule clicks Close to dismiss the banner; opt-in
+// and self-test don't apply (no real consent state to flip).
+// See lib/cmps/onetrust.ts for the variant detection.
+generateCMPTests(
+    'Onetrust',
+    [
+        'https://www.columbia.com/c/mens-insulated-puffer-jackets/',
+        'https://www.mountainhardwear.com/',
+        'https://www.prana.com/',
+        'https://www.sorel.com/',
+    ],
+    {
+        onlyRegions: ['US'],
+        testOptIn: false,
+        testSelfTest: false,
+    },
+);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1214360268568240?focus=true

## Description:

Fix the OneTrust optOut flow when the deployed banner is the **CCPA "Close Banner Only" notice variant**. This variant ships only a "Close" button — no Accept/Reject/Settings — and is identified by the `ot-close-btn-link` class on `#onetrust-banner-sdk`.

### Problem

On `columbia.com` (visited from the US), the OneTrust banner that appears looks like this:

```html
<div id="onetrust-banner-sdk"
     class="otFloatingRounded otRelFont ot-bottom-left ot-wo-title ot-close-btn-link vertical-align-content">
    <div class="ot-sdk-container" role="dialog" aria-label="Privacy">
        … policy text + privacy policy link …
        <button class="onetrust-close-btn-handler banner-close-button ot-close-link">Close</button>
    </div>
</div>
```

The existing OneTrust rule's `optOut`:
1. Looks for `#onetrust-reject-all-handler` → not present.
2. Looks for `.onetrust-close-btn-handler` whose text matches `reject|decline|without|…` → "Close" doesn't match.
3. Falls through to a settings-panel flow (`#onetrust-pc-btn-handler` / `.ot-sdk-show-settings` → preferences toggles → `.save-preference-btn-handler`). None of these elements exist on this variant.
4. Calls `waitForVisible('#onetrust-banner-sdk', 5000, 'none')`, which returns `false`.
5. **Unconditionally `return true;`** — autoconsent reports a successful opt-out while the banner is still on screen.

### Fix

After the existing reject-all and reject-text-on-close paths, add a branch that detects the notice-only variant via the `ot-close-btn-link` class and the absence of any Accept / Reject / Settings handler, and clicks `Close` to dismiss the banner.

```ts
const banner = document.getElementById('onetrust-banner-sdk');
const isCloseOnlyNotice =
    banner?.classList.contains('ot-close-btn-link') &&
    !this.elementExists(
        '#onetrust-accept-btn-handler,#onetrust-reject-all-handler,#onetrust-pc-btn-handler,.ot-sdk-show-settings,button.js-cookie-settings',
    );
if (isCloseOnlyNotice) {
    return await this.click('.onetrust-close-btn-handler');
}
```

This is a narrow, opt-in branch — it only fires when the explicit notice-only class is present **and** the standard handlers are all missing, so existing variants (StackOverflow, OkCupid, doodle.com, etc.) are unaffected.

### Test coverage

Added a new `generateCMPTests` group in `tests/onetrust.spec.ts` for four sites that all use this exact variant in the US (verified end-to-end with autoconsent — same banner classes, same Close-only DOM, same successful opt-out):

- `columbia.com` (the original report)
- `mountainhardwear.com` (Columbia Sportswear sister brand)
- `prana.com` (Columbia Sportswear sister brand)
- `sorel.com` (Columbia Sportswear sister brand)

These run in `onlyRegions: ['US']` (CCPA-only variant), with `testOptIn: false` and `testSelfTest: false` because the banner has no Accept button to click and no consent state to verify (the variant just dismisses, it doesn't actually opt out — that matches what a user can do manually).

### Notes

- This banner has no real opt-out path in the DOM (CCPA notice-only). Clicking "Close" matches what a user can do manually. The selfTest (`window.OnetrustActiveGroups.split(',').filter(s => s.length > 0).length <= 1`) will continue to fail because the consent state is unchanged — that's expected for this variant. The user-visible banner is dismissed regardless, which is the goal of the task.
- Considered but rejected:
  - Improving the heuristic rule: the heuristic only acts when a popup contains a button whose text matches a reject pattern. "Close" is not a reject pattern (and shouldn't be added globally — it would massively over-match), so the heuristic correctly skips this banner.
  - Making it cosmetic: the existing OneTrust rule is non-cosmetic, and this variant has a real button to click. Keeping it as a click-based action preserves the cookie-storing side effect of OneTrust's own close handler.
- There is a separate, pre-existing timing variability issue on columbia.com where the banner can take 7–16 s to load — outside the autoconsent detection-retry budget on slow runs. This affects the rule trigger probability but is unrelated to this fix.

## Steps to test this PR:

1. `npm ci && npm run prepublish`
2. Load `dist/addon-mv3/` as an unpacked extension in Chrome.
3. Open DevTools → Console.
4. Navigate to https://www.columbia.com/c/mens-insulated-puffer-jackets/?icpa=mjacketsplp&icid=hdrbn&icsa=ALL&prid=vn_grid&icst=visnav&crid=mens-shopinsulatedjackets&icca=img from a US IP.
5. Wait ~10–20 s for the OneTrust banner to load. Expected: console shows `Found CMP: Onetrust`, then `Onetrust: opt out result true`, and the banner is no longer visible (`#onetrust-banner-sdk` has `display: none`).
6. Repeat for `mountainhardwear.com`, `prana.com`, `sorel.com` — same expected behavior.

### Before / After

Before — banner still visible after rule (incorrectly reported `optOutResult: true`):

[Columbia banner before fix - banner still visible at bottom](https://cursor.com/agents/bc-d8a42772-bee9-4693-8d9e-18ee44121d7b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcolumbia_before_fix.jpg)

After — banner dismissed by clicking Close (`display: none`, `opacity: 0`), 1 click, ~26 ms:

[Columbia after fix - no banner, full page visible](https://cursor.com/agents/bc-d8a42772-bee9-4693-8d9e-18ee44121d7b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcolumbia_after_fix.png)

Verified again after rebasing onto current `main`:

[Columbia after rebase - banner dismissed](https://cursor.com/agents/bc-d8a42772-bee9-4693-8d9e-18ee44121d7b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcolumbia_rebased_verified.png)

### Diff scope

This PR contains exactly two commits, touching only:

```
 lib/cmps/onetrust.ts   | 14 ++++++++++++++
 tests/onetrust.spec.ts | 19 +++++++++++++++++++
 2 files changed, 33 insertions(+)
```

### Verification

- Rebased onto current `main` (`7c77db98f`, autoconsent v14.75.0). Two commits on top of main: the rule fix and the test additions. No unrelated changes.
- `npm run lint` ✅
- `npm run rule-syntax-check` ✅
- `npm run test:lib` — 790/790 unit tests pass ✅
- `npx playwright test tests/onetrust.spec.ts --project webkit` — 15 pass / 17 pre-existing failures (the 17 failures are identical with-and-without our change; they're EU-only sites being run from NA without a proxy, plus a stackoverflow variant — none are caused by this PR). The new tests are correctly gated to `REGION=US` and don't run in `NA` ✅
- `npx playwright test tests/onetrust.spec.ts --list` confirms the four new tests appear when `REGION=US` and don't appear when `REGION=NA` ✅
- BrightData runs from `us-newyork`: `optOutResult: true`, `totalClicks: 1`, banner becomes `display: none / opacity: 0` on all four sites (`columbia.com`, `mountainhardwear.com`, `prana.com`, `sorel.com`) ✅
- End-to-end manual test with the unpacked extension in Chrome (post-rebase): `Found CMP: Onetrust → opt out result true → done in 26ms with 1 click`, banner DOM check confirms `bannerVisible: false`, `classes` contains `ot-close-btn-link` ✅
- Regression check: `https://stackoverflow.com/` (regular OneTrust with Reject All) — still passes selfTest, opt-out result `true` ✅

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8a42772-bee9-4693-8d9e-18ee44121d7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8a42772-bee9-4693-8d9e-18ee44121d7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

