### PR TITLE
Defer heuristic CMP fallback behind declarative retry

### DIFF
--- a/lib/web.ts
+++ b/lib/web.ts
@@ -267,10 +267,9 @@ export default class AutoConsent {
         return result;
     }
 
-    async findCmp(retries: number): Promise<AutoCMP[]> {
+    async findCmp(retries: number, deferHeuristicFallback = true): Promise<AutoCMP[]> {
         const logsConfig = this.config.logs;
         this.updateState({ findCmpAttempts: this.state.findCmpAttempts + 1 });
-        const foundCMPs: AutoCMP[] = [];
         const isTop = isTopFrame();
 
         // refilter relevant rules for this context
@@ -291,21 +290,25 @@ export default class AutoConsent {
         // heuristic CMP is only run in the top frame and only if heuristic action is enabled
         const heuristicRules = isTop && this.config.enableHeuristicAction ? [new AutoConsentHeuristicCMP(this)] : [];
 
-        const rulesPriorityStages: [string, AutoCMP[]][] = [
+        const declarativeRulesPriorityStages: [string, AutoCMP[]][] = [
             ['site-specific', siteSpecificRules],
             ['generic', genericRules],
-            ['heuristic', heuristicRules],
         ];
-        const runDetectCmp = async (cmp: AutoCMP) => {
+        const reportDetectedCmp = (cmp: AutoCMP) => {
+            logsConfig.lifecycle && console.log(`Found CMP: ${cmp.name} ${window.location.href}`);
+            this.sendContentMessage({
+                type: 'cmpDetected',
+                url: location.href,
+                cmp: cmp.name,
+            }); // notify the browser
+        };
+        const runDetectCmp = async (cmp: AutoCMP, foundCMPs: AutoCMP[], reportDetection = true) => {
             try {
                 const result = await cmp.detectCmp();
                 if (result) {
-                    logsConfig.lifecycle && console.log(`Found CMP: ${cmp.name} ${window.location.href}`);
-                    this.sendContentMessage({
-                        type: 'cmpDetected',
-                        url: location.href,
-                        cmp: cmp.name,
-                    }); // notify the browser
+                    if (reportDetection) {
+                        reportDetectedCmp(cmp);
+                    }
                     foundCMPs.push(cmp);
                 }
             } catch (e) {
@@ -316,24 +319,43 @@ export default class AutoConsent {
         const mutationObserver = this.domActions.waitForMutation('html');
         mutationObserver.catch(() => {}); // ensure promise rejection is caught
 
-        for (const [stageName, ruleGroup] of rulesPriorityStages) {
+        for (const [stageName, ruleGroup] of declarativeRulesPriorityStages) {
             logsConfig.lifecycle &&
                 ruleGroup.length > 0 &&
                 console.log(
                     `Trying ${stageName} rules`,
                     ruleGroup.map((r) => r.name),
                 );
-            await Promise.all(ruleGroup.map(runDetectCmp));
+            const foundInStage: AutoCMP[] = [];
+            await Promise.all(ruleGroup.map((cmp) => runDetectCmp(cmp, foundInStage)));
 
             // exit early if we already found a CMP
-            if (foundCMPs.length > 0) {
-                break;
+            if (foundInStage.length > 0) {
+                this.detectHeuristics(); // run heuristics after trying rules
+                return ruleGroup.filter((cmp) => foundInStage.includes(cmp));
             }
         }
 
         this.detectHeuristics(); // run heuristics after trying rules
 
-        if (foundCMPs.length === 0 && retries > 0) {
+        const foundHeuristicCMPs: AutoCMP[] = [];
+        for (const heuristicRule of heuristicRules) {
+            logsConfig.lifecycle && console.log('Trying heuristic rules', [heuristicRule.name]);
+            await runDetectCmp(heuristicRule, foundHeuristicCMPs, false);
+        }
+
+        if (foundHeuristicCMPs.length > 0) {
+            if (deferHeuristicFallback && retries > 0) {
+                logsConfig.lifecycle && console.log('HEURISTIC matched; retrying declarative rules before using fallback');
+                await this.domActions.wait(500);
+                return this.findCmp(0, false);
+            }
+
+            foundHeuristicCMPs.forEach(reportDetectedCmp);
+            return foundHeuristicCMPs;
+        }
+
+        if (retries > 0) {
             // if we didn't find a CMP, try again
             // We wait 500ms, and also for some kind of dom mutation to happen before
             // rerunning the findCmp check
@@ -344,10 +366,10 @@ export default class AutoConsent {
                 return [];
             }
 
-            return this.findCmp(retries - 1);
+            return this.findCmp(retries - 1, deferHeuristicFallback);
         }
 
-        return foundCMPs;
+        return [];
     }
 
     detectHeuristics() {

--- a/tests-wtr/lifecycle/find-cmp.ts
+++ b/tests-wtr/lifecycle/find-cmp.ts
@@ -159,6 +159,7 @@ describe('Autoconsent.findCmp', () => {
                 autoAction: null,
                 enableHeuristicAction: true,
             });
+            autoconsent.rules = [];
         });
 
         afterEach(() => {

--- a/tests-wtr/lifecycle/find-cmp.ts
+++ b/tests-wtr/lifecycle/find-cmp.ts
@@ -208,7 +208,7 @@ describe('Autoconsent.findCmp', () => {
                 const lateCmp = document.createElement('div');
                 lateCmp.id = 'late-ketch-cmp';
                 document.body.appendChild(lateCmp);
-            });
+            }, 100);
 
             const found = await autoconsent.findCmp(1);
 

--- a/tests-wtr/lifecycle/find-cmp.ts
+++ b/tests-wtr/lifecycle/find-cmp.ts
@@ -2,6 +2,22 @@ import { expect } from '@esm-bundle/chai';
 import Autoconsent from '../../lib/web';
 import Onetrust from '../../lib/cmps/onetrust';
 
+function ensureHeuristicPopup() {
+    if (document.getElementById('heuristic-popup')) {
+        return;
+    }
+
+    const popup = document.createElement('div');
+    popup.id = 'heuristic-popup';
+    popup.setAttribute('style', 'position: fixed; top: 0; left: 0; width: 300px; height: 200px; background: white');
+    popup.innerHTML = `
+        <p>We use cookies to improve your experience.</p>
+        <button>Accept All</button>
+        <button>Reject All</button>
+    `;
+    document.body.appendChild(popup);
+}
+
 describe('Autoconsent.findCmp', () => {
     let autoconsent: Autoconsent;
 
@@ -137,6 +153,7 @@ describe('Autoconsent.findCmp', () => {
 
     describe('enableHeuristicAction = true', () => {
         beforeEach(() => {
+            ensureHeuristicPopup();
             autoconsent = new Autoconsent((msg) => Promise.resolve(), {
                 enabled: false,
                 autoAction: null,
@@ -146,6 +163,7 @@ describe('Autoconsent.findCmp', () => {
 
         afterEach(() => {
             document.getElementById('heuristic-popup')?.remove();
+            document.getElementById('late-ketch-cmp')?.remove();
         });
 
         it('returns heuristic CMP when no declarative rules match', async () => {
@@ -175,6 +193,27 @@ describe('Autoconsent.findCmp', () => {
 
             expect(found).to.have.length(1);
             expect(found[0].name).to.equal('test');
+        });
+
+        it('retries declarative rules once before falling back to heuristic CMP', async () => {
+            autoconsent.addDeclarativeCMP({
+                name: 'late-ketch',
+                detectCmp: [{ exists: '#late-ketch-cmp' }],
+                detectPopup: [],
+                optIn: [],
+                optOut: [],
+            });
+
+            setTimeout(() => {
+                const lateCmp = document.createElement('div');
+                lateCmp.id = 'late-ketch-cmp';
+                document.body.appendChild(lateCmp);
+            });
+
+            const found = await autoconsent.findCmp(1);
+
+            expect(found).to.have.length(1);
+            expect(found[0].name).to.equal('late-ketch');
         });
     });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL:
https://app.asana.com/1/137249556945/project/1201844467387842/task/1214734628093282?focus=true

## Description:
- Treat HEURISTIC as a fallback when it matches while declarative detection still has retry budget.
- Give site-specific/generic rules one short retry before accepting HEURISTIC so late CMP markers like Ketch can win.
- Return multiple declarative matches in configured rule order within a priority stage.

## Steps to test this PR:
- npm run test:lib -- --files tests-wtr/lifecycle/find-cmp.html
- npm run test:lib
- npm run lint
- npm run prepublish
- Oxylabs regional Ketch spec checks across supported regions
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72501e8b-b62e-4c2b-b85c-f244724789cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72501e8b-b62e-4c2b-b85c-f244724789cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

