### PR TITLE
Add GoDaddy Website Builder cookie banner rule (covers termlimitthecourt.com)

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -53,8 +53,13 @@ export function isElementVisible(elem: HTMLElement): boolean {
     } else {
         const css = window.getComputedStyle(elem);
         if (css.position === 'fixed' && css.display !== 'none') {
-            // fixed elements may be visible even if the parent is not
-            return true;
+            // Fixed elements may be visible even if the parent is not. But sites
+            // sometimes leave fixed banners parked offscreen (e.g. below the
+            // viewport, with no transform set) instead of removing them from
+            // the DOM after dismissal — verify that the element actually
+            // intersects the viewport before treating it as visible.
+            const r = elem.getBoundingClientRect();
+            return r.bottom > 0 && r.right > 0 && r.top < window.innerHeight && r.left < window.innerWidth;
         }
     }
     return false;

--- a/rules/autoconsent/godaddy-website-builder.json
+++ b/rules/autoconsent/godaddy-website-builder.json
@@ -2,15 +2,15 @@
     "name": "godaddy-website-builder",
     "vendorUrl": "https://www.godaddy.com/websites/website-builder",
     "cosmetic": false,
-    "prehideSelectors": ["[data-aid='FOOTER_COOKIE_BANNER_RENDERED'][style*='translateY']"],
+    "prehideSelectors": ["[data-aid='FOOTER_COOKIE_BANNER_RENDERED']"],
     "detectCmp": [
         {
-            "exists": "[data-aid='FOOTER_COOKIE_BANNER_RENDERED'][style*='translateY']"
+            "exists": "[data-aid='FOOTER_COOKIE_BANNER_RENDERED']"
         }
     ],
     "detectPopup": [
         {
-            "visible": "[data-aid='FOOTER_COOKIE_BANNER_RENDERED'][style*='translateY']"
+            "visible": "[data-aid='FOOTER_COOKIE_BANNER_RENDERED']"
         }
     ],
     "optIn": [
@@ -35,7 +35,7 @@
     ],
     "test": [
         {
-            "visible": "[data-aid='FOOTER_COOKIE_BANNER_RENDERED'][style*='translateY']",
+            "visible": "[data-aid='FOOTER_COOKIE_BANNER_RENDERED']",
             "check": "none"
         }
     ]

--- a/rules/autoconsent/godaddy-website-builder.json
+++ b/rules/autoconsent/godaddy-website-builder.json
@@ -1,0 +1,42 @@
+{
+    "name": "godaddy-website-builder",
+    "vendorUrl": "https://www.godaddy.com/websites/website-builder",
+    "cosmetic": false,
+    "prehideSelectors": ["[data-aid='FOOTER_COOKIE_BANNER_RENDERED']"],
+    "detectCmp": [
+        {
+            "exists": "[data-aid='FOOTER_COOKIE_BANNER_RENDERED']"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "[data-aid='FOOTER_COOKIE_BANNER_RENDERED']"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "[data-aid='FOOTER_COOKIE_CLOSE_RENDERED']"
+        }
+    ],
+    "optOut": [
+        {
+            "if": { "exists": "[data-aid='FOOTER_COOKIE_DECLINE_RENDERED']" },
+            "then": [
+                {
+                    "waitForThenClick": "[data-aid='FOOTER_COOKIE_DECLINE_RENDERED']"
+                }
+            ],
+            "else": [
+                {
+                    "hide": "[data-aid='FOOTER_COOKIE_BANNER_RENDERED']"
+                }
+            ]
+        }
+    ],
+    "test": [
+        {
+            "visible": "[data-aid='FOOTER_COOKIE_BANNER_RENDERED']",
+            "check": "none"
+        }
+    ]
+}

--- a/rules/autoconsent/godaddy-website-builder.json
+++ b/rules/autoconsent/godaddy-website-builder.json
@@ -2,15 +2,15 @@
     "name": "godaddy-website-builder",
     "vendorUrl": "https://www.godaddy.com/websites/website-builder",
     "cosmetic": false,
