### PR TITLE
Add volvocars-com rule

### DIFF
--- a/rules/autoconsent/volvocars-com.json
+++ b/rules/autoconsent/volvocars-com.json
@@ -1,0 +1,44 @@
+{
+    "name": "volvocars-com",
+    "_metadata": {
+        "vendorUrl": "https://www.volvocars.com/"
+    },
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https://([a-z0-9-]+\\.)?volvocars\\.com/"
+    },
+    "prehideSelectors": ["cookie-banner#cookie-banner-host"],
+    "detectCmp": [
+        {
+            "exists": ["cookie-banner#cookie-banner-host", "#dialog_cookie_consent"]
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": ["cookie-banner#cookie-banner-host", "#dialog_cookie_consent"]
+        }
+    ],
+    "optIn": [
+        { "wait": 500 },
+        {
+            "waitForThenClick": ["cookie-banner#cookie-banner-host", "#onetrust-accept-btn-handler"]
+        }
+    ],
+    "optOut": [
+        { "wait": 500 },
+        {
+            "waitForThenClick": ["cookie-banner#cookie-banner-host", "#onetrust-reject-all-handler"]
+        },
+        {
+            "waitForVisible": ["cookie-banner#cookie-banner-host", "#dialog_cookie_consent"],
+            "check": "none",
+            "timeout": 5000
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "groups=C1%3A1%2CC3%3A0"
+        }
+    ]
+}

--- a/tests/volvocars-com.spec.ts
+++ b/tests/volvocars-com.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('volvocars-com', ['https://www.volvocars.com/uk/cars/ex60-electric/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1214680067540685?focus=true

## Description:

Adds a site-specific rule for `volvocars.com`. The site uses OneTrust under the hood, but wraps the banner UI in a custom element (`<cookie-banner id="cookie-banner-host" data-theme="centenary">`) that renders the OneTrust dialog inside its open Shadow DOM. The light-DOM `#onetrust-banner-sdk` is hidden via `display: none !important`, so the generic OneTrust code-based rule detects the CMP but never finds a visible popup and times out.

The new rule pierces the shadow root with array selectors and clicks the OneTrust reject / accept buttons inside the shadow tree:

```json
"detectPopup": [
    { "visible": ["cookie-banner#cookie-banner-host", "#dialog_cookie_consent"] }
],
"optOut": [
    { "waitForThenClick": ["cookie-banner#cookie-banner-host", "#onetrust-reject-all-handler"] }
]
```

A `urlPattern` constrains the rule to `volvocars.com` (any subdomain / country path) so it is prioritized over the generic OneTrust rule and cannot false-positive elsewhere.

## Steps to test this PR:

Verified with the `oxylabs-testing` skill from real geographic IPs (UK was the originally reported region):

| Region | URL | Result |
|---|---|---|
| UK (`gb`) | `/uk/cars/ex60-electric/` (reported URL) | PASS — opt-out + self-test |
| US (`us-newyork`) | `/us/cars/ex60-electric/` | PASS — opt-out + self-test (different button copy, same IDs) |
| Intl (`de`) | `/intl/` | PASS — opt-out succeeds, banner dismissed |
| FR (`fr`) | `/fr/` | NO CMP — popup not shown in this region |

The Playwright test (`tests/volvocars-com.spec.ts`) is included for parity with other rules, but local runs hit Volvo's Akamai bot-protection ("Access Denied") and are expected to fail in CI for the same reason — verification was performed with Oxylabs against the live site.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f037dc57-ebde-423e-ac32-eac0e589a9e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f037dc57-ebde-423e-ac32-eac0e589a9e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

