### PR TITLE
oxylabs-testing: settle after selfTestResult before screenshot

### DIFF
--- a/.agents/skills/oxylabs-testing/scripts/oxylabs.mjs
+++ b/.agents/skills/oxylabs-testing/scripts/oxylabs.mjs
@@ -429,8 +429,18 @@ export async function testPage(page, url, regionKey, options = {}) {
         }
 
         const completed = await ctx.waitForCompletion(completionTimeout);
+        // The rule's `test` step (e.g. waitForVisible with check: 'none') can
+        // poll for up to 10s on its own before reporting back. Wait longer than
+        // that here so we don't race autoconsent's internal timeout and take a
+        // screenshot while the close animation/network round-trip is still in
+        // flight (which would produce `selfTestResult: null` + a misleading
+        // screenshot with the banner still visible).
         if (completed && !ctx.hasMessage('selfTestResult')) {
-            await ctx.waitForMessage('selfTestResult', 10000);
+            await ctx.waitForMessage('selfTestResult', 20000);
+        }
+        // Brief settle to let close animations finish before screenshotting.
+        if (completed) {
+            await page.waitForTimeout(500);
         }
 
         const result = ctx.collectResult(url, regionKey);

--- a/.agents/skills/oxylabs-testing/scripts/oxylabs.mjs
+++ b/.agents/skills/oxylabs-testing/scripts/oxylabs.mjs
@@ -429,18 +429,36 @@ export async function testPage(page, url, regionKey, options = {}) {
         }
 
         const completed = await ctx.waitForCompletion(completionTimeout);
