### PR TITLE
Fix delayed OneTrust banner detection on College Board

### DIFF
--- a/lib/cmps/onetrust.ts
+++ b/lib/cmps/onetrust.ts
@@ -18,7 +18,7 @@ export default class Onetrust extends AutoConsentCMPBase {
     }
 
     async detectCmp() {
-        return this.elementExists('#onetrust-banner-sdk,#onetrust-pc-sdk');
+        return this.elementExists('#onetrust-banner-sdk') || this.elementVisible('#onetrust-pc-sdk', 'any');
     }
 
     async detectPopup() {

--- a/tests-wtr/lifecycle/find-cmp.html
+++ b/tests-wtr/lifecycle/find-cmp.html
@@ -19,5 +19,6 @@
             <button>Accept All</button>
             <button>Reject All</button>
         </div>
+        <div id="onetrust-pc-sdk" style="display: none">Cookie Preference Center</div>
     </body>
 </html>

--- a/tests-wtr/lifecycle/find-cmp.ts
+++ b/tests-wtr/lifecycle/find-cmp.ts
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import Autoconsent from '../../lib/web';
+import Onetrust from '../../lib/cmps/onetrust';
 
 describe('Autoconsent.findCmp', () => {
     let autoconsent: Autoconsent;
@@ -60,6 +61,12 @@ describe('Autoconsent.findCmp', () => {
                 optIn: [],
                 optOut: [],
             });
+            const found = await autoconsent.findCmp(0);
+            expect(found).to.have.length(0);
+        });
+
+        it('does not match Onetrust for a hidden preference center without a banner', async () => {
+            autoconsent.rules.push(new Onetrust(autoconsent));
             const found = await autoconsent.findCmp(0);
             expect(found).to.have.length(0);
         });

--- a/tests/onetrust.spec.ts
+++ b/tests/onetrust.spec.ts
@@ -7,6 +7,7 @@ generateCMPTests('Onetrust', [
     'https://doodle.com/',
     'https://www.coca-cola.com/us/en',
     'https://www.seur.com/es/index.html',
+    'https://satsuite.collegeboard.org/sat/dates-deadlines',
 ]);
 
 generateCMPTests('Onetrust', ['https://mailchimp.com/', 'https://www.accenture.com/', 'https://www.zoom.us'], {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL:
https://app.asana.com/1/137249556945/project/1203268166580279/task/1214072692630116?focus=true

## Description:
- Narrow OneTrust CMP detection so hidden preference-center markup does not start popup detection before the banner exists.
- Add the College Board SAT dates page to the OneTrust Playwright spec coverage.
- Add a WTR regression test for hidden OneTrust preference-center markup without a banner.

## Steps to test this PR:
- npm run test:lib -- --playwright --browsers chromium --files tests-wtr/lifecycle/find-cmp.html
- npx playwright test tests/onetrust.spec.ts -g "satsuite.collegeboard.org.*optOut" --project chrome

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6abc4cb-a432-4f70-b8a8-9162dafb22d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6abc4cb-a432-4f70-b8a8-9162dafb22d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

