### PR TITLE
Add facebook-mobile rule for m.facebook.com

### DIFF
--- a/rules/autoconsent/facebook-mobile.json
+++ b/rules/autoconsent/facebook-mobile.json
@@ -1,0 +1,17 @@
+{
+    "name": "facebook-mobile",
+    "runContext": {
+        "urlPattern": "^https://(m|mbasic)\\.facebook\\.com/"
+    },
+    "prehideSelectors": ["[data-testid=\"cookie-policy-manage-dialog\"]"],
+    "detectCmp": [{ "exists": "[data-testid=\"cookie-policy-manage-dialog\"]" }],
+    "detectPopup": [{ "visible": "[data-testid=\"cookie-policy-manage-dialog\"]" }],
+    "optIn": [
+        { "waitForThenClick": "[data-testid=\"cookie-policy-manage-dialog-accept-button\"]" },
+        { "waitForVisible": "[data-testid=\"cookie-policy-manage-dialog\"]", "check": "none" }
+    ],
+    "optOut": [
+        { "waitForThenClick": "[data-testid=\"cookie-policy-manage-dialog-decline-button\"]" },
+        { "waitForVisible": "[data-testid=\"cookie-policy-manage-dialog\"]", "check": "none" }
+    ]
+}

--- a/rules/autoconsent/facebook.json
+++ b/rules/autoconsent/facebook.json
@@ -1,7 +1,7 @@
 {
     "name": "facebook",
     "runContext": {
-        "urlPattern": "^https://([a-z0-9-]+\\.)?facebook\\.com/"
+        "urlPattern": "^https://(www\\.)?facebook\\.com/"
     },
     "prehideSelectors": [],
     "detectCmp": [

--- a/tests/facebook-mobile.spec.ts
+++ b/tests/facebook-mobile.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('facebook-mobile', ['https://m.facebook.com/'], {
+    mobile: true,
+    skipRegions: ['US'],
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1214804250186822?focus=true

## Description:

The cookie popup on `m.facebook.com` (and `mbasic.facebook.com`) was left unhandled because the existing `facebook` rule's deep `nth-child` selectors target the desktop `www.facebook.com` DOM, which is different on mobile, and the heuristic skips the mobile dialog (`position: absolute`, no `role="dialog"`).

The mobile dialog still exposes stable `data-testid` markers, so this PR adds a separate `facebook-mobile` rule for the mobile subdomains using those markers, and narrows the existing desktop rule's `urlPattern` to `(www\.)?facebook\.com` to avoid overlap.

## Steps to test this PR:

1. From an EU IP, on a mobile UA, open `https://m.facebook.com/` — the cookie banner should be auto-dismissed.
2. Verified opt-out and opt-in via Oxylabs in `fr`, `de`, `gb`, `nl`, `it`, `mt` regions.
3. Desktop `www.facebook.com` flow (handled by the existing rule + heuristic) is unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcf1322c-97f1-4f68-88a8-19d105f252f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcf1322c-97f1-4f68-88a8-19d105f252f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

