### PR TITLE
Add edpb-edps rule for EDPB/EDPS cookie banner

### DIFF
--- a/rules/autoconsent/edpb-edps.json
+++ b/rules/autoconsent/edpb-edps.json
@@ -1,0 +1,35 @@
+{
+    "name": "edpb-edps",
+    "_metadata": {
+        "vendorUrl": "https://www.edpb.europa.eu/"
+    },
+    "runContext": {
+        "urlPattern": "^https://(www\\.)?(edpb|edps)\\.europa\\.eu/"
+    },
+    "prehideSelectors": ["#edp-cookies-banner"],
+    "detectCmp": [
+        {
+            "exists": "#edp-cookies-banner .edp-cookies-refuse"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#edp-cookies-banner"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "#edp-cookies-banner .edp-cookies-accept"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "#edp-cookies-banner .edp-cookies-refuse"
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "edp_cookie_agree=0"
+        }
+    ]
+}

--- a/tests/edpb-edps.spec.ts
+++ b/tests/edpb-edps.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('edpb-edps', [
+    'https://www.edpb.europa.eu/our-work-tools/our-documents/topic/anonymization_en',
+    'https://www.edps.europa.eu/',
+]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1214749110112432?focus=true

## Description:

Adds a new `edpb-edps` autoconsent rule to handle the custom `#edp-cookies-banner` shown on `www.edpb.europa.eu` and `www.edps.europa.eu` (European Data Protection Board / Supervisor).

Currently the only handling for this banner is the cosmetic filterlist entry `###edp-cookies-banner`, which only hides it visually without actually setting the user's reject choice. The new rule clicks the `No thanks, only essential cookies` button so that the `edp_cookie_agree=0` cookie is set and the choice is properly recorded.

The banner is custom to these two domains (confirmed via PublicWWW search for `edp-cookies-banner` / `edp-cookies-accept` / `edp-cookies-refuse` — only `edpb.europa.eu` and `edps.europa.eu` use it). `runContext.urlPattern` is therefore restricted to `^https://(www\.)?(edpb|edps)\.europa\.eu/`.

The existing `europa-eu` rule (handling the EC `.cck-container` Cookie Consent Kit) is unaffected, since its `detectCmp` checks for a different selector.

## Steps to test this PR:

1. Visit https://www.edpb.europa.eu/our-work-tools/our-documents/topic/anonymization_en — the cookie banner should be auto-rejected and disappear, and a `edp_cookie_agree=0` cookie should be set.
2. Same for https://www.edps.europa.eu/.
3. `npm run prepublish && npm run rule-syntax-check`.
4. `npx playwright test tests/edpb-edps.spec.ts`.

### Regional verification (Oxylabs Unblocker)

Tested both URLs across `de`, `fr`, `gb`, `us-newyork`, `ca`, `au` regions — all returned `PASS` with `CMP: edpb-edps`, `Popup: true | OptOut: true | SelfTest: true`. Screenshots confirm the banner is gone after the rule runs.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34042d3b-9d8d-4b00-88b6-04a5e211bcfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34042d3b-9d8d-4b00-88b6-04a5e211bcfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