-        // The rule's `test` step (e.g. waitForVisible with check: 'none') can
-        // poll for up to 10s on its own before reporting back. Wait longer than
-        // that here so we don't race autoconsent's internal timeout and take a
-        // screenshot while the close animation/network round-trip is still in
-        // flight (which would produce `selfTestResult: null` + a misleading
-        // screenshot with the banner still visible).
-        if (completed && !ctx.hasMessage('selfTestResult')) {
-            await ctx.waitForMessage('selfTestResult', 20000);
+        // `autoconsentDone` is the rule's "everything is finished" signal — by
+        // the time it's on the wire the optOut/optIn flow has fully completed
+        // and any subsequent `selfTest` is just verification. Gate the
+        // screenshot on this rather than on `selfTestResult` so the captured
+        // frame reflects the state the rule itself produced.
+        if (completed && !ctx.hasMessage('autoconsentDone')) {
+            await ctx.waitForMessage('autoconsentDone', 5000);
         }
-        // Brief settle to let close animations finish before screenshotting.
-        if (completed) {
-            await page.waitForTimeout(500);
+
+        const screenshotPath = (() => {
+            try {
+                const domain = new URL(url).hostname;
+                const filepath = path.join(screenshotsDir, `${domain}-${regionKey}-final.jpg`);
+                fs.mkdirSync(screenshotsDir, { recursive: true });
+                return filepath;
+            } catch {
+                return null;
+            }
+        })();
+        if (screenshotPath) {
+            try {
+                await page.screenshot({ path: screenshotPath, quality: 50, scale: 'css', timeout: 5000, type: 'jpeg' });
+            } catch {}
+        }
+
+        // Drain `selfTestResult` for reporting; this doesn't gate the
+        // screenshot. If autoconsentDone fires but selfTest fails or never
+        // reports, that's surfaced in the result, not hidden by waiting.
+        if (completed && !ctx.hasMessage('selfTestResult')) {
+            await ctx.waitForMessage('selfTestResult', 10000);
         }
 
         const result = ctx.collectResult(url, regionKey);
@@ -452,13 +470,9 @@ export async function testPage(page, url, regionKey, options = {}) {
             result.errors.push('Timed out waiting for autoconsent to complete');
         }
 
-        try {
-            const domain = new URL(url).hostname;
-            const filepath = path.join(screenshotsDir, `${domain}-${regionKey}-final.jpg`);
-            fs.mkdirSync(screenshotsDir, { recursive: true });
-            await page.screenshot({ path: filepath, quality: 50, scale: 'css', timeout: 5000, type: 'jpeg' });
-            result.screenshotPaths.push(filepath);
-        } catch {}
+        if (screenshotPath) {
+            result.screenshotPaths.push(screenshotPath);
+        }
 
         return result;
     } catch (e) {

--- a/.agents/skills/oxylabs-testing/scripts/oxylabs.mjs
+++ b/.agents/skills/oxylabs-testing/scripts/oxylabs.mjs
@@ -429,40 +429,14 @@ export async function testPage(page, url, regionKey, options = {}) {
         }
 
         const completed = await ctx.waitForCompletion(completionTimeout);
-        // `autoconsentDone` is the rule's "everything is finished" signal,
-        // emitted right after `optOutResult`/`optInResult`. The subsequent
-        // `selfTest` round trip is just verification and is irrelevant for
-        // screenshot timing. However, the page's own close animation /
-        // teardown can still be in flight at the moment `autoconsentDone`
-        // fires, so we wait a short settle window before capturing the frame.
-        if (completed && !ctx.hasMessage('autoconsentDone')) {
-            await ctx.waitForMessage('autoconsentDone', 5000);
-        }
-        if (completed) {
-            await page.waitForTimeout(1500);
-        }
-
-        const screenshotPath = (() => {
-            try {
-                const domain = new URL(url).hostname;
-                const filepath = path.join(screenshotsDir, `${domain}-${regionKey}-final.jpg`);
-                fs.mkdirSync(screenshotsDir, { recursive: true });
-                return filepath;
-            } catch {
-                return null;
-            }
-        })();
-        if (screenshotPath) {
-            try {
-                await page.screenshot({ path: screenshotPath, quality: 50, scale: 'css', timeout: 5000, type: 'jpeg' });
-            } catch {}
-        }
-
-        // Drain `selfTestResult` for reporting; this doesn't gate the
-        // screenshot. If autoconsentDone fires but selfTest fails or never
-        // reports, that's surfaced in the result, not hidden by waiting.
         if (completed && !ctx.hasMessage('selfTestResult')) {
             await ctx.waitForMessage('selfTestResult', 10000);
+        }
+        // Brief settle after the rule (and its verification) has finished, to
+        // outlast the page's own close animation / DOM teardown which can
+        // still be in flight when the screenshot is taken.
+        if (completed) {
+            await page.waitForTimeout(1500);
         }
 
         const result = ctx.collectResult(url, regionKey);
@@ -474,9 +448,13 @@ export async function testPage(page, url, regionKey, options = {}) {
             result.errors.push('Timed out waiting for autoconsent to complete');
         }
 
-        if (screenshotPath) {
-            result.screenshotPaths.push(screenshotPath);
-        }
+        try {
+            const domain = new URL(url).hostname;
+            const filepath = path.join(screenshotsDir, `${domain}-${regionKey}-final.jpg`);
+            fs.mkdirSync(screenshotsDir, { recursive: true });
+            await page.screenshot({ path: filepath, quality: 50, scale: 'css', timeout: 5000, type: 'jpeg' });
+            result.screenshotPaths.push(filepath);
+        } catch {}
 
         return result;
     } catch (e) {

--- a/.agents/skills/oxylabs-testing/scripts/oxylabs.mjs
+++ b/.agents/skills/oxylabs-testing/scripts/oxylabs.mjs
@@ -429,13 +429,17 @@ export async function testPage(page, url, regionKey, options = {}) {
         }
 
         const completed = await ctx.waitForCompletion(completionTimeout);
-        // `autoconsentDone` is the rule's "everything is finished" signal — by
-        // the time it's on the wire the optOut/optIn flow has fully completed
-        // and any subsequent `selfTest` is just verification. Gate the
-        // screenshot on this rather than on `selfTestResult` so the captured
-        // frame reflects the state the rule itself produced.
+        // `autoconsentDone` is the rule's "everything is finished" signal,
+        // emitted right after `optOutResult`/`optInResult`. The subsequent
+        // `selfTest` round trip is just verification and is irrelevant for
+        // screenshot timing. However, the page's own close animation /
+        // teardown can still be in flight at the moment `autoconsentDone`
+        // fires, so we wait a short settle window before capturing the frame.
         if (completed && !ctx.hasMessage('autoconsentDone')) {
             await ctx.waitForMessage('autoconsentDone', 5000);
+        }
+        if (completed) {
+            await page.waitForTimeout(1500);
         }
 
         const screenshotPath = (() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214071182387181?focus=true

## Description:

While verifying the LinkedIn cookie popup on `https://www.linkedin.com/company/weareandros/` from Portugal (reported flaky), one out of ~10 runs produced a misleading "popup still visible" final screenshot. The fix is just a 1.5 s settle before capturing the frame.

The original order was correct:

1. Wait for `optOutResult` / `optInResult`.
2. Wait (up to 10 s) for `selfTestResult` — the rule's own verification step.
3. Take screenshot.

What was missing: autoconsent emits `autoconsentDone` immediately after the rule's click without waiting for the page to react. The page's own close animation / DOM teardown of the banner can still be in flight when we capture the frame, which is what produced the half-closed banner in the flaky screenshot.

Net change (vs. base `oxylabs`): a 5-line addition that sleeps 1.5 s after `selfTestResult` (or its 10 s timeout) before taking the screenshot. No autoconsent rule or eval-snippet changes.

The earlier commits on this branch (which experimented with gating on `autoconsentDone` instead of `selfTestResult`) are preserved as history but are superseded by the final commit `a85f31bc9`.

## Steps to test this PR:

1. Set `OXYLABS_USER` / `OXYLABS_PASSWORD` env vars.
2. `npm run prepublish`
3. Run a region that previously showed the flake, e.g.:
   ```js
   import { testUrl, REGIONS } from './.agents/skills/oxylabs-testing/scripts/oxylabs.mjs';
   REGIONS.pt = { p_cc: 'PT' };
   for (let i = 0; i < 5; i++) {
       const r = await testUrl('https://www.linkedin.com/company/weareandros/', 'pt');
       console.log(r.selfTestResult, r.screenshotPaths);
   }
   ```
4. Confirm: every run reports `selfTestResult: true` and the saved screenshots show the LinkedIn cookie banner fully gone (the central LinkedIn sign-in modal is unrelated and is expected to remain). Before this change one run in ~10 returned `selfTestResult: null` or showed the banner mid-animation in the final frame.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bb5967f-a181-452d-8d83-f8e208a4f393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bb5967f-a181-452d-8d83-f8e208a4f393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

