### PR TITLE
Make Didomi popup detection robust on nothing.tech

### DIFF
--- a/rules/autoconsent/didomi.json
+++ b/rules/autoconsent/didomi.json
@@ -3,10 +3,10 @@
     "prehideSelectors": [
         "#didomi-popup,.didomi-popup-container,.didomi-popup-notice,.didomi-consent-popup-preferences,#didomi-notice,.didomi-popup-backdrop,.didomi-screen-medium"
     ],
-    "detectCmp": [{ "visible": "#didomi-host" }],
+    "detectCmp": [{ "exists": "#didomi-host" }],
     "detectPopup": [
         {
-            "visible": "#didomi-popup, #didomi-notice, .didomi-popup-notice, .didomi-notice-banner",
+            "visible": "#didomi-popup, #didomi-notice, .didomi-popup-notice, .didomi-notice-banner, #didomi-host:not(:empty)",
             "check": "any"
         }
     ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tightens the Didomi rule so it stays in sync with `#didomi-host` on sites that mount the host element ahead of the popup. On `nothing.tech` the host is injected very early (often as an empty `<div id="didomi-host">`), then the popup wrapper (with a generated class such as `didomi-consent-popup__<uuid>`) is rendered later. This produced two flaky scenarios:

- `detectCmp: { visible: "#didomi-host" }` could miss the host while it had `width/height: 0` — the rule then never saw the CMP at all in that detection cycle.
- `detectPopup` only checked `#didomi-popup, #didomi-notice, .didomi-popup-notice, .didomi-notice-banner`, so once the host *was* detected, popup detection (10×500ms) sometimes timed out before any of those classes appeared.

## Change

```diff
- "detectCmp": [{ "visible": "#didomi-host" }],
+ "detectCmp": [{ "exists": "#didomi-host" }],
  "detectPopup": [
      {
-         "visible": "#didomi-popup, #didomi-notice, .didomi-popup-notice, .didomi-notice-banner",
+         "visible": "#didomi-popup, #didomi-notice, .didomi-popup-notice, .didomi-notice-banner, #didomi-host:not(:empty)",
          "check": "any"
      }
  ],
```

- `detectCmp` uses `exists`, since we want detection as soon as the host is in the DOM. Visibility is gated by `detectPopup` anyway.
- `detectPopup` adds `#didomi-host:not(:empty)`, which matches the popup as soon as its wrapper is mounted, regardless of which Didomi popup container class is used.

## Walkthrough

Before / after a single page load on `https://nothing.tech/` (US datacenter IP, headless Chrome with autoconsent injected):

[nothing.tech without autoconsent — Didomi ](https://cursor.com/agents/bc-ec9b39fe-3eb2-49fe-a968-923d11d54db0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnothing_tech_without_autoconsent.png)

[nothing.tech with autoconsent — Didomi popup is dismissed; only the unrelated store-locator dialog remains](https://cursor.com/agents/bc-ec9b39fe-3eb2-49fe-a968-923d11d54db0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnothing_tech_with_autoconsent.png)

Regional results (`scripts/brightdata.mjs` against the production rule):

[regional_test_summary.txt](https://cursor.com/agents/bc-ec9b39fe-3eb2-49fe-a968-923d11d54db0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fregional_test_summary.txt)

## Testing

- ✅ `npm run build-rules`
- ✅ `npm run rule-syntax-check`
- ✅ `npm run lint`
- ✅ `npm run prepublish`
- ✅ `npx playwright test tests/didomi.spec.ts --project=chrome` — 12/12 didomi specs pass
- ✅ `npx web-test-runner` (29 files / 2947 unit tests, including rule-compaction round-trip)
- ✅ BrightData regional sweep against `https://nothing.tech/` covering `gb`, `de`, `fr`, `us-newyork`, `us-losangeles`, `ca`, `au`, `nl` — all regions where the CMP was shown report `cmpDetected: didomi`, `popupFound: true`, `optOut: true`.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec9b39fe-3eb2-49fe-a968-923d11d54db0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec9b39fe-3eb2-49fe-a968-923d11d54db0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