-    "prehideSelectors": ["[data-aid='FOOTER_COOKIE_BANNER_RENDERED']"],
+    "prehideSelectors": ["[data-aid='FOOTER_COOKIE_BANNER_RENDERED'][style*='translateY']"],
     "detectCmp": [
         {
-            "exists": "[data-aid='FOOTER_COOKIE_BANNER_RENDERED']"
+            "exists": "[data-aid='FOOTER_COOKIE_BANNER_RENDERED'][style*='translateY']"
         }
     ],
     "detectPopup": [
         {
-            "visible": "[data-aid='FOOTER_COOKIE_BANNER_RENDERED']"
+            "visible": "[data-aid='FOOTER_COOKIE_BANNER_RENDERED'][style*='translateY']"
         }
     ],
     "optIn": [
@@ -35,7 +35,7 @@
     ],
     "test": [
         {
-            "visible": "[data-aid='FOOTER_COOKIE_BANNER_RENDERED']",
+            "visible": "[data-aid='FOOTER_COOKIE_BANNER_RENDERED'][style*='translateY']",
             "check": "none"
         }
     ]

--- a/tests-wtr/dom-actions/dom-actions.element-visible.html
+++ b/tests-wtr/dom-actions/dom-actions.element-visible.html
@@ -23,5 +23,20 @@
             <button>This one is visible</button>
             <button>This one too</button>
         </div>
+
+        <!--
+            Fixed banners that GoDaddy/Websites+Marketing-style site builders
+            leave parked in the DOM after dismissal: position: fixed, display:
+            block, but rendered far outside the viewport. Treat as not visible.
+        -->
+        <div id="fixed-parked-below" style="position: fixed; left: 0; top: 9999px; width: 300px; height: 200px; background: white">
+            <button>Decline</button>
+        </div>
+        <div id="fixed-parked-right" style="position: fixed; left: 9999px; top: 0; width: 300px; height: 200px; background: white">
+            <button>Decline</button>
+        </div>
+        <div id="fixed-onscreen" style="position: fixed; left: 0; bottom: 0; width: 300px; height: 200px; background: white">
+            <button>Decline</button>
+        </div>
     </body>
 </html>

--- a/tests-wtr/dom-actions/dom-actions.element-visible.ts
+++ b/tests-wtr/dom-actions/dom-actions.element-visible.ts
@@ -60,4 +60,16 @@ describe('elementVisible', () => {
             expect(domActions.elementVisible(['#all-visible', 'button'], 'all')).to.be.true;
         });
     });
+
+    describe('fixed elements parked outside the viewport', () => {
+        it('treats a fixed element rendered below the viewport as not visible', () => {
+            expect(domActions.elementVisible('#fixed-parked-below', 'any')).to.be.false;
+        });
+        it('treats a fixed element rendered to the right of the viewport as not visible', () => {
+            expect(domActions.elementVisible('#fixed-parked-right', 'any')).to.be.false;
+        });
+        it('treats a fixed element inside the viewport as visible', () => {
+            expect(domActions.elementVisible('#fixed-onscreen', 'any')).to.be.true;
+        });
+    });
 });

--- a/tests/godaddy-website-builder.spec.ts
+++ b/tests/godaddy-website-builder.spec.ts
@@ -1,0 +1,7 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('godaddy-website-builder', [
+    'https://termlimitthecourt.com/',
+    'https://digitronixone.com/',
+    'https://filmschoolrejects.com/',
+]);

--- a/tests/godaddy-website-builder.spec.ts
+++ b/tests/godaddy-website-builder.spec.ts
@@ -1,7 +1,3 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('godaddy-website-builder', [
-    'https://termlimitthecourt.com/',
-    'https://digitronixone.com/',
-    'https://filmschoolrejects.com/',
-]);
+generateCMPTests('godaddy-website-builder', ['https://termlimitthecourt.com/', 'https://dilbert.com/', 'https://gapmedics.com/']);

