### PR TITLE
Add justgiving.com cookie popup rule

### DIFF
--- a/rules/autoconsent/justgiving.json
+++ b/rules/autoconsent/justgiving.json
@@ -1,0 +1,46 @@
+{
+    "name": "justgiving.com",
+    "vendorUrl": "https://www.justgiving.com/",
+    "runContext": {
+        "urlPattern": "^https://([a-z0-9-]+\\.)*justgiving\\.com/"
+    },
+    "prehideSelectors": ["#cookiebanner-popup"],
+    "detectCmp": [
+        {
+            "any": [
+                {
+                    "exists": "#cookiebanner-popup"
+                },
+                {
+                    "exists": "#jg-chrome-header"
+                }
+            ]
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#cookiebanner-popup"
+        },
+        {
+            "exists": "#cookiebanner-popup #accept-essential-Cookies"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "#cookiebanner-popup #accept-all-Cookies"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "#cookiebanner-popup #accept-essential-Cookies"
+        }
+    ],
+    "test": [
+        {
+            "wait": 500
+        },
+        {
+            "cookieContains": "necessary:true%2Cpreferences:false"
+        }
+    ]
+}

--- a/rules/autoconsent/justgiving.json
+++ b/rules/autoconsent/justgiving.json
@@ -2,7 +2,7 @@
     "name": "justgiving.com",
     "vendorUrl": "https://www.justgiving.com/",
     "runContext": {
-        "urlPattern": "^https://([a-z0-9-]+\\.)*justgiving\\.com/"
+        "urlPattern": "^https://(?:[a-z0-9-]+\\.)?justgiving\\.com/"
     },
     "prehideSelectors": ["#cookiebanner-popup"],
     "detectCmp": [

--- a/tests/justgiving.spec.ts
+++ b/tests/justgiving.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('justgiving.com', ['https://www.justgiving.com/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1214769645981728?focus=true

## Description:

Adds a new site-specific rule for `justgiving.com` to handle the cookie consent popup shown on `https://www.justgiving.com/` and other `justgiving.com` subdomains that render the same `#cookiebanner-popup` UI.

JustGiving uses a custom cookie consent popup backed by Cookiebot under the hood (`window.Cookiebot` is loaded from `consent.cookiebot.com`, and the standard `CookieConsent` cookie is written), but the visible UI is JG's own component with bespoke button IDs (`#accept-all-Cookies`, `#accept-essential-Cookies`). The generic `Cybotcookiebot` rule cannot dismiss this UI because it targets `#CybotCookiebotDialog` elements that are present in the DOM but never displayed on JustGiving.

The popup is identical across regions (UK, US, DE, AU all show the same GDPR-style dialog with the "Essential cookies only" reject path), so a single rule covers all geographies.

The new rule:

- restricts itself to `justgiving.com` (and subdomains) via `runContext.urlPattern`
- detects the popup container `#cookiebanner-popup` (with a fallback to `#jg-chrome-header` so detection wins the race against the generic Cookiebot rule on slower page loads)
- opts in via `#accept-all-Cookies` and opts out via `#accept-essential-Cookies`
- verifies opt-out by checking the `CookieConsent` cookie contains `necessary:true%2Cpreferences:false`

## Steps to test this PR:

1. `npm ci && npm run prepublish`
2. `npm run rule-syntax-check`
3. `npm run test:lib`
4. `REGION=GB npx playwright test tests/justgiving.spec.ts` (run across `chrome`, `webkit`, `firefox`)
5. Load the built extension (`dist/addon-mv3/`) in Chrome, visit `https://www.justgiving.com/`, and confirm the popup is dismissed automatically and the page remains usable.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-972aea5e-19dd-4bb5-889a-d1c701aae8b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-972aea5e-19dd-4bb5-889a-d1c701aae8b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

