### PR TITLE
Skip age-verification popups in heuristic CMP detection (doublelist.com fix)

### DIFF
--- a/lib/heuristic-patterns.ts
+++ b/lib/heuristic-patterns.ts
@@ -715,3 +715,26 @@ export const NEVER_MATCH_PATTERNS = [
     /sostienici/is,
     /suscribir/is,
 ];
+
+// Popup-text patterns that exclude a popup from heuristic handling, even if it
+// matches a cookie pattern and exposes a reject-style button. Targets age gates
+// and adult-content disclaimers whose "reject" button leads to a dead end.
+export const POPUP_EXCLUDE_PATTERNS = [
+    // "Age verification", "age confirmation", "age check", "age gate"
+    /age\s+(?:verification|confirmation|check|gate|restriction)/i,
+
+    // "INTENDED ONLY FOR PERSONS OVER 18 YEARS OF AGE", "must be over 18", "at least 18 years"
+    /(?:over|above|at\s*least|minimum|older\s+than)\s*(?:18|21)\s*(?:years|yo|y\.?o\.?|\+)?/i,
+
+    // "18 years of age", "18+ years old", "21 years or older"
+    /(?:18|21)\s*(?:\+|years?)\s*(?:of\s*age|or\s*older|or\s*above)/i,
+
+    // "I am 18+", "I am over 18", "I'm 21 or older"
+    /(?:i'?m|i\s*am)\s*(?:over|above|at\s*least)?\s*(?:18|21)(?:\+|\s*(?:or\s*older|years))?/i,
+
+    // "you must be 18", "you must be at least 18 years old"
+    /(?:you|users?|visitors?)\s+must\s+be\s+(?:over|above|at\s*least)?\s*(?:18|21)/i,
+
+    // "adult oriented material", "adult content", "adult-only material/website"
+    /adult[\s-]+(?:oriented|only|content|material|websites?)/i,
+];

--- a/lib/heuristics.ts
+++ b/lib/heuristics.ts
@@ -1,4 +1,4 @@
-import { DETECT_PATTERNS, NEVER_MATCH_PATTERNS, REJECT_PATTERNS } from './heuristic-patterns';
+import { DETECT_PATTERNS, NEVER_MATCH_PATTERNS, POPUP_EXCLUDE_PATTERNS, REJECT_PATTERNS } from './heuristic-patterns';
 import { ButtonData, PopupData } from './types';
 import { isElementVisible, isTopFrame } from './utils';
 
@@ -25,6 +25,11 @@ export function getActionablePopups(): PopupData[] {
     const result = popups.reduce((acc, popup) => {
         const popupText = popup.text?.trim();
         if (popupText) {
+            // Skip age gates / adult-content disclaimers whose reject button
+            // leads to a dead-end page (e.g. doublelist.com).
+            if (isExcludedPopup(popupText)) {
+                return acc;
+            }
             const { patterns } = checkHeuristicPatterns(popupText);
             if (patterns.length > 0) {
                 const { rejectButtons, otherButtons } = classifyButtons(popup.buttons);
@@ -40,6 +45,14 @@ export function getActionablePopups(): PopupData[] {
         return acc;
     }, [] as PopupData[]);
     return result;
+}
+
+export function isExcludedPopup(popupText: string, excludePatterns = POPUP_EXCLUDE_PATTERNS): boolean {
+    if (!popupText) {
+        return false;
+    }
+    const truncated = popupText.slice(0, TEXT_LIMIT);
+    return excludePatterns.some((p) => p.test(truncated));
 }
 
 export function classifyButtons(buttons: ButtonData[]): { rejectButtons: ButtonData[]; otherButtons: ButtonData[] } {

--- a/tests-wtr/heuristics/get-actionable-popups.html
+++ b/tests-wtr/heuristics/get-actionable-popups.html
@@ -92,5 +92,15 @@
             <button>Accept All</button>
             <button>Reject All</button>
         </dialog>
+
+        <div id="popup-age-gate" class="popup" role="dialog">
+            <h2>Age verification &amp; content rules</h2>
+            <p>
+                This section may contain adult oriented material of a graphic and sexual nature. This material is INTENDED ONLY FOR PERSONS
+                OVER 18 YEARS OF AGE. This site uses cookies for logins, ads and other normal site function.
+            </p>
+            <button>I accept</button>
+            <button>I reject</button>
+        </div>
     </body>
 </html>

--- a/tests-wtr/heuristics/get-actionable-popups.ts
+++ b/tests-wtr/heuristics/get-actionable-popups.ts
@@ -41,6 +41,14 @@ describe('getActionablePopups', () => {
 
             expect(popups.length).to.equal(0);
         });
+
+        it('ignores age-verification popup that incidentally mentions cookies', () => {
+            showPopup('popup-age-gate');
+
+            const popups = getActionablePopups();
+
+            expect(popups.length).to.equal(0);
+        });
     });
 
     describe('positioning', () => {

--- a/tests-wtr/heuristics/heuristics-utils.test.ts
+++ b/tests-wtr/heuristics/heuristics-utils.test.ts
@@ -8,6 +8,7 @@ import {
     excludeContainers,
     getButtonData,
     isDialogLikeElement,
+    isExcludedPopup,
 } from '../../lib/heuristics';
 
 describe('checkHeuristicPatterns', () => {
@@ -37,6 +38,43 @@ describe('checkHeuristicPatterns', () => {
 
         expect(patterns).to.have.length(0);
         expect(snippets).to.have.length(0);
+    });
+});
+
+describe('isExcludedPopup', () => {
+    it('flags doublelist-style age verification popups', () => {
+        // Real-world text from the doublelist.com age gate (M4M listings page)
+        const text =
+            'Age verification & content rules This section may contain adult oriented material of a graphic and sexual nature, ' +
+            'and could be viewed objectionable to some persons. This material is INTENDED ONLY FOR PERSONS OVER 18 YEARS OF AGE. ' +
+            'This site uses cookies for logins, ads and other normal site function. I accept I reject';
+        expect(isExcludedPopup(text)).to.be.true;
+    });
+
+    it('flags popups headed "Age verification"', () => {
+        expect(isExcludedPopup('Age verification\nYou must confirm your age to continue.')).to.be.true;
+    });
+
+    it('flags "must be 18 or older" disclaimers', () => {
+        expect(isExcludedPopup('You must be 18 years or older to enter this site.')).to.be.true;
+    });
+
+    it('flags "I am 18+" age gates', () => {
+        expect(isExcludedPopup('Confirm your age to continue. I am 18+ I am under 18')).to.be.true;
+    });
+
+    it('flags adult-content disclaimers', () => {
+        expect(isExcludedPopup('This website contains adult oriented material. Please confirm to enter.')).to.be.true;
+        expect(isExcludedPopup('Adult-only website. You must be 21 or older to enter.')).to.be.true;
+        expect(isExcludedPopup('Adult website ahead.')).to.be.true;
+    });
+
+    it('does not flag a normal cookie consent popup', () => {
+        expect(isExcludedPopup('We use cookies to enhance your experience. Accept All Reject All')).to.be.false;
+    });
+
+    it('does not flag empty strings', () => {
+        expect(isExcludedPopup('')).to.be.false;
     });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1214706429742001?focus=true

## Description:

The HEURISTIC rule was clicking the **"I reject"** button on doublelist.com's age-verification dialog, navigating users to a `Don't want to abide by Doublelist terms?` dead-end page (no listings shown).

The age modal contains the sentence

> *This site uses cookies for logins, ads and other normal site function.*

which matches the heuristic's `"this site … cookies"` cookie-consent pattern, and exposes a button labeled `I reject` (matches the English `reject` regex). The popup looked like a cookie consent prompt to autoconsent — but rejecting actually rejects the age verification + ToS, not cookies.

### Fix

Add `POPUP_EXCLUDE_PATTERNS` to `lib/heuristic-patterns.ts`. When any pattern matches the popup's body text, the popup is excluded from heuristic handling regardless of cookie/reject signals. Patterns target unambiguous age-gate phrasing:

- `age verification` / `age confirmation` / `age check` / `age gate`
- `over/above/at least 18 years`, `21 years of age or older`, `18+`, etc.
- `I am 18+`, `I'm over 21`
- `you/users/visitors must be 18`
- `adult oriented/only/content/material/website`

`getActionablePopups` now skips popups whose text matches any exclude pattern before classifying buttons.

### Why fix the heuristic instead of just adding a doublelist site exception?

A site exception for `doublelist.com` was already merged in [privacy-configuration#5137](https://github.com/duckduckgo/privacy-configuration/pull/5137) earlier today, so users are already protected. This change goes further and prevents the same class of breakage on other adult / age-gated sites that pair a `cookies` mention with an `accept`/`reject` age choice — without requiring per-site exceptions.

The privacy-configuration exception remains harmless once this lands; it'll just become a no-op since HEURISTIC will no longer try to act on the modal.

## Steps to test this PR:

1. `npm ci && npm run prepublish`
2. `npm run lint` — passes (eslint + prettier + JSON rule schema)
3. `npm run test:lib` — 800 tests pass, including the new `isExcludedPopup` unit tests and the `popup-age-gate` integration case in `tests-wtr/heuristics/get-actionable-popups.{html,ts}`.
4. **Repro / verification on the live site** (Oxylabs remote browser, US / `us-newyork`):
   - URL: `https://doublelist.com/city/new_york/M4M/`

   **Before — autoconsent injected, US region — broken:**

   [Before fix: Don](https://cursor.com/agents/bc-32a846b7-401c-4581-982a-cc621327c6ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdl-before-fix-us.jpg)

   **After — autoconsent injected, US region — age modal preserved:**

   [After fix: age verification modal still shown](https://cursor.com/agents/bc-32a846b7-401c-4581-982a-cc621327c6ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdl-after-fix-us.jpg)

5. Regional checks:
   - `us-newyork` — no cookie banner; previously HEURISTIC clicked age modal "I reject" → now no-op. ✅
   - `gb` — OneTrust banner detected on the home, opt-out succeeds (unchanged); age modal on listings is now untouched. ✅

     [GB region home with OneTrust opted out](https://cursor.com/agents/bc-32a846b7-401c-4581-982a-cc621327c6ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdl-home-gb-after.jpg)

     [GB region M4M page: OneTrust opted out, age modal preserved](https://cursor.com/agents/bc-32a846b7-401c-4581-982a-cc621327c6ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdl-after-fix-gb.jpg)
   - `de` — no cookie banner shown.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32a846b7-401c-4581-982a-cc621327c6ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32a846b7-401c-4581-982a-cc621327c6ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