--- a/tests/godaddy-website-builder.spec.ts
+++ b/tests/godaddy-website-builder.spec.ts
@@ -1,3 +1,3 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('godaddy-website-builder', ['https://termlimitthecourt.com/', 'https://dilbert.com/', 'https://gapmedics.com/']);
+generateCMPTests('godaddy-website-builder', ['https://termlimitthecourt.com/', 'https://breakingtheviciouscycle.info/']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1214468130355855?focus=true

## Description:

Adds a generic CMP rule for the cookie banner rendered by GoDaddy's "Websites + Marketing" website builder. The banner is widespread — PublicWWW returns 100k+ matches for the `data-aid="FOOTER_COOKIE_BANNER_RENDERED"` attribute on the banner container.

Reported on https://termlimitthecourt.com/ (macOS, US), where the variant on that site only renders an `ACCEPT` button:

- If `[data-aid='FOOTER_COOKIE_DECLINE_RENDERED']` exists (e.g. `breakingtheviciouscycle.info`), opt-out clicks Decline.
- Otherwise (e.g. `termlimitthecourt.com`), the rule falls back to a cosmetic `hide` of the banner — same pattern as `google-cookiebar.json`.

Opt-in clicks `[data-aid='FOOTER_COOKIE_CLOSE_RENDERED']`.

### Engine fix: `isElementVisible` viewport intersection check

The GoDaddy template renders the banner element into the DOM on every page load regardless of whether the user has already dismissed it: it stays `position: fixed; display: block; opacity: 1`, just rendered below the viewport. The previous `isElementVisible` heuristic treated any `position: fixed; display !== none` element as visible regardless of its bounding rect, which made:

- the **heuristic CMP** false-fire on the parked banner (clicking the offscreen "Decline" button), and
- any `visible` rule step on the banner return true even when nothing was being shown to the user.

`lib/utils.ts` — `isElementVisible` now also verifies the element's `getBoundingClientRect()` intersects the viewport before treating a fixed element with no `offsetParent` as visible. Elements with `offsetParent !== null` keep the existing fast path. Unit tests cover fixed elements parked below / to the right of the viewport and a control case for an in-viewport fixed element.

### Verification

Cross-region run (oxylabs) — fresh visits across US/DE/GB on `termlimitthecourt.com`, `breakingtheviciouscycle.info`, and `digitronixone.com`:

```
termlimitthecourt.com         [us-newyork]: cmp=godaddy-website-builder popup=true optOut=true selfTest=true
termlimitthecourt.com         [de]:         cmp=godaddy-website-builder popup=true optOut=true selfTest=true
termlimitthecourt.com         [gb]:         cmp=godaddy-website-builder popup=true optOut=true selfTest=true
breakingtheviciouscycle.info  [us-newyork]: cmp=godaddy-website-builder popup=true optOut=true selfTest=true
breakingtheviciouscycle.info  [de]:         cmp=godaddy-website-builder popup=true optOut=true selfTest=true
breakingtheviciouscycle.info  [gb]:         cmp=godaddy-website-builder popup=true optOut=true selfTest=true
digitronixone.com             [us-newyork]: cmp=godaddy-website-builder popup=true optOut=true selfTest=true
```

Returning-visit (cookie pre-set, banner parked offscreen):

```
termlimitthecourt.com         [us-newyork]: popup=false optOut=null  (no false action)
breakingtheviciouscycle.info  [us-newyork]: popup=false optOut=null  (no false action)
digitronixone.com             [us-newyork]: popup=false optOut=null  (no false action)
```

The heuristic no longer fires on the parked banner; my rule's `detectCmp: exists` still matches (the element is in the DOM) but `detectPopup: visible` correctly returns false thanks to the engine fix, so no opt-out is taken.

Local Playwright (`npx playwright test tests/godaddy-website-builder.spec.ts --project chrome`): 4 passed.
Web Test Runner unit tests: 795 passed (including 3 new tests for the `isElementVisible` viewport check).

## Steps to test this PR:

1. `npm ci && npm run prepublish`
2. `npm run test:lib` — Web Test Runner unit tests, including the new `isElementVisible` cases
3. `npx playwright test tests/godaddy-website-builder.spec.ts`
4. (Optional) Use a regional-testing skill to verify on `termlimitthecourt.com` (Accept-only) and `breakingtheviciouscycle.info` (Accept + Decline) across regions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82556c35-63a7-4f64-b5a9-40c6f16baeef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82556c35-63a7-4f64-b5a9-40c6f16baeef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

