### PR TITLE
Add rule for Kickstarter custom consent modal

### DIFF
--- a/rules/autoconsent/kickstarter.json
+++ b/rules/autoconsent/kickstarter.json
@@ -1,0 +1,34 @@
+{
+    "name": "kickstarter.com",
+    "vendorUrl": "https://www.kickstarter.com/",
+    "runContext": {
+        "urlPattern": "^https?://(www\\.)?kickstarter\\.com/"
+    },
+    "prehideSelectors": ["#react-consent-modal"],
+    "detectCmp": [
+        {
+            "exists": "#react-consent-modal .flex.flex-column"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#react-consent-modal .flex.flex-column"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "#react-consent-modal .flex.flex-row.justify-between button:last-child"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "#react-consent-modal .flex.flex-row.justify-between button:first-child"
+        }
+    ],
+    "test": [
+        {
+            "visible": "#react-consent-modal .flex.flex-column",
+            "check": "none"
+        }
+    ]
+}

--- a/tests/kickstarter.spec.ts
+++ b/tests/kickstarter.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('kickstarter.com', [
+    'https://www.kickstarter.com/projects/simonegiertz/laundry-chair-the-bedroom-chair-you-have-always-wanted',
+    'https://www.kickstarter.com/',
+]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1213753146969578?focus=true

## Description:

Kickstarter bundles Transcend's consent manager (an empty `#transcend-consent-manager` div is always present in the DOM) alongside its own custom React-based consent modal (`#react-consent-modal`) which is what the user actually sees. The existing `transcend` rule matched the empty container, reported success via a cosmetic style override, and never addressed the visible modal — leaving the opt-out banner on screen.

This PR adds a site-specific rule for `kickstarter.com` that targets the custom modal:

- `detectCmp` / `detectPopup` look for the rendered dialog inside `#react-consent-modal` (the outer div is always present, even when no popup is showing, so we have to match the inner dialog).
- `optOut` clicks the first button in the button row (`Confirm`, which submits the default-rejected preferences).
- `optIn` clicks the last button (`Accept all`).
- `runContext.urlPattern` scopes the rule to `kickstarter.com` so it gets priority over the generic `transcend` rule.
- `prehideSelectors` covers `#react-consent-modal` to avoid flicker.
- Self-test confirms the inner dialog is no longer visible after the click.

## Steps to test this PR:

1. `npm ci && npm run prepublish`
2. `npx playwright test tests/kickstarter.spec.ts --project=chrome`
3. Manually verify across regions using the `brightdata-testing` skill (see screenshots below — tested in US-NY, DE, and GB).

### Before (transcend rule reports success, popup still visible in DE/GB)
[Before — DE popup still visible](https://cursor.com/agents/bc-8fbafdb9-d39c-4660-bf97-a6afccaddc0e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreens-before%2Fwww.kickstarter.com-de-final.jpg)
[Before — GB popup still visible](https://cursor.com/agents/bc-8fbafdb9-d39c-4660-bf97-a6afccaddc0e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreens-before%2Fwww.kickstarter.com-gb-final.jpg)

### After (popup is handled correctly)
[After — US-NY opt-out](https://cursor.com/agents/bc-8fbafdb9-d39c-4660-bf97-a6afccaddc0e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreens-final%2Fwww.kickstarter.com-us-newyork-final.jpg)
[After — DE opt-out](https://cursor.com/agents/bc-8fbafdb9-d39c-4660-bf97-a6afccaddc0e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreens-final%2Fwww.kickstarter.com-de-final.jpg)
[After — GB opt-out](https://cursor.com/agents/bc-8fbafdb9-d39c-4660-bf97-a6afccaddc0e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreens-final%2Fwww.kickstarter.com-gb-final.jpg)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fbafdb9-d39c-4660-bf97-a6afccaddc0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fbafdb9-d39c-4660-bf97-a6afccaddc0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

