### PR TITLE
Coverage data update

### DIFF
--- a/data/coverage.json
+++ b/data/coverage.json
@@ -1,70 +1,52 @@
 {
   "Admiral": {
     "DE": {
-      "sites": 33,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.power-wrestling.de/",
-        "http://www.insidermonkey.com/",
-        "http://vixcentral.com/",
-        "http://www.inc.com/",
-        "http://www.charlieintel.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.realitytea.com/",
-        "http://www.sammobile.com/",
-        "http://www.gameskinny.com/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 87,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.isthmian.co.uk/",
-        "http://manunews.com/",
-        "http://www.golfempire.co.uk/",
-        "http://www.collectors-club-of-great-britain.co.uk/",
-        "http://tfcstadiums.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.gameskinny.com/",
-        "http://www.painters-online.co.uk/",
-        "http://www.world-of-railways.co.uk/"
-      ],
-      "errorSites": []
-    }
-  },
-  "Adroll": {
-    "DE": {
-      "sites": 14,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.ztedevices.com/",
-        "http://sonix.ai/",
-        "http://www.snapeda.com/",
-        "http://www.fpmarkets.com/",
-        "http://www.edaboard.com/"
+        "http://finviz.com/",
+        "http://www.dexerto.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 32,
+      "sites": 24,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.sorrystaterecords.com/",
-        "http://www.proofreadingservices.com/",
-        "http://www.cosmo-restaurants.co.uk/",
-        "http://www.diversityresources.com/",
-        "http://www.totaltools.com.au/"
+        "http://www.lexusownersclub.co.uk/",
+        "http://www.yourtango.com/",
+        "http://www.followfollow.com/",
+        "http://www.outandaboutlive.co.uk/",
+        "http://harrowonline.org/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    }
+  },
+  "Adroll": {
+    "DE": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://iboysoft.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 2,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://iboysoft.com/",
+        "http://www.folger.edu/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -73,121 +55,66 @@
   },
   "Complianz banner": {
     "DE": {
-      "sites": 1819,
-      "errors": 2,
-      "selfTestFailures": 77,
+      "sites": 53,
+      "errors": 0,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.luftfahrtmagazin.de/",
-        "http://www.nds-fluerat.org/",
-        "http://www.seo-tech.de/",
-        "http://techbios.de/",
-        "http://www.australien-guide.de/"
+        "http://wiesbadenaktuell.de/",
+        "http://www.veranstaltung-baden-wuerttemberg.de/",
+        "http://gebrauchtwagenberater.de/",
+        "http://www.2basketballbundesliga.de/",
+        "http://pdf-xchange.de/"
       ],
-      "failingSites": [
-        "http://dlb-aoer.de/",
-        "http://ilovecycling.de/",
-        "http://leckerkuche.de/",
-        "http://kerntemperatur-tabelle.de/",
-        "http://tinderacademy.com/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [
-        "http://flamingo-fkk.de/",
-        "http://www.autocolumn.com/",
-        "http://guitar-shop.de/",
-        "http://www.saunapark-siebengebirge.de/",
-        "http://www.hausbauen24.eu/"
+        "http://www.autocolumn.com/"
       ],
-      "errorSites": [
-        "http://robinkaiser.eu/",
-        "http://www.muenchen-sehen.de/"
-      ]
+      "errorSites": []
     },
     "GB": {
-      "sites": 1330,
-      "errors": 5,
-      "selfTestFailures": 57,
+      "sites": 28,
+      "errors": 0,
+      "selfTestFailures": 5,
       "exampleSites": [
-        "http://cinnamon.org.uk/",
-        "http://www.eshores.co.uk/",
-        "http://mypatientadvice.co.uk/",
-        "http://whaleybridgecanal.org/",
-        "http://pipeline-products.co.uk/"
+        "http://www.ypc.co.uk/",
+        "http://ballotbox.scot/",
+        "http://thyroiduk.org/",
+        "http://greenparty.org.uk/",
+        "http://www.nationaltrail.co.uk/"
       ],
       "failingSites": [
-        "http://www.camping-online.co.uk/",
-        "http://derestreet.co.uk/",
-        "http://tileandstonemedic.co.uk/",
-        "http://swheritage.org.uk/",
-        "http://www.arenaswimuk.com/"
+        "http://rsgb.org/",
+        "http://www.bedfordshirehospitals.nhs.uk/",
+        "http://www.mkuh.nhs.uk/",
+        "http://www.splitmyfare.co.uk/",
+        "http://www.thedecoratorsforum.com/"
       ],
-      "unsuccessfulSites": [
-        "http://peerage.org.uk/",
-        "http://clubhubuk.co.uk/",
-        "http://linuxbeast.com/",
-        "http://food-mag.co.uk/",
-        "http://incogniton.com/"
-      ],
-      "errorSites": [
-        "http://applerepairprices.co.uk/",
-        "http://resartis.org/",
-        "http://www.thebookbuyer.co.uk/",
-        "http://linuxbeast.com/",
-        "http://lotterychecker.co.uk/"
-      ]
+      "unsuccessfulSites": [],
+      "errorSites": []
     },
     "US": {
-      "sites": 535,
+      "sites": 13,
       "errors": 0,
-      "selfTestFailures": 19,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://drbarbara.info/",
-        "http://elrio.org/",
-        "http://www.thestranger.com/",
-        "http://www.fuller.edu/",
-        "http://thebusinessdive.com/"
+        "http://houseandbeyond.org/",
+        "http://lifestance.com/",
+        "http://www.mvd.newmexico.gov/",
+        "http://sportsbrackets.net/",
+        "http://www.gun-tests.com/"
       ],
-      "failingSites": [
-        "http://www.nasdaqprivatemarket.com/",
-        "http://lovefoodfeed.com/",
-        "http://www.ankarsrum.com/",
-        "http://rxo.com/",
-        "http://megagames.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://barrett.net/",
-        "http://www.thechicagoschool.edu/",
-        "http://victorycruiselines.com/",
-        "http://www.twia.org/",
-        "http://www.tvseasonspoilers.com/"
-      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "Complianz categories": {
     "DE": {
-      "sites": 28,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.kunstsammlungen-chemnitz.de/",
-        "http://www.dein-wollshop.de/",
-        "http://www.waffenhandelmesser.de/",
-        "http://www.aussenrollo.de/",
-        "http://www.topleiter.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.dein-wollshop.de/",
-        "http://www.kunstsammlungen-chemnitz.de/"
-      ],
-      "errorSites": []
-    },
-    "US": {
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://online.colostate.edu/"
+        "http://www.taxi.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -196,524 +123,284 @@
   },
   "Complianz notice": {
     "DE": {
-      "sites": 728,
+      "sites": 38,
       "errors": 0,
-      "selfTestFailures": 3,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.gaydemon.com/",
-        "http://www.kerze-anzuenden.de/",
-        "http://www.opencompute.org/",
-        "http://sinnblock.de/",
-        "http://www.timeserver.ru/"
+        "http://www.czech-tourist.de/",
+        "http://www.staatstheater-mainz.com/",
+        "http://www.laufpix.de/",
+        "http://youtubemp3free.com/",
+        "http://forum.eve-rave.ch/"
       ],
-      "failingSites": [
-        "http://zauber-lingerie.com/",
-        "http://nivadagrenchenofficial.com/",
-        "http://www.fleshlight.com/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [
-        "http://discussion.fedoraproject.org/",
-        "http://forum.digitalisierung-mit-kopf.de/",
-        "http://community.zimaspace.com/",
-        "http://spie.org/",
-        "http://forum.cannabisanbauen.net/"
+        "http://discussion.fedoraproject.org/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 779,
+      "sites": 32,
       "errors": 0,
-      "selfTestFailures": 6,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.theonegroup.co.uk/",
-        "http://librariesandarchives.portsmouth.gov.uk/",
-        "http://www.woodmanforum.com/",
-        "http://ajbfunerals.co.uk/",
-        "http://medicine.nus.edu.sg/"
+        "http://www.outdoorgearlab.com/",
+        "http://www.thetalentmanager.com/",
+        "http://bondagevalley.cc/",
+        "http://www.yopa.co.uk/",
+        "http://www.crazyoz.com/"
       ],
-      "failingSites": [
-        "http://animology.co.uk/",
-        "http://fiorelli.com/",
-        "http://genuinemotors.co.uk/",
-        "http://shinkansen-ticket.com/",
-        "http://www.redcandy.co.uk/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.fuelsindustryuk.org/",
-        "http://www.britishtheatreguide.info/",
-        "http://forums.lawrencesystems.com/",
-        "http://spie.org/",
-        "http://forum.mikrotik.com/"
+        "http://blenderartists.org/",
+        "http://discussion.fedoraproject.org/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 447,
+      "sites": 32,
       "errors": 0,
-      "selfTestFailures": 1,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://ora.ox.ac.uk/",
-        "http://forum.freecad.org/",
-        "http://chessbroadway.com/",
-        "http://www.montanabar.org/",
-        "http://www.migrationpolicy.org/"
+        "http://www.bullion.com/",
+        "http://www.techgearlab.com/",
+        "http://uquiz.com/",
+        "http://www.neighborhoodscout.com/",
+        "http://www.voya.com/"
       ],
-      "failingSites": [
-        "http://drkellyann.com/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [
-        "http://forums.lawrencesystems.com/",
-        "http://forum.ansible.com/",
-        "http://www.usnh.edu/",
-        "http://www.wilmu.edu/",
-        "http://www.keene.edu/"
+        "http://discussion.fedoraproject.org/"
       ],
       "errorSites": []
     }
   },
   "Complianz opt-both": {
-    "DE": {
-      "sites": 35,
-      "errors": 35,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.wearerewind.com/",
-        "http://www.iallpowers.de/",
-        "http://www.gripgrab.com/",
-        "http://m1-sporttechnik.eu/",
-        "http://www.ironmaxx.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://juice.world/",
-        "http://www.penoblo.de/",
-        "http://www.flauschecke.com/"
-      ],
-      "errorSites": [
-        "http://www.spigen.com/",
-        "http://www.flauschecke.com/",
-        "http://styyl.de/",
-        "http://www.hauptstadt-moeblerei.de/",
-        "http://www.wearerewind.com/"
-      ]
-    },
     "GB": {
-      "sites": 65,
-      "errors": 58,
+      "sites": 1,
+      "errors": 1,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.stewartandgibson.co.uk/",
-        "http://sporttape.co.uk/",
-        "http://www.thegarlicfarm.co.uk/",
-        "http://showery.co.uk/",
-        "http://www.vegerpower.com/"
+        "http://www.preppersshop.co.uk/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://uk.walkingpad.com/",
-        "http://ilovewallpaper.com/",
-        "http://ravenforge.com/",
-        "http://www.fright-rags.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": [
-        "http://uk.mattandnat.com/",
-        "http://www.emmawillis.com/",
-        "http://roof-bars.co.uk/",
-        "http://sexyemporium.com/",
-        "http://www.tridenttowing.co.uk/"
-      ]
-    },
-    "US": {
-      "sites": 29,
-      "errors": 27,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.thefryecompany.com/",
-        "http://ghostgolf.com/",
-        "http://bitsysbikinis.com/",
-        "http://www.prioritybicycles.com/",
-        "http://buffcitysoap.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://aquasureusa.com/"
-      ],
-      "errorSites": [
-        "http://www.tirediscounters.com/",
-        "http://outofdarts.com/",
-        "http://bitsysbikinis.com/",
-        "http://www.sixzeropickleball.com/",
-        "http://ruggedrosaries.com/"
+        "http://www.preppersshop.co.uk/"
       ]
     }
   },
   "Complianz opt-out": {
     "DE": {
-      "sites": 188,
-      "errors": 1,
-      "selfTestFailures": 1,
+      "sites": 13,
+      "errors": 0,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.druck-medien.net/",
-        "http://www.lichtspielkino.de/",
-        "http://www.flyrotax.com/",
-        "http://www.engelglobal.com/",
-        "http://www.ktm-bikes.at/"
-      ],
-      "failingSites": [
-        "http://plustek.com/"
-      ],
-      "unsuccessfulSites": [
+        "http://biogena.com/",
+        "http://www.keba.com/",
+        "http://www.patienteninfo-service.de/",
         "http://tradersplace.de/",
-        "http://trauer.die-glocke.de/",
-        "http://www.porr.de/",
-        "http://www.haassohn.com/"
+        "http://www.dtv.de/"
       ],
-      "errorSites": [
-        "http://gewinnspiele-heute.com/"
-      ]
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://tradersplace.de/"
+      ],
+      "errorSites": []
     },
     "GB": {
-      "sites": 65,
-      "errors": 1,
-      "selfTestFailures": 1,
+      "sites": 3,
+      "errors": 0,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.themodelrailwayclub.org/",
-        "http://monochrome-watches.com/",
-        "http://www.twistbioscience.com/",
-        "http://myaccount.water-plus.co.uk/",
-        "http://stcg.ac.uk/"
+        "http://hotwifecaps.com/",
+        "http://www.abbywinters.com/",
+        "http://www.guitarcenter.com/"
       ],
-      "failingSites": [
-        "http://plustek.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.amcarparts.co.uk/",
-        "http://myaccount.water-plus.co.uk/",
-        "http://www.jointhecops.co.uk/"
-      ],
-      "errorSites": [
-        "http://spiritnavigator.com/"
-      ]
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
     },
     "US": {
-      "sites": 161,
+      "sites": 21,
       "errors": 0,
-      "selfTestFailures": 3,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://support.deltafaucet.com/",
-        "http://www.behr.com/",
-        "http://www.wellcare.com/",
-        "http://www.musicarts.com/",
-        "http://www.hcahoustonhealthcare.com/"
+        "http://www.finra.org/",
+        "http://www.musiciansfriend.com/",
+        "http://www.eyemed.com/",
+        "http://hotwifecaps.com/",
+        "http://www.wellcarenow.com/"
       ],
-      "failingSites": [
-        "http://www.scotchbrand.com/",
-        "http://www.command.com/",
-        "http://hca.epayhealthcare.com/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [
-        "http://clickhouse.com/",
-        "http://www.3m.com/",
-        "http://www.hrci.org/",
-        "http://blog.purestorage.com/",
-        "http://orkin.com/"
+        "http://cava.com/"
       ],
       "errorSites": []
     }
   },
   "Complianz optin": {
     "DE": {
-      "sites": 528,
+      "sites": 25,
       "errors": 0,
-      "selfTestFailures": 1,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.maritim.de/",
-        "http://www.gottesdienst-ref.ch/",
-        "http://super-twins.de/",
-        "http://www.tascam.eu/",
-        "http://download.eclipse.org/"
+        "http://www.kvb.koeln/",
+        "http://www.simply-yummy.de/",
+        "http://www.svb.de/",
+        "http://www.bibo-dresden.de/",
+        "http://www.deutschestheater.de/"
       ],
-      "failingSites": [
-        "http://www.kvberlin.de/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.diy-academy.eu/",
-        "http://www.kv-sachsen.de/",
-        "http://www.dr-feil.com/",
-        "http://www.einladungen-selbst-gestalten.de/",
-        "http://www.weidemann.de/"
+        "http://www.hertz.de/",
+        "http://www.maritim.de/",
+        "http://www.rheuma-liga.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 247,
+      "sites": 20,
       "errors": 0,
-      "selfTestFailures": 0,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.tascam.eu/",
-        "http://www.dourishandday.co.uk/",
-        "http://bruntonresidential.com/",
-        "http://www.identibase.co.uk/",
-        "http://www.1-hydroponics.co.uk/"
+        "http://www.3m.co.uk/",
+        "http://www.gth.net/",
+        "http://www.united.com/",
+        "http://www.merton.gov.uk/",
+        "http://www.jackson-stops.co.uk/"
       ],
-      "failingSites": [],
+      "failingSites": [
+        "http://www10.surreycc.gov.uk/"
+      ],
       "unsuccessfulSites": [
-        "http://lexblinds.co.uk/",
-        "http://www.1-hydroponics.co.uk/",
-        "http://www.emas.nhs.uk/",
-        "http://shape.nato.int/",
-        "http://clickhouse.com/"
+        "http://www.hertz.co.uk/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 54,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.pepsico.com/",
-        "http://www.associaonline.com/",
-        "http://www.clarkart.edu/",
-        "http://www.pepsicojobs.com/",
-        "http://www.hines.com/"
+        "http://www.dollargeneral.com/",
+        "http://www.hertz.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://acct.ezpassde.com/",
-        "http://www.hertz.com/",
-        "http://www.cateye.com/",
-        "http://hohner.de/",
-        "http://hertz.com/"
+        "http://www.dollargeneral.com/",
+        "http://www.hertz.com/"
       ],
       "errorSites": []
     }
   },
   "Cookie Information Banner": {
     "DE": {
-      "sites": 184,
+      "sites": 9,
       "errors": 0,
-      "selfTestFailures": 1,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.meintrendyhandy.de/",
-        "http://www.media-university.de/",
-        "http://www.vacanceselect.com/",
-        "http://devzone.nordicsemi.com/",
-        "http://www.lindberghfashion.com/"
+        "http://www.visitdenmark.de/",
+        "http://www.hifiklubben.de/",
+        "http://skylum.com/",
+        "http://www.makita.de/",
+        "http://www.colorline.de/"
       ],
-      "failingSites": [
-        "http://www.hbkworld.com/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [
-        "http://sostrenegrene.com/",
-        "http://www.alslinjen.de/",
-        "http://www.boconcept.com/",
-        "http://www.oresundslinjen.com/",
-        "http://www.toontrack.com/"
+        "http://sostrenegrene.com/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 117,
+      "sites": 8,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://www.sinful.co.uk/",
         "http://officialcarmats.co.uk/",
-        "http://glasdon.com/",
-        "http://www.klattermusen.com/",
-        "http://store.danfoss.com/",
-        "http://www.oticon.co.uk/"
+        "http://www.cashconverters.co.uk/",
+        "http://www.lincoln.gov.uk/",
+        "http://www.puregym.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://sostrenegrene.com/",
-        "http://oleandsteen.co.uk/",
-        "http://www.toontrack.com/",
-        "http://www.holland.com/",
-        "http://www.carlhansen.com/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 38,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.ignitioncasino.eu/",
-        "http://www.captureone.com/",
-        "http://powersource.danfoss.com/",
-        "http://na.nokiantyres.com/",
-        "http://www.oticon.global/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.petiteknit.com/",
-        "http://www.toontrack.com/",
-        "http://www.emporia.edu/",
-        "http://www.eposaudio.com/",
-        "http://www.havilavoyages.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "Cybotcookiebot": {
     "DE": {
-      "sites": 4757,
+      "sites": 399,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://ger.sungrowpower.com/",
-        "http://bildungslexikon.gew-nrw.de/",
-        "http://www.thomas-porzellan.de/",
-        "http://www.bund.net/",
-        "http://www.wiberg.eu/"
+        "http://www.rechtsportal.de/",
+        "http://wero-wallet.eu/",
+        "http://solarhandel24.de/",
+        "http://www.jobs-beim-staat.de/",
+        "http://www.fraenkische.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://biotioo.com/",
-        "http://www.sperrer.de/",
-        "http://www.recharge.com/",
-        "http://www.egger.com/",
-        "http://www.pasing-arcaden.de/"
+        "http://www.vbn.de/",
+        "http://www.apotheke-adhoc.de/",
+        "http://www.scfreiburg.com/",
+        "http://www.firmenabc.at/",
+        "http://www.online-handelsregister.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 3817,
-      "errors": 2,
-      "selfTestFailures": 6,
-      "exampleSites": [
-        "http://www.schwalbe.com/",
-        "http://www.scotlandshop.com/",
-        "http://www.999inks.co.uk/",
-        "http://www.vividhomes.co.uk/",
-        "http://hss.com/"
-      ],
-      "failingSites": [
-        "http://adoebike.co.uk/",
-        "http://gibsonsgames.co.uk/",
-        "http://intrepidcamera.co.uk/",
-        "http://panzers.co.uk/",
-        "http://www.vanguardworld.co.uk/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.lbhf.gov.uk/",
-        "http://scampanddude.com/",
-        "http://www.mailerlite.com/",
-        "http://www.gruum.com/",
-        "http://www.totalfitness.co.uk/"
-      ],
-      "errorSites": [
-        "http://gibsonsgames.co.uk/",
-        "http://www.vanguardworld.co.uk/"
-      ]
-    },
-    "US": {
-      "sites": 1249,
-      "errors": 0,
-      "selfTestFailures": 8,
-      "exampleSites": [
-        "http://my.lesmillsondemand.com/",
-        "http://colonialwilliamsburg.org/",
-        "http://www.royalmint.com/",
-        "http://support.na.square-enix.com/",
-        "http://frontsteps.com/"
-      ],
-      "failingSites": [
-        "http://www.onxmaps.com/",
-        "http://www.streamsongresort.com/",
-        "http://www.jensonusa.com/",
-        "http://www.betterworldbooks.com/",
-        "http://www.irishcentral.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.marcorubber.com/",
-        "http://my.lesmillsondemand.com/",
-        "http://www.bbcmaestro.com/",
-        "http://www.britishmuseum.org/",
-        "http://www.auvik.com/"
-      ],
-      "errorSites": []
-    }
-  },
-  "Drupal": {
-    "DE": {
-      "sites": 1,
+      "sites": 420,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.drupal.org/"
+        "http://www.gardeningdirect.co.uk/",
+        "http://www.hss.com/",
+        "http://www.yorkracecourse.co.uk/",
+        "http://www.panini.co.uk/",
+        "http://www.cartridgesave.co.uk/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.drupal.org/"
+      "unsuccessfulSites": [
+        "http://anyflip.com/",
+        "http://heals.com/",
+        "http://thenewtinsomerset.com/",
+        "http://www.ucas.com/",
+        "http://www.bangor.ac.uk/"
       ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 2,
+      "sites": 93,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.drupal.org/",
-        "http://api.drupal.org/"
+        "http://www.similarweb.com/",
+        "http://jensonusa.com/",
+        "http://www.upmc.com/",
+        "http://www.classaction.org/",
+        "http://www.l3harris.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [],
+      "unsuccessfulSites": [
+        "http://www.santafenewmexican.com/",
+        "http://www.sharkninja.com/",
+        "http://www.similarweb.com/",
+        "http://www.titleist.com/"
+      ],
       "errorSites": []
     }
   },
   "EU Cookie Law": {
     "DE": {
-      "sites": 45,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.phv-bw.de/",
-        "http://jazzradio.net/",
-        "http://publikumskonferenz.de/",
-        "http://polt.de/",
-        "http://www.assmann-stiftung.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 26,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.froglife.org/",
-        "http://www.sheffieldchildrens.nhs.uk/",
-        "http://gomedica.org/",
-        "http://www.pv-magazine.com/",
-        "http://www.martinsmagic.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://library.sheffieldchildrens.nhs.uk/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 8,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.musicanet.org/",
-        "http://pv-magazine-usa.com/",
-        "http://sheetmusicforfree.com/",
-        "http://www.willyworries.com/",
-        "http://factmyth.com/"
+        "http://marcofellner.at/",
+        "http://www.inch-cm.de/",
+        "http://www.umrechnung-zoll-cm.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -722,567 +409,455 @@
   },
   "EZoic": {
     "DE": {
-      "sites": 345,
+      "sites": 40,
       "errors": 0,
-      "selfTestFailures": 2,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://chmodcommand.com/",
-        "http://astroinsightz.com/",
+        "http://inside-sim.de/",
+        "http://kuechegemacht.de/",
         "http://www.metric-conversions.org/",
-        "http://forum.plutonium.pw/",
-        "http://www.boote-forum.de/"
+        "http://guterboden.de/",
+        "http://de.manuals.plus/"
       ],
-      "failingSites": [
-        "http://oohmami.de/",
-        "http://artdaily.com/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.hoshyoga.org/",
-        "http://123mathe.de/",
-        "http://wordleplay.com/",
-        "http://naturwissenschaften24.com/",
-        "http://www.chorder.com/"
+        "http://feiertag.info/",
+        "http://pytutorial.com/",
+        "http://rpgbot.net/",
+        "http://www.jesus-info.de/",
+        "http://www.klinikbewertungen.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 868,
-      "errors": 3,
-      "selfTestFailures": 5,
-      "exampleSites": [
-        "http://www.generatormix.com/",
-        "http://myhomemaderecipe.com/",
-        "http://autocadeverything.com/",
-        "http://spartacus-educational.com/",
-        "http://www.chuckhawks.com/"
-      ],
-      "failingSites": [
-        "http://artdaily.cc/",
-        "http://artdaily.com/",
-        "http://howpowertool.com/",
-        "http://consort-design.com/",
-        "http://jamieolivereats.co.uk/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.libreofficetemplates.net/",
-        "http://houseofsaud.com/",
-        "http://quordlegame.org/",
-        "http://resizemyimg.com/",
-        "http://rocketcyclist.com/"
-      ],
-      "errorSites": [
-        "http://autotoride.com/",
-        "http://sammyguru.com/",
-        "http://www.pickcomfort.com/"
-      ]
-    },
-    "US": {
-      "sites": 1,
+      "sites": 69,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.theholyscript.com/"
+        "http://www.joinmychurch.com/",
+        "http://www.kyivpost.com/",
+        "http://learnprotips.com/",
+        "http://hairybikersrecipes.co.uk/",
+        "http://www.stampdutycalculator.org.uk/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [],
+      "unsuccessfulSites": [
+        "http://linuxhandbook.com/",
+        "http://pytutorial.com/",
+        "http://rpgbot.net/",
+        "http://www.dealdrop.com/"
+      ],
       "errorSites": []
     }
   },
   "Ensighten": {
     "DE": {
-      "sites": 42,
+      "sites": 10,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://volkswagen.de/",
-        "http://www.avast.de/",
-        "http://www.fidelity.co.uk/",
-        "http://www.audi-mediacenter.com/",
-        "http://at.rs-online.com/"
+        "http://www.volkswagen-nutzfahrzeuge.de/",
+        "http://www.audi.de/",
+        "http://www.easyjet.com/",
+        "http://www.bhphotovideo.com/",
+        "http://www.volkswagen.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://community.ccleaner.com/",
-        "http://www.avira.com/",
         "http://www.audi.de/",
-        "http://avast.com/",
-        "http://www.volkswagen.ch/"
+        "http://www.avast.com/",
+        "http://www.volkswagen.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 68,
+      "sites": 26,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://help.virginatlantic.com/",
-        "http://www.lvgi-intermediaries.co.uk/",
-        "http://support.ccleaner.com/",
-        "http://www.waitrosecellar.com/",
-        "http://int.rsdelivers.com/"
+        "http://www.tescoinsurance.com/",
+        "http://www.jal.co.jp/",
+        "http://www.fidelity.co.uk/",
+        "http://www.easyjet.com/",
+        "http://www.bhphotovideo.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.volkswagen.co.uk/",
-        "http://www.vw.com/",
-        "http://www.avira.com/",
-        "http://www.theheinekencompany.com/",
-        "http://www.volkswagen-vans.co.uk/"
+        "http://www.avast.com/",
+        "http://www.volkswagen-vans.co.uk/",
+        "http://www.volkswagen.co.uk/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 63,
+      "sites": 15,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://www.bhphotovideo.com/",
+        "http://www.redwingshoes.com/",
         "http://www.ccleaner.com/",
-        "http://www.krylon.com/",
-        "http://www.audi.com/",
-        "http://www.storage.com/",
-        "http://industrial.sherwin-williams.com/"
+        "http://selfstorage.com/",
+        "http://worldmarket.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://account.gomotive.com/",
-        "http://www.vw.com/",
         "http://community.avast.com/",
-        "http://www.avg.com/",
-        "http://www.avast.com/"
+        "http://lifelock.norton.com/",
+        "http://www.avast.com/",
+        "http://www.redwingshoes.com/",
+        "http://www.vw.com/"
       ],
       "errorSites": []
     }
   },
   "Evidon": {
     "DE": {
-      "sites": 25,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.gehealthcare.com/",
-        "http://www.canon.de/",
-        "http://canon.de/",
-        "http://www.rama.com/",
-        "http://www.cruisecritic.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.theforkmanager.com/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 23,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://devforum.roblox.com/",
-        "http://www.canon.co.uk/",
-        "http://shop.calor.co.uk/",
-        "http://account.depositprotection.com/",
-        "http://www.depositprotection.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.investorcentre.com/",
-        "http://www.scansnapit.com/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 47,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.e-rewards.com/",
-        "http://www-us.computershare.com/",
-        "http://en.help.roblox.com/",
-        "http://www.gevernova.com/",
-        "http://www.academybank.com/"
+        "http://www.canon.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 5,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://devforum.roblox.com/",
+        "http://www.calor.co.uk/",
+        "http://www.canon.co.uk/",
+        "http://www.computershare.com/",
+        "http://www.depositprotection.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 8,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://devforum.roblox.com/",
+        "http://www.computershare.com/",
+        "http://lenovo.com/",
+        "http://support.lenovo.com/",
+        "http://www.motorola.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://devforum.roblox.com/"
+      ],
       "errorSites": []
     }
   },
   "HEURISTIC": {
     "DE": {
-      "sites": 8782,
-      "errors": 4,
-      "selfTestFailures": 1053,
-      "exampleSites": [
-        "http://www.eichel-sensibilisieren.de/",
-        "http://www.berliner-radiosender.de/",
-        "http://www.surfoffice.com/",
-        "http://plane.so/",
-        "http://www.kreissparkasse-schwalm-eder.de/"
-      ],
-      "failingSites": [
-        "http://www.herbrand.de/",
-        "http://www.der-zooexperte.de/",
-        "http://www.hcc.de/",
-        "http://myproduct.de/",
-        "http://www.cog.de/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.logifie.com/",
-        "http://comicskingdom.com/",
-        "http://www.ulprospector.com/",
-        "http://zed.dev/",
-        "http://assettocorsa.gg/"
-      ],
-      "errorSites": [
-        "http://www.paginasamarillas.es/",
-        "http://centerparcs.de/",
-        "http://www.bricodepot.fr/",
-        "http://www.centerparcs.de/"
-      ]
-    },
-    "GB": {
-      "sites": 4587,
-      "errors": 5,
-      "selfTestFailures": 615,
-      "exampleSites": [
-        "http://fontawesome.com/",
-        "http://www.dalemain.com/",
-        "http://sterlingcarsreading.com/",
-        "http://pmx.parentmail.co.uk/",
-        "http://flywith.virginatlantic.com/"
-      ],
-      "failingSites": [
-        "http://comealiveshow.com/",
-        "http://suffolkandnortheastessex.icb.nhs.uk/",
-        "http://www.stampinup.uk/",
-        "http://www.basilicasanpietro.va/",
-        "http://airhex.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://deepinsex.com/",
-        "http://thespinningroomhifi.co.uk/",
-        "http://www.brazzers.com/",
-        "http://www.europeansleeper.eu/",
-        "http://www.blindsbypost.co.uk/"
-      ],
-      "errorSites": [
-        "http://guide.michelin.com/",
-        "http://crohns-disease.org.uk/",
-        "http://www.paginasamarillas.es/",
-        "http://www.pickupbrain.com/",
-        "http://www.bricodepot.fr/"
-      ]
-    },
-    "US": {
-      "sites": 2219,
-      "errors": 1,
-      "selfTestFailures": 421,
-      "exampleSites": [
-        "http://lordofthemysteries.fandom.com/",
-        "http://www.earthquakerdevices.com/",
-        "http://www.wisdomonline.org/",
-        "http://comic-invincible.fandom.com/",
-        "http://www.shrinerschildrens.org/"
-      ],
-      "failingSites": [
-        "http://dreamworks.fandom.com/",
-        "http://honkai-star-rail.fandom.com/",
-        "http://eecu.org/",
-        "http://www.mustangseats.com/",
-        "http://www.macktrucks.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://vulcraft.com/",
-        "http://vixenswimwear.com/",
-        "http://batesnursery.com/",
-        "http://www.nobuhotels.com/",
-        "http://gatherer.wizards.com/"
-      ],
-      "errorSites": [
-        "http://chat.deepseek.com/"
-      ]
-    }
-  },
-  "Klaro": {
-    "DE": {
-      "sites": 1063,
+      "sites": 812,
       "errors": 0,
-      "selfTestFailures": 19,
+      "selfTestFailures": 78,
       "exampleSites": [
-        "http://3d-drucken.info/",
-        "http://www.trier.de/",
-        "http://mecklenburg-vorpommern.nabu.de/",
-        "http://fitbase.fitness/",
-        "http://www.amperhof.de/"
+        "http://www.proidee.de/",
+        "http://edeka.de/",
+        "http://booking.com/",
+        "http://www.midea.com/",
+        "http://surfshark.com/"
       ],
       "failingSites": [
-        "http://www.th-ab.de/",
-        "http://www.nationalpark-hainich.de/",
-        "http://www.bibiblocksberg.de/",
-        "http://www.cducsu.de/",
-        "http://www.frischeparadies.de/"
+        "http://www.kzvb.de/",
+        "http://www.cms.hu-berlin.de/",
+        "http://www.vogue.de/",
+        "http://de.wikiital.com/",
+        "http://www.bmvg.de/"
       ],
       "unsuccessfulSites": [
-        "http://www.oberschwabenklinik.de/",
-        "http://tv.eintracht.de/",
-        "http://www.kv-thueringen.de/",
-        "http://kapellmann.de/",
-        "http://www.clickandprint.de/"
+        "http://trustlocal.de/",
+        "http://help.disneyplus.com/",
+        "http://www.airbnb.ch/",
+        "http://web.magentatv.de/",
+        "http://www.logo.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 138,
+      "sites": 613,
+      "errors": 0,
+      "selfTestFailures": 65,
+      "exampleSites": [
+        "http://www.primevideo.com/",
+        "http://zed.dev/",
+        "http://fr.pornhub.com/",
+        "http://www.bbc.co.uk/",
+        "http://www.coventrybuildingsociety.co.uk/"
+      ],
+      "failingSites": [
+        "http://www.audacityteam.org/",
+        "http://www.sutton.gov.uk/",
+        "http://www.binance.com/",
+        "http://shevibe.com/",
+        "http://www.radissonhotels.com/"
+      ],
+      "unsuccessfulSites": [
+        "http://www.mandg.com/",
+        "http://dashboard.stripe.com/",
+        "http://setapp.com/",
+        "http://tik-porn.com/",
+        "http://remarkable.com/"
+      ],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 222,
+      "errors": 0,
+      "selfTestFailures": 50,
+      "exampleSites": [
+        "http://www.chicagobears.com/",
+        "http://fridaynightfunking.fandom.com/",
+        "http://fleshbot.com/",
+        "http://community.fortinet.com/",
+        "http://blabbermouth.net/"
+      ],
+      "failingSites": [
+        "http://genshin-impact.fandom.com/",
+        "http://www.stockgumshoe.com/",
+        "http://www.lpsg.com/",
+        "http://harrypotter.fandom.com/",
+        "http://www.lemonade.com/"
+      ],
+      "unsuccessfulSites": [
+        "http://www.talkie-ai.com/",
+        "http://huskers.com/",
+        "http://wwws.airfrance.fr/",
+        "http://www.beatport.com/",
+        "http://www.ethanallen.com/"
+      ],
+      "errorSites": []
+    }
+  },
+  "Klaro": {
+    "DE": {
+      "sites": 74,
       "errors": 0,
       "selfTestFailures": 3,
       "exampleSites": [
-        "http://apmg-international.com/",
-        "http://www.giantbomb.com/",
-        "http://www.budget.ie/",
-        "http://www.enfsolar.com/",
-        "http://www.stats.ox.ac.uk/"
+        "http://www.stw-thueringen.de/",
+        "http://www.lehrerforen.de/",
+        "http://www.fb03.uni-frankfurt.de/",
+        "http://www.adac-shop.de/",
+        "http://www.oberberg-aktuell.de/"
       ],
       "failingSites": [
-        "http://avery.co.uk/",
-        "http://english.hi.is/",
+        "http://wogibtswas.de/",
+        "http://www.avery-zweckform.com/",
+        "http://www.selgros.de/"
+      ],
+      "unsuccessfulSites": [
+        "http://www.audio-markt.de/",
+        "http://www.oberberg-aktuell.de/"
+      ],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 16,
+      "errors": 0,
+      "selfTestFailures": 1,
+      "exampleSites": [
+        "http://www.easthants.gov.uk/",
+        "http://www.brighton-hove.gov.uk/",
+        "http://www.barbican.org.uk/",
+        "http://www.dundee.ac.uk/",
+        "http://www.avery.co.uk/"
+      ],
+      "failingSites": [
         "http://www.avery.co.uk/"
       ],
       "unsuccessfulSites": [
-        "http://rothenberger.com/",
-        "http://www.theory11.com/",
-        "http://www.lindsays.co.uk/",
         "http://www.dudley.gov.uk/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 68,
+      "sites": 4,
       "errors": 0,
-      "selfTestFailures": 2,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.iit.edu/",
-        "http://www.pricegrabber.com/",
-        "http://www.ymcaeastbay.org/",
-        "http://www.stonebrewing.com/",
+        "http://poets.org/",
+        "http://ucanr.edu/",
         "http://www.prolific.com/"
       ],
-      "failingSites": [
-        "http://www.pricegrabber.com/",
-        "http://www.avery.co.uk/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.montereycountynow.com/",
-        "http://education.virginia.edu/"
-      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "Moove": {
     "DE": {
-      "sites": 242,
-      "errors": 2,
-      "selfTestFailures": 4,
-      "exampleSites": [
-        "http://lernen-aus-der-geschichte.de/",
-        "http://www.meinseitensprung.com/",
-        "http://baudienst.shop/",
-        "http://www.top-10-liste.de/",
-        "http://kaffeeman.de/"
-      ],
-      "failingSites": [
-        "http://vrgamingworld.de/",
-        "http://gamefinity.net/",
-        "http://www.meinseitensprung.com/",
-        "http://baudienst.shop/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.muenchen-sehen.de/",
-        "http://www.tomatenjunkie.de/",
-        "http://aaai.org/",
-        "http://www.rolf-spectacles.com/"
-      ],
-      "errorSites": [
-        "http://www.muenchen-sehen.de/",
-        "http://aaai.org/"
-      ]
-    },
-    "GB": {
-      "sites": 409,
+      "sites": 8,
       "errors": 0,
-      "selfTestFailures": 4,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://mykitchenaccessories.co.uk/",
-        "http://sleep-apnoea-trust.org/",
-        "http://pearlacoustics.com/",
-        "http://www.rugbystore.co.uk/",
-        "http://manchesterwindowfactory.co.uk/"
+        "http://augengeradeaus.net/",
+        "http://www.mwgfd.org/",
+        "http://cyborgseason.com/",
+        "http://physio-sos.de/",
+        "http://kulturnews.de/"
       ],
-      "failingSites": [
-        "http://highlightcrafts.com/",
-        "http://www.realityproject.net/",
-        "http://www.roastwinner.co.uk/",
-        "http://www.westmidlands-pcc.gov.uk/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [
-        "http://cornishmetals.com/",
-        "http://bromleylittletheatre.org/",
-        "http://studyinternational.com/",
-        "http://kingpins.co.uk/",
-        "http://givingisgreat.org/"
+        "http://www.tomatenjunkie.de/"
       ],
       "errorSites": []
     },
-    "US": {
-      "sites": 165,
+    "GB": {
+      "sites": 6,
       "errors": 0,
-      "selfTestFailures": 3,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.findthebestcarprice.com/",
-        "http://www.tacocabana.com/",
-        "http://understandingfafsa.org/",
-        "http://neilchasefilm.com/",
-        "http://www.mvsb.com/"
+        "http://basc.org.uk/",
+        "http://hoa.org.uk/",
+        "http://osmouk.com/",
+        "http://skygarden.london/",
+        "http://www.nhslanarkshire.scot.nhs.uk/"
       ],
-      "failingSites": [
-        "http://www.realityproject.net/",
-        "http://www.cbtnews.com/",
-        "http://neilchasefilm.com/"
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 5,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.wbu.com/"
       ],
-      "unsuccessfulSites": [
-        "http://conference.bioneers.org/",
-        "http://ykkamericas.com/",
-        "http://studyinternational.com/",
-        "http://www.tacocabana.com/",
-        "http://floorcritics.com/"
-      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "Onetrust": {
     "DE": {
-      "sites": 4534,
-      "errors": 1,
-      "selfTestFailures": 2,
+      "sites": 698,
+      "errors": 2,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.seagate.com/",
-        "http://www.brenntag.com/",
-        "http://www.monster.de/",
-        "http://mattermost.com/",
-        "http://www.antalis.de/"
+        "http://www.servustv.com/",
+        "http://www.acer.com/",
+        "http://mtg.fandom.com/",
+        "http://www.zdnet.com/",
+        "http://www.zeiss.com/"
       ],
       "failingSites": [
-        "http://global.morningstar.com/",
-        "http://www.radissonhotels.com/"
+        "http://www.healthline.com/"
       ],
       "unsuccessfulSites": [
-        "http://www.beretta.com/",
-        "http://community.spiceworks.com/",
-        "http://www.lodgify.com/",
-        "http://www.chargepoint.com/",
-        "http://www.boohooman.com/"
+        "http://starlink.com/",
+        "http://asana.com/",
+        "http://www.espn.com/",
+        "http://eu.patagonia.com/",
+        "http://sudoku.com/"
       ],
       "errorSites": [
-        "http://www.news24.com/"
+        "http://www.healthline.com/",
+        "http://www.medicalnewstoday.com/"
       ]
     },
     "GB": {
-      "sites": 7299,
-      "errors": 5,
-      "selfTestFailures": 1,
-      "exampleSites": [
-        "http://www.hardistyestateagents.co.uk/",
-        "http://www.gates.com/",
-        "http://www.armani.com/",
-        "http://www.freyalingerie.com/",
-        "http://www.ticketmaster.ie/"
-      ],
-      "failingSites": [
-        "http://www.omnipod.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://careers.ocadogroup.com/",
-        "http://omaze.co.uk/",
-        "http://www.partycasino.com/",
-        "http://www.winkworth.co.uk/",
-        "http://www.everlastgyms.com/"
-      ],
-      "errorSites": [
-        "http://www.technologyreview.com/",
-        "http://www.umc.org/",
-        "http://www.healthline.com/",
-        "http://www.medicalnewstoday.com/",
-        "http://www.pacsun.com/"
-      ]
-    },
-    "US": {
-      "sites": 7634,
+      "sites": 1355,
       "errors": 3,
       "selfTestFailures": 3,
       "exampleSites": [
-        "http://www.orrick.com/",
-        "http://www.upstart.com/",
-        "http://adanews.ada.org/",
-        "http://www.argos.co.uk/",
-        "http://www.atlantafalcons.com/"
+        "http://apple.stackexchange.com/",
+        "http://www.irishnews.com/",
+        "http://www.sadlerswells.com/",
+        "http://www.jstor.org/",
+        "http://business.currys.co.uk/"
       ],
       "failingSites": [
-        "http://www.radissonhotels.com/",
-        "http://www.ismworld.org/",
-        "http://ecards.heart.org/"
+        "http://www.binance.com/",
+        "http://www.healthline.com/",
+        "http://www.radissonhotels.com/"
       ],
       "unsuccessfulSites": [
-        "http://allegiantair.com/",
-        "http://www.americanolean.com/",
-        "http://tuckercarlson.com/",
-        "http://www.codetwo.com/",
-        "http://www.jhnewsandguide.com/"
+        "http://www.avios.com/",
+        "http://asana.com/",
+        "http://www.onsemi.com/",
+        "http://central.xero.com/",
+        "http://www.si.com/"
       ],
       "errorSites": [
-        "http://www.pacsun.com/",
-        "http://rsc.byu.edu/",
-        "http://pacsun.com/"
+        "http://www.healthline.com/",
+        "http://www.medicalnewstoday.com/",
+        "http://www.pgachampionship.com/"
       ]
+    },
+    "US": {
+      "sites": 798,
+      "errors": 0,
+      "selfTestFailures": 1,
+      "exampleSites": [
+        "http://www.pearsonvue.com/",
+        "http://www.csulb.edu/",
+        "http://zoom.us/",
+        "http://www.bk.com/",
+        "http://mopar.com/"
+      ],
+      "failingSites": [
+        "http://www.seikowatches.com/"
+      ],
+      "unsuccessfulSites": [
+        "http://www.lennar.com/",
+        "http://www.nascar.com/",
+        "http://www.popeyes.com/",
+        "http://www.ups.com/",
+        "http://birkenstock.com/"
+      ],
+      "errorSites": []
     }
   },
   "PrimeBox CookieBar": {
     "DE": {
-      "sites": 66,
+      "sites": 5,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.online-berechnung.at/",
+        "http://berlin.kauperts.de/",
+        "http://odir.org/",
         "http://odir.us/",
-        "http://www.bahnhofspassagen-potsdam.de/",
-        "http://www.feinesholz.de/",
-        "http://www.bszwillbrock.de/"
+        "http://www.hautschutzengel.de/",
+        "http://www.weimar.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 123,
+      "sites": 9,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.homeswaps.co.uk/",
-        "http://general-knowledge-quiz.co.uk/",
-        "http://m.highwaysengland.co.uk/",
-        "http://accountancyage.com/",
-        "http://www.woodlandsfamilypractice.nhs.uk/"
+        "http://www.homipi.co.uk/",
+        "http://radioreferenceuk.co.uk/",
+        "http://whoiscallingyou.co.uk/",
+        "http://www.omeek.co.uk/",
+        "http://www.northlanarkshire.gov.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 12,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://fijipocketguide.com/",
-        "http://www.wantedinrome.com/",
-        "http://www.annualreviews.org/",
-        "http://odir.us/",
-        "http://map.projectzomboid.com/"
+        "http://www.lockheedmartin.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -1291,49 +866,41 @@
   },
   "Sirdata": {
     "DE": {
-      "sites": 73,
+      "sites": 7,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.allereifendruck.de/",
-        "http://www.mtgtop8.com/",
-        "http://www.ems-dental.com/",
-        "http://www.synonymo.fr/",
-        "http://www.ibtimes.co.uk/"
+        "http://classic.goldgoblin.net/",
+        "http://www.meerestemperatur.de/",
+        "http://upway.de/",
+        "http://www.dafont.com/",
+        "http://www.infobel.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.centrepompidou.fr/",
-        "http://www.goldgoblin.net/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 70,
+      "sites": 7,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.verbier.ch/",
-        "http://www.tyre-pressure.co.uk/",
-        "http://help.forumotion.com/",
-        "http://local.infobel.ie/",
-        "http://all.rugby/"
+        "http://www.ipsos.com/",
+        "http://tunebat.com/",
+        "http://www.01net.com/",
+        "http://www.ibtimes.co.uk/",
+        "http://www.highonfilms.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.saintlary.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 4,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.sozcu.com.tr/",
-        "http://gizmodo.com/",
-        "http://kotaku.com/",
-        "http://america.felco.com/"
+        "http://kotaku.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -1342,403 +909,312 @@
   },
   "Sourcepoint-frame": {
     "DE": {
-      "sites": 1293,
+      "sites": 462,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.laptopmag.com/",
-        "http://scienceblogs.de/",
-        "http://www.stuff.tv/",
-        "http://www.sz-trauer.de/",
-        "http://www.id4-forum.de/"
+        "http://www.motorradundreisen.de/",
+        "http://www.musik-sammler.de/",
+        "http://equipboard.com/",
+        "http://www.vecteezy.com/",
+        "http://www.phoronix.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://kittenspaceagency.wiki.gg/",
-        "http://www.cx60forum.de/",
-        "http://spaceengineers.wiki.gg/",
-        "http://aethermancer.wiki.gg/",
-        "http://www.womanandhome.com/"
+        "http://www.toggo.de/",
+        "http://www.cyclingnews.com/",
+        "http://muellmail.com/",
+        "http://www.vrt.be/",
+        "http://progameguides.com/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 1132,
+      "sites": 355,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.midweekherald.co.uk/",
-        "http://tensura.wiki.gg/",
-        "http://www.planetrocktickets.co.uk/",
-        "http://pokopia.wiki.fextralife.com/",
-        "http://www.fictiondb.com/"
+        "http://weather.com/",
+        "http://www.accountingweb.co.uk/",
+        "http://www.t3.com/",
+        "http://www.neowin.net/",
+        "http://microbenotes.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.sloughobserver.co.uk/",
-        "http://www.peeblesshirenews.com/",
-        "http://www.rhyljournal.co.uk/",
-        "http://www.runcornandwidnesworld.co.uk/",
-        "http://www.peterboroughmatters.co.uk/"
+        "http://www.hampshirechronicle.co.uk/",
+        "http://www.musicradar.com/",
+        "http://www.dunfermlinepress.com/",
+        "http://www.topgear.com/",
+        "http://theweek.com/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 144,
+      "sites": 34,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.kxlf.com/",
-        "http://www.beautycon.com/",
-        "http://www.kxlh.com/",
-        "http://www.entertainmentdaily.com/",
-        "http://www.10news.com/"
+        "http://www.classical-music.com/",
+        "http://www.theguardian.com/",
+        "http://www.myfitnesspal.com/",
+        "http://morsecode.world/",
+        "http://www.radiotimes.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://royal-insider.com/",
-        "http://www.carmagazine.co.uk/",
+        "http://www.wtvr.com/",
         "http://www.economist.com/",
-        "http://f1help.formula1.com/",
-        "http://badoo.com/"
+        "http://www.fox13now.com/",
+        "http://www.motorsport.com/",
+        "http://www.myfitnesspal.com/"
       ],
       "errorSites": []
     }
   },
   "Tealium": {
     "DE": {
-      "sites": 112,
+      "sites": 29,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://sim24.de/",
-        "http://www.dws.com/",
-        "http://www.telekom.de/",
+        "http://www.penguinrandomhouse.com/",
         "http://www.aktion-mensch.de/",
-        "http://www.familienratgeber.de/"
+        "http://www.lufthansa.com/",
+        "http://www.telekom.de/",
+        "http://www.discover-airlines.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://meinereisen.meinschiff.com/",
-        "http://www.byk.com/",
-        "http://www.impfen.de/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 128,
+      "sites": 33,
       "errors": 0,
-      "selfTestFailures": 1,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://ciiom.hsbc.com/",
-        "http://stores.tescomobile.com/",
-        "http://www.heathrowexpress.com/",
         "http://www7.marksandspencer.com/",
-        "http://uk.diesel.com/"
+        "http://www.ti.com/",
+        "http://www.crocs.co.uk/",
+        "http://www.nsandi.com/",
+        "http://www.barclaycard.co.uk/"
       ],
-      "failingSites": [
-        "http://www.santander.pl/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [
-        "http://send.royalmail.com/",
-        "http://www.anantara.com/",
-        "http://www.rmwilliams.com/"
+        "http://send.royalmail.com/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 73,
+      "sites": 10,
       "errors": 0,
-      "selfTestFailures": 1,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.blackbaud.com/",
-        "http://www.heydude.com/",
-        "http://www.penguinrandomhouseretail.com/",
-        "http://www.dws.com/",
-        "http://timothysnyder.org/"
+        "http://www.allaboutvision.com/",
+        "http://www.otterbox.com/",
+        "http://www.lufthansa.com/",
+        "http://www.dominos.com/",
+        "http://www.swiss.com/"
       ],
-      "failingSites": [
-        "http://www.papyrusonline.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://tanafrench.com/",
-        "http://timothysnyder.org/"
-      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "Termly": {
     "DE": {
-      "sites": 95,
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.omg.org/",
-        "http://starwalk.space/",
-        "http://www.workato.com/",
-        "http://www.scrapingbee.com/",
-        "http://rankedkings.com/"
+        "http://loaded.com/",
+        "http://www.alamy.com/",
+        "http://www.alamy.de/",
+        "http://www.studysmarter.de/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://logo.com/",
-        "http://campermate.com/",
-        "http://www.specialchem.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 475,
-      "errors": 3,
-      "selfTestFailures": 2,
-      "exampleSites": [
-        "http://www.osmohair.co.uk/",
-        "http://www.greenhousepeople.co.uk/",
-        "http://jamiesonbrothers.com/",
-        "http://www.renovatewithreno.co.uk/",
-        "http://www.eden.co.uk/"
-      ],
-      "failingSites": [
-        "http://skullshaver.co.uk/",
-        "http://www.kitandkaboodal.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.specialchem.com/",
-        "http://www.nationalnumbers.co.uk/",
-        "http://www.solostove.com/",
-        "http://www.racingtv.com/",
-        "http://www.greatbritishfoodawards.com/"
-      ],
-      "errorSites": [
-        "http://skullshaver.co.uk/",
-        "http://gulfnews.com/",
-        "http://www.kitandkaboodal.com/"
-      ]
-    },
-    "US": {
-      "sites": 390,
+      "sites": 56,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.horiconbank.com/",
-        "http://www.studying-in-germany.org/",
-        "http://www.homebaseusa.com/",
-        "http://case-clicker.com/",
-        "http://www.mybinding.com/"
+        "http://americangolf.co.uk/",
+        "http://www.loaded.com/",
+        "http://www.btf-thyroid.org/",
+        "http://www.chisholmhunter.co.uk/",
+        "http://www.opieoils.co.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.lodinews.com/",
-        "http://www.bahamas.com/",
-        "http://infinitefusiondex.com/",
-        "http://www.bristolpress.com/",
-        "http://www.subsplash.com/"
+        "http://thenaturenetwork.co.uk/",
+        "http://www.johnpye.co.uk/",
+        "http://www.racingtv.com/"
+      ],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 17,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.catholic.com/",
+        "http://www.partzilla.com/",
+        "http://usafacts.org/",
+        "http://www.brownhealth.org/",
+        "http://streamfind.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://www.flybreeze.com/"
       ],
       "errorSites": []
     }
   },
   "TrustArc-frame": {
     "DE": {
-      "sites": 36,
+      "sites": 5,
       "errors": 0,
-      "selfTestFailures": 4,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.flickr.com/",
         "http://access.redhat.com/",
-        "http://www.resideo.com/",
-        "http://learn.redhat.com/",
-        "http://www.dsm-firmenich.com/"
+        "http://docs.redhat.com/",
+        "http://www.flickr.com/",
+        "http://www.philips-hue.com/",
+        "http://www.redhat.com/"
       ],
       "failingSites": [
-        "http://flickr.com/",
-        "http://www.motorolasolutions.com/",
-        "http://api.flickr.com/",
         "http://www.flickr.com/"
       ],
       "unsuccessfulSites": [
-        "http://quay.io/",
-        "http://www.redhat.com/",
-        "http://www.wacom.com/",
-        "http://shopping.mattel.com/",
-        "http://docs.redhat.com/"
+        "http://access.redhat.com/",
+        "http://docs.redhat.com/",
+        "http://www.philips-hue.com/",
+        "http://www.redhat.com/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 63,
+      "sites": 8,
       "errors": 0,
-      "selfTestFailures": 5,
+      "selfTestFailures": 3,
       "exampleSites": [
-        "http://corporate.mattel.com/",
-        "http://www.aveva.com/",
-        "http://opensource.com/",
-        "http://www.moo.com/",
-        "http://developers.redhat.com/"
+        "http://access.redhat.com/",
+        "http://api.flickr.com/",
+        "http://docs.redhat.com/",
+        "http://www.redhat.com/",
+        "http://www.screwfix.com/"
       ],
       "failingSites": [
         "http://api.flickr.com/",
         "http://flickr.com/",
-        "http://www.avantiwestcoast.co.uk/",
-        "http://www.flickr.com/",
-        "http://www.motorolasolutions.com/"
+        "http://www.flickr.com/"
       ],
       "unsuccessfulSites": [
-        "http://www.napier.ac.uk/",
-        "http://galaxy.ansible.com/",
-        "http://www.concur.co.uk/",
         "http://access.redhat.com/",
-        "http://www.aveva.com/"
+        "http://docs.redhat.com/",
+        "http://www.redhat.com/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 23,
+      "sites": 1,
       "errors": 0,
-      "selfTestFailures": 1,
-      "exampleSites": [
-        "http://www.usa.lighting.philips.com/",
-        "http://www.signify.com/",
-        "http://www.philips.co.uk/",
-        "http://www.philips.com/",
-        "http://hamiltonbeach.com/"
-      ],
-      "failingSites": [
-        "http://hamiltonbeach.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.usa.lighting.philips.com/",
-        "http://www.philips.ca/",
-        "http://www.philips.co.uk/",
-        "http://www.genlyte.com/",
-        "http://www.usa.philips.com/"
-      ],
+      "selfTestFailures": 0,
+      "exampleSites": [],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "TrustArc-top": {
     "DE": {
-      "sites": 188,
+      "sites": 36,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://developer.ibm.com/",
+        "http://www.ihg.com/",
+        "http://userapps.support.sap.com/",
         "http://www.delonghi.com/",
-        "http://www.mercari.com/",
-        "http://www.airmusictech.com/",
-        "http://www.ihg.com/"
+        "http://www.citrix.com/",
+        "http://makerworld.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.gutscheingold.de/",
-        "http://www.redbooks.ibm.com/",
-        "http://www.fendt.com/",
-        "http://community.sap.com/",
-        "http://classpass.de/"
+        "http://eu.community.samsung.com/",
+        "http://userapps.support.sap.com/",
+        "http://www.te.com/",
+        "http://samsung.com/",
+        "http://support.garmin.com/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 265,
+      "sites": 55,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.churchofjesuschrist.org/",
-        "http://www.merceroneview.ie/",
-        "http://www.oneplus.com/",
-        "http://auth.diy.com/",
-        "http://www.mascus.co.uk/"
+        "http://www.converse.com/",
+        "http://community.sap.com/",
+        "http://www.parcelforce.com/",
+        "http://www.sagasavings.co.uk/",
+        "http://diy.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.familysearch.org/",
-        "http://flex.amazon.co.uk/",
-        "http://www.sas.com/",
-        "http://www.gold.org/",
-        "http://acuityscheduling.com/"
+        "http://www.royalmail.com/",
+        "http://www.sandisk.com/",
+        "http://www.sjp.co.uk/",
+        "http://www8.garmin.com/",
+        "http://eu.community.samsung.com/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 384,
-      "errors": 1,
-      "selfTestFailures": 7,
+      "sites": 59,
+      "errors": 0,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.nadadventist.org/",
-        "http://shipping.amazon.com/",
-        "http://www.taylormadeproducts.com/",
-        "http://www.deltek.com/",
-        "http://www.freestyle.abbott/"
+        "http://www.centerpointenergy.com/",
+        "http://www.venetianlasvegas.com/",
+        "http://www.ea.com/",
+        "http://www.firsttechfed.com/",
+        "http://www.mercari.com/"
       ],
-      "failingSites": [
-        "http://www.mercer.com/",
-        "http://www.aarons.com/",
-        "http://www.clearancejobs.com/",
-        "http://www.fastsigns.com/",
-        "http://gorving.com/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [
-        "http://store.galaxy-of-heroes.starwars.ea.com/",
-        "http://www.darden.virginia.edu/",
-        "http://www.selectmedical.com/",
-        "http://www.nmhs.net/",
-        "http://secure.logmeinrescue.com/"
+        "http://www.ea.com/",
+        "http://bambulab.com/",
+        "http://www.lincolnfinancial.com/",
+        "http://community.sap.com/",
+        "http://www.opb.org/"
       ],
-      "errorSites": [
-        "http://rsc.byu.edu/"
-      ]
+      "errorSites": []
     }
   },
   "UK Cookie Consent": {
     "DE": {
-      "sites": 13,
+      "sites": 1,
       "errors": 0,
-      "selfTestFailures": 3,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.perfekte-pizza.de/",
-        "http://shinetight.com/",
-        "http://www.erotik-von-nebenan.com/",
-        "http://www.bankhelfer.de/",
-        "http://www.fischhalle-harburg.de/"
+        "http://zeichen-zum-kopieren.de/"
       ],
-      "failingSites": [
-        "http://finanzquelle.com/",
-        "http://www.bankhelfer.de/",
-        "http://www.cosmiq.de/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 26,
-      "errors": 0,
-      "selfTestFailures": 10,
-      "exampleSites": [
-        "http://www.corporation.org.uk/",
-        "http://shinetight.com/",
-        "http://www.wealddown.co.uk/",
-        "http://www.dancecity.co.uk/",
-        "http://garringtonsouthwest.co.uk/"
-      ],
-      "failingSites": [
-        "http://www.thisisgorilla.com/",
-        "http://www.hope.pub/",
-        "http://lizzieharper.co.uk/",
-        "http://www.wealddown.co.uk/",
-        "http://www.lumos-experiences.com/"
-      ],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://siliconangle.com/",
-        "http://www.thereloadersnetwork.com/"
+        "http://www.markpack.org.uk/"
       ],
       "failingSites": [
-        "http://siliconangle.com/"
+        "http://www.markpack.org.uk/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
@@ -1746,190 +1222,90 @@
   },
   "Uniconsent": {
     "DE": {
-      "sites": 34,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://typ2-ladekabel.de/",
-        "http://www.imcdb.org/",
-        "http://serienguru.de/",
-        "http://www.starzip.de/",
-        "http://www.hardwareinside.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.gadget-rausch.de/",
-        "http://www.hessennews.tv/",
-        "http://www.synonymer.se/",
-        "http://balkonkraftwerk-check.de/",
-        "http://allergieladen.de/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 47,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://loftforwords.fansnetwork.co.uk/",
-        "http://www.newdvdreleasedates.com/",
-        "http://www.freeformatter.com/",
-        "http://www.absolute-snow.co.uk/",
-        "http://dogfuriendly.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://en.climate-data.org/",
-        "http://www.teamtalk.com/",
-        "http://www.planetfootball.com/",
-        "http://www.football365.com/",
-        "http://www.loverugbyleague.com/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 6,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://portal.tds.net/",
-        "http://www.countryandtownhouse.com/",
-        "http://www.equibase.com/",
-        "http://us.blochworld.com/",
-        "http://blog.qrfs.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
-  "WP Cookie Notice for GDPR": {
-    "DE": {
       "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://sonne-wolken.de/",
-        "http://www.fasynation.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 8,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://invinciblevs.com/",
-        "http://shcg.ac.uk/",
-        "http://circuitoftheamericas.com/",
-        "http://www.littletigergifts.co.uk/",
-        "http://ymcayactive.org/"
+        "http://de.climate-data.org/",
+        "http://www.offen.net/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.littletigergifts.co.uk/"
+        "http://de.climate-data.org/"
+      ],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 12,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.planetf1.com/",
+        "http://singletrackworld.com/",
+        "http://trueamaters.com/",
+        "http://www.ruck.co.uk/",
+        "http://www.twtd.co.uk/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://www.football365.com/",
+        "http://www.planetf1.com/",
+        "http://www.ruck.co.uk/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 5,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://invinciblevs.com/",
-        "http://livebh.com/",
-        "http://chuzefitness.com/",
-        "http://circuitoftheamericas.com/"
+        "http://www.equibase.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://livebh.com/",
-        "http://chuzefitness.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "WP DSGVO Tools": {
     "DE": {
-      "sites": 84,
-      "errors": 0,
-      "selfTestFailures": 12,
-      "exampleSites": [
-        "http://www.rueckenwind.de/",
-        "http://www.bruns.de/",
-        "http://www.hellfire-magazin.de/",
-        "http://shop.fellhof.com/",
-        "http://www.system-bahn.net/"
-      ],
-      "failingSites": [
-        "http://www.zeitumstellung.in/",
-        "http://sonnigo.de/",
-        "http://www.system-bahn.net/",
-        "http://blog.daniel.wydler.eu/",
-        "http://guildnews.de/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.sem-chemnitz.de/",
-        "http://www.lastminute-billiger-buchen.de/",
-        "http://www.globuliwelt.de/",
-        "http://dietzberlin.de/",
-        "http://faszinationjagd.de/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 1,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://ptk-hessen.de/",
         "http://www.wienerlinien.at/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [],
+      "unsuccessfulSites": [
+        "http://ptk-hessen.de/"
+      ],
       "errorSites": []
     }
   },
   "Yahoo": {
     "DE": {
-      "sites": 13,
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://de.hilfe.yahoo.com/",
-        "http://www.yahoo.com/",
-        "http://de.search.yahoo.com/",
+        "http://de.nachrichten.yahoo.com/",
+        "http://de.yahoo.com/",
         "http://finance.yahoo.com/",
-        "http://de.yahoo.com/"
+        "http://www.yahoo.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 17,
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://us.yahoo.com/",
-        "http://uk.movies.yahoo.com/",
-        "http://search.yahoo.com/",
-        "http://hk.yahoo.com/",
-        "http://uk.yahoo.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 3,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://fr.yahoo.com/",
+        "http://finance.yahoo.com/",
         "http://uk.style.yahoo.com/",
-        "http://uk.yahoo.com/"
+        "http://uk.yahoo.com/",
+        "http://www.yahoo.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -1938,149 +1314,63 @@
   },
   "acris": {
     "DE": {
-      "sites": 186,
+      "sites": 11,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.raeer.com/",
-        "http://www.ledaquaristik.de/",
-        "http://engel-natur.de/",
-        "http://hofats.com/",
-        "http://www.mycovital.de/"
+        "http://12seemeilen.de/",
+        "http://baer-schuhe.de/",
+        "http://www.roesle.com/",
+        "http://sallys-blog.de/",
+        "http://www.baer-schuhe.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.arya-laya.de/",
-        "http://blackbeards.de/",
-        "http://travelite.com/",
-        "http://www.anhaenger-baumann.de/",
-        "http://www.moses-verlag.de/"
+        "http://12seemeilen.de/",
+        "http://baer-schuhe.de/",
+        "http://www.baer-schuhe.de/",
+        "http://www.befestigungsfuchs.de/",
+        "http://www.campingplus.de/"
       ],
       "errorSites": []
-    },
-    "GB": {
-      "sites": 6,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.arctic.de/",
-        "http://www.baer-shoes.co.uk/",
-        "http://www.d-edition.de/",
-        "http://www.bresser.com/",
-        "http://www.bresseruk.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.baer-shoes.co.uk/",
-        "http://www.gallagher.eu/",
-        "http://www.bresser.com/",
-        "http://www.bresseruk.com/"
-      ],
-      "errorSites": []
-    },
+    }
+  },
+  "adopt": {
     "US": {
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.arctic.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
-  "adopt": {
-    "DE": {
-      "sites": 3,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://generated.photos/",
-        "http://www.olx.com.br/",
-        "http://www.vivareal.com.br/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 5,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://stageagent.com/",
-        "http://generated.photos/",
-        "http://www.stayforlong.co.uk/",
-        "http://www.olx.com.br/",
-        "http://www.vivareal.com.br/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 6,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.olx.com.br/",
-        "http://stageagent.com/",
-        "http://generated.photos/",
-        "http://www.vivareal.com.br/",
-        "http://ysu.edu/"
+        "http://stageagent.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.olx.com.br/",
-        "http://generated.photos/",
-        "http://www.tramontina.com/",
-        "http://www.vivareal.com.br/",
-        "http://ysu.edu/"
+        "http://stageagent.com/"
       ],
       "errorSites": []
     }
   },
   "adultfriendfinder": {
-    "DE": {
+    "GB": {
       "sites": 1,
       "errors": 0,
-      "selfTestFailures": 1,
+      "selfTestFailures": 0,
       "exampleSites": [
         "http://www3.adultfriendfinder.com/"
       ],
-      "failingSites": [
-        "http://www3.adultfriendfinder.com/"
-      ],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 2,
-      "errors": 0,
-      "selfTestFailures": 2,
-      "exampleSites": [
-        "http://adultfriendfinder.com/",
-        "http://www3.adultfriendfinder.com/"
-      ],
-      "failingSites": [
-        "http://adultfriendfinder.com/",
-        "http://www3.adultfriendfinder.com/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 3,
+      "sites": 2,
       "errors": 0,
-      "selfTestFailures": 2,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://www3.adultfriendfinder.com/",
-        "http://login.adultfriendfinder.com/",
-        "http://adultfriendfinder.com/"
+        "http://adultfriendfinder.com/",
+        "http://www3.adultfriendfinder.com/"
       ],
       "failingSites": [
-        "http://www3.adultfriendfinder.com/",
         "http://adultfriendfinder.com/"
       ],
       "unsuccessfulSites": [],
@@ -2089,21 +1379,19 @@
   },
   "aliexpress": {
     "DE": {
-      "sites": 4,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.aliexpress.com/",
+        "http://aliexpress.com/",
         "http://de.aliexpress.com/",
-        "http://fr.aliexpress.com/",
-        "http://aliexpress.com/"
+        "http://www.aliexpress.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.aliexpress.com/",
+        "http://aliexpress.com/",
         "http://de.aliexpress.com/",
-        "http://fr.aliexpress.com/",
-        "http://aliexpress.com/"
+        "http://www.aliexpress.com/"
       ],
       "errorSites": []
     },
@@ -2125,14 +1413,14 @@
   },
   "amazon.com": {
     "DE": {
-      "sites": 19,
+      "sites": 8,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://amazon.co.uk/",
-        "http://www.amazon.pl/",
-        "http://www.amazon.com.be/",
-        "http://www.amazon.com.tr/",
+        "http://www.amazon.it/",
+        "http://www.amazon.co.uk/",
+        "http://www.amazon.de/",
+        "http://www.amazon.nl/",
         "http://www.amazon.fr/"
       ],
       "failingSites": [],
@@ -2142,37 +1430,32 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 13,
+      "sites": 5,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://amazon.co.uk/",
+        "http://www.amazon.de/",
+        "http://www.amazon.es/",
+        "http://www.amazon.ie/",
+        "http://www.amazon.it/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 6,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://www.amazon.ca/",
-        "http://amazon.nl/",
-        "http://amazon.de/",
-        "http://www.amazon.es/",
-        "http://www.amazon.nl/"
+        "http://www.amazon.co.uk/",
+        "http://www.amazon.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
         "http://www.amazon.ca/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 14,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.amazon.ca/",
-        "http://www.amazon.fr/",
-        "http://amazon.co.uk/",
-        "http://www.amazon.de/",
-        "http://www.amazon.nl/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.amazon.ca/",
-        "http://amazon.ca/"
       ],
       "errorSites": []
     }
@@ -2190,12 +1473,10 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 3,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://global.americanexpress.com/",
-        "http://online.americanexpress.com/",
         "http://www.americanexpress.com/"
       ],
       "failingSites": [],
@@ -2205,30 +1486,24 @@
   },
   "anthropic": {
     "DE": {
-      "sites": 5,
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://resources.anthropic.com/",
-        "http://platform.claude.com/",
-        "http://www.anthropic.com/",
         "http://claude.ai/",
-        "http://code.claude.com/"
+        "http://platform.claude.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 5,
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://platform.claude.com/",
-        "http://resources.anthropic.com/",
         "http://claude.ai/",
-        "http://code.claude.com/",
-        "http://www.anthropic.com/"
+        "http://platform.claude.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -2245,63 +1520,21 @@
     }
   },
   "aquasana.com": {
-    "DE": {
-      "sites": 9,
+    "US": {
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.skagen.com/",
-        "http://www.arrma-rc.com/",
-        "http://emea.mizuno.com/",
-        "http://www.fossil.com/",
-        "http://www.museum-brandhorst.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 10,
-      "errors": 1,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.westmarine.com/",
-        "http://www.martinguitar.com/",
-        "http://www.charleskeith.co.uk/",
-        "http://www.pacsun.com/",
-        "http://www.fossil.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.pacsun.com/"
-      ],
-      "errorSites": [
-        "http://www.pacsun.com/"
-      ]
-    },
-    "US": {
-      "sites": 32,
-      "errors": 3,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://kichlerlightinglights.com/",
-        "http://www.westmarine.com/",
-        "http://www.redkap.com/",
-        "http://www.arrma-rc.com/",
-        "http://www.travelonbags.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.pacsun.com/",
-        "http://www.zabars.com/",
         "http://www.altardstate.com/",
-        "http://pacsun.com/"
+        "http://www.citizenwatch.com/",
+        "http://www.hpb.com/",
+        "http://www.martinguitar.com/"
       ],
-      "errorSites": [
-        "http://www.pacsun.com/",
-        "http://www.petsupermarket.com/",
-        "http://pacsun.com/"
-      ]
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://www.altardstate.com/"
+      ],
+      "errorSites": []
     }
   },
   "arbeitsagentur": {
@@ -2310,30 +1543,8 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://jobboerse.arbeitsagentur.de/",
         "http://web.arbeitsagentur.de/",
-        "http://www.arbeitsagentur.de/",
-        "http://jobboerse.arbeitsagentur.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.arbeitsagentur.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
         "http://www.arbeitsagentur.de/"
       ],
       "failingSites": [],
@@ -2343,11 +1554,12 @@
   },
   "asus": {
     "DE": {
-      "sites": 1,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://rog.asus.com/"
+        "http://rog.asus.com/",
+        "http://www.asus.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -2358,31 +1570,19 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://rog.asus.com/"
+        "http://www.asus.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 1,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://rog.asus.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
-  "athlinks-com": {
-    "US": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.athlinks.com/"
+        "http://rog.asus.com/",
+        "http://www.asus.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -2391,92 +1591,62 @@
   },
   "automattic-cmp-optout": {
     "DE": {
-      "sites": 6,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://ssfbonn.de/",
-        "http://pocketcasts.com/",
-        "http://wordpress.com/",
-        "http://www.autoaid.de/",
-        "http://boeser-junge.de/"
+        "http://wordpress.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://ssfbonn.de/",
-        "http://pocketcasts.com/",
-        "http://www.autoaid.de/",
-        "http://boeser-junge.de/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 11,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://bookwhen.com/",
-        "http://gravatar.com/",
-        "http://oxfordandcambridgeclub.co.uk/",
-        "http://jetpack.com/",
-        "http://polisen.se/"
+        "http://wordpress.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://bookwhen.com/",
-        "http://oxfordandcambridgeclub.co.uk/",
-        "http://pocketcasts.com/",
-        "http://www.northeastmuseums.org.uk/",
-        "http://www.new-wine.org/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "aws.amazon.com": {
     "DE": {
-      "sites": 11,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://calculator.aws/",
-        "http://s3.amazonaws.com/",
-        "http://skillbuilder.aws/",
-        "http://docs.aws.amazon.com/",
-        "http://gallery.ecr.aws/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://repost.aws/",
-        "http://skillbuilder.aws/",
-        "http://docs.aws.amazon.com/",
-        "http://gallery.ecr.aws/",
-        "http://health.aws.amazon.com/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 11,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://aws.amazon.com/",
-        "http://kiro.dev/",
-        "http://www.aws.training/",
-        "http://repost.aws/",
         "http://docs.aws.amazon.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://docs.amplify.aws/",
-        "http://skillbuilder.aws/",
-        "http://health.aws.amazon.com/",
+        "http://docs.aws.amazon.com/"
+      ],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 3,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://aws.amazon.com/",
         "http://docs.aws.amazon.com/",
-        "http://calculator.aws/"
+        "http://repost.aws/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://aws.amazon.com/",
+        "http://docs.aws.amazon.com/",
+        "http://repost.aws/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 12,
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [],
@@ -2487,111 +1657,85 @@
   },
   "axeptio": {
     "DE": {
-      "sites": 131,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.sfa-sanibroy.de/",
-        "http://passionata.com/",
-        "http://www.ackerherz.de/",
-        "http://www.logishotels.com/",
-        "http://www.origine-cycles.com/"
+        "http://bmw.europe-moto.com/",
+        "http://mistral.ai/",
+        "http://www.france.fr/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.ackerherz.de/",
-        "http://forum.mycad.visiativ.com/",
-        "http://www.sortlist.de/",
-        "http://www.operadeparis.fr/",
-        "http://www.lecyclo.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 113,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://docs.mistral.ai/",
-        "http://www.sortlist.co.uk/",
-        "http://www.france.fr/",
-        "http://www.dxo.com/",
-        "http://www.iledefrance-mobilites.fr/"
+        "http://mistral.ai/",
+        "http://www.dxo.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.sortlist.co.uk/",
-        "http://www.st-mellion.co.uk/",
-        "http://www.anglicancommunion.org/",
-        "http://www.dxo.com/",
-        "http://www.operadeparis.fr/"
+        "http://www.dxo.com/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 39,
+      "sites": 1,
       "errors": 0,
-      "selfTestFailures": 1,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://winamp.com/",
-        "http://www.motul.com/",
-        "http://www.tbm.aero/",
-        "http://mistral.ai/",
-        "http://shs.cairn.info/"
-      ],
-      "failingSites": [
         "http://can-am.brp.com/"
       ],
-      "unsuccessfulSites": [
-        "http://www.operadeparis.fr/",
-        "http://ski-doo.brp.com/",
-        "http://www.sortlist.com/",
-        "http://www.dxo.com/"
-      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "b-cookie": {
     "DE": {
-      "sites": 36,
+      "sites": 12,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.poshgay.com/",
+        "http://4kpornvideos.tv/",
+        "http://www.good-gay.tv/",
+        "http://www.brutalgays.net/",
         "http://www.xgaytube.tv/",
-        "http://goodpornvids.com/",
-        "http://www.verygayboys.com/",
-        "http://bootytube.tv/"
+        "http://www.icegay.tv/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 49,
+      "sites": 19,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.freegaytube.xxx/",
-        "http://www.goldgay.tv/",
-        "http://www.boy18tube.com/",
-        "http://www.xlgaytube.tv/",
-        "http://www.icetranny.com/"
+        "http://www.brutalgays.net/",
+        "http://www.icegay.tv/",
+        "http://www.xgaytube.tv/",
+        "http://www.verygayboys.com/",
+        "http://www.boy18tube.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 34,
+      "sites": 12,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.gayperv.com/",
-        "http://www.machotube.tv/",
-        "http://www.gayguysfilm.com/",
-        "http://www.gaymaletube.name/",
-        "http://4kpornvideos.tv/"
+        "http://www.meatyhunks.com/",
+        "http://www.trannytube.tv/",
+        "http://www.xgaytube.tv/",
+        "http://www.gaymenring.com/",
+        "http://www.gaypornarchive.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -2600,15 +1744,15 @@
   },
   "baden-wuerttemberg.de": {
     "DE": {
-      "sites": 42,
+      "sites": 7,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://oberlandesgericht-stuttgart.justiz-bw.de/",
-        "http://mlw.baden-wuerttemberg.de/",
-        "http://www.verfassungsschutz-bw.de/",
+        "http://finanzamt-bw.fv-bwl.de/",
         "http://km.baden-wuerttemberg.de/",
-        "http://ka.schulamt-bw.de/"
+        "http://lehrer-online-bw.de/",
+        "http://zsl-bw.de/",
+        "http://www.baden-wuerttemberg.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -2617,11 +1761,10 @@
   },
   "bahn-de": {
     "DE": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://bahnbonus.bahncard.de/",
         "http://www.bahn.de/"
       ],
       "failingSites": [],
@@ -2642,7 +1785,7 @@
   },
   "bandcamp.com": {
     "DE": {
-      "sites": 6,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
@@ -2655,53 +1798,35 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 10,
+      "sites": 1,
       "errors": 0,
-      "selfTestFailures": 2,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://bandcamp.com/",
-        "http://uk.bandcamp.com/"
+        "http://bandcamp.com/"
       ],
       "failingSites": [
-        "http://bandcamp.com/",
-        "http://uk.bandcamp.com/"
+        "http://bandcamp.com/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
-      "selfTestFailures": 0,
+      "selfTestFailures": 1,
       "exampleSites": [
         "http://bandcamp.com/"
       ],
-      "failingSites": [],
+      "failingSites": [
+        "http://bandcamp.com/"
+      ],
       "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "bbb.org": {
-    "DE": {
-      "sites": 5,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "GB": {
-      "sites": 12,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 5,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [],
@@ -2712,74 +1837,54 @@
   },
   "bigcommerce-consent-manager": {
     "DE": {
-      "sites": 13,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.jimdunlop.com/",
         "http://germany.muji.eu/",
-        "http://www.chaosium.com/",
-        "http://acinfinity.eu/",
-        "http://acinfinity.com/"
+        "http://system76.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.theemcshop.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 198,
+      "sites": 12,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.ijtdirect.co.uk/",
-        "http://8bitmods.com/",
-        "http://www.fixthebog.uk/",
-        "http://www.cherrytreecountryclothing.com/",
-        "http://www.absolutemusic.co.uk/"
+        "http://guardianbookshop.com/",
+        "http://www.menkind.co.uk/",
+        "http://richtonemusic.co.uk/",
+        "http://system76.com/",
+        "http://uk.muji.eu/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.piratescave.co.uk/",
-        "http://www.rfsolutions.co.uk/",
-        "http://www.darksidedevelopments.co.uk/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 211,
+      "sites": 7,
       "errors": 0,
-      "selfTestFailures": 1,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://otistec.com/",
-        "http://www.albanesecandy.com/",
-        "http://www.surpluscenter.com/",
-        "http://repaintsupply.com/",
-        "http://cattlevisions.com/"
+        "http://simplicity.com/",
+        "http://smkw.com/",
+        "http://www.tackledirect.com/",
+        "http://thedrardisshow.com/",
+        "http://www.sarcoinc.com/"
       ],
-      "failingSites": [
-        "http://www.show-score.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://theyotagarage.com/",
-        "http://www.eod-gear.com/",
-        "http://arblueclean.com/",
-        "http://vintageair.com/",
-        "http://www.highflowfuel.com/"
-      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "bing.com": {
     "DE": {
-      "sites": 4,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://tools.couchsurfing.com/",
-        "http://de.bing.com/",
-        "http://bing.com/",
         "http://www.bing.com/"
       ],
       "failingSites": [],
@@ -2787,28 +1892,11 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 5,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://bing.com/",
-        "http://uk.bing.com/",
-        "http://www.uk.bing.com/",
-        "http://www.bing.com/",
-        "http://www2.bing.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
-  "blocksy": {
-    "US": {
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://howdoihomeschool.com/"
+        "http://www.bing.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -2817,89 +1905,47 @@
   },
   "borlabs": {
     "DE": {
-      "sites": 1801,
+      "sites": 60,
       "errors": 0,
-      "selfTestFailures": 87,
+      "selfTestFailures": 7,
       "exampleSites": [
-        "http://arthaus-kino.de/",
-        "http://www.musikmachen.de/",
-        "http://www.grill-kenner.de/",
-        "http://www.uwebwerner.de/",
-        "http://stengel-fussring.com/"
+        "http://granfondo-cycling.com/",
+        "http://deutsch-klett.de/",
+        "http://www.beste-testsieger.de/",
+        "http://filmspiegel-essen.de/",
+        "http://www.amazona.de/"
       ],
       "failingSites": [
-        "http://graphisoft-nord.de/",
-        "http://urlaubspunkt.de/",
-        "http://trinkreif.de/",
-        "http://entspannteordnung.de/",
-        "http://ruecken-zentrum.de/"
+        "http://www.stereo.de/",
+        "http://mal-alt-werden.de/",
+        "http://report24.news/",
+        "http://www.apfelpatient.de/",
+        "http://www.ra-kotz.de/"
       ],
       "unsuccessfulSites": [
-        "http://augenkompetenzzentren.de/",
-        "http://www.contentmanager.de/",
-        "http://www.staatsanzeiger.de/",
-        "http://www.salesjob.de/",
-        "http://u-s-e.org/"
+        "http://basic-tutorials.de/",
+        "http://www.globuli.de/",
+        "http://getcheex.com/",
+        "http://www.delamar.de/",
+        "http://www.naturundheilen.de/"
       ],
       "errorSites": []
     },
-    "GB": {
-      "sites": 37,
-      "errors": 0,
-      "selfTestFailures": 3,
-      "exampleSites": [
-        "http://collectorscarworld.com/",
-        "http://barefootman.org/",
-        "http://www.bachelorprint.com/",
-        "http://www.pituitary.org.uk/",
-        "http://enduro-mtb.com/"
-      ],
-      "failingSites": [
-        "http://pride-mobility.co.uk/",
-        "http://luggageguide.co.uk/",
-        "http://www.myexpattaxes.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.lpi.org/",
-        "http://barefootman.org/",
-        "http://basic-tutorials.com/",
-        "http://www.bachelorprint.com/",
-        "http://dignitas.ch/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 10,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.voigtlaender.de/",
-        "http://getcheex.com/",
-        "http://www.gearnews.com/",
-        "http://bushhog.com/",
-        "http://adfinternational.org/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://getcheex.com/",
-        "http://wrtrading.com/",
-        "http://adfinternational.org/"
-      ],
-      "errorSites": []
-    }
-  },
-  "bswhealth": {
     "GB": {
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
-      "exampleSites": [],
+      "exampleSites": [
+        "http://www.gearnews.com/"
+      ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
-    },
+    }
+  },
+  "bswhealth": {
     "US": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [],
@@ -2910,21 +1956,7 @@
   },
   "bundesregierung.de": {
     "DE": {
-      "sites": 6,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.bundeskanzler.de/",
-        "http://www.bundesregierung.de/",
-        "http://www.integrationsbeauftragte.de/",
-        "http://www.eu-gleichbehandlungsstelle.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 1,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
@@ -2937,104 +1969,80 @@
   },
   "burpee.com": {
     "DE": {
-      "sites": 58,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://traxxas.com/",
-        "http://www.tesland.com/",
-        "http://www.jardindupicvert.de/",
-        "http://www.dedeman.ro/",
-        "http://www.dutch-headshop.de/"
+        "http://21run.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://partao.com.de/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 166,
+      "sites": 10,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.oasisfloral.co.uk/",
-        "http://www.durite.co.uk/",
+        "http://cutmy.co.uk/",
+        "http://e-hardware.co.uk/",
         "http://www.justlawnmowers.co.uk/",
-        "http://www.sewingmachinesales.co.uk/",
-        "http://www.mapsinternational.co.uk/"
+        "http://www.lawsons.co.uk/",
+        "http://www.sosandar.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.sosandar.com/",
-        "http://www.thejewelhut.co.uk/"
+        "http://cutmy.co.uk/",
+        "http://www.sosandar.com/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 58,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.reinders.com/",
-        "http://www.gfifoods.com/",
-        "http://usa.minelab.com/",
-        "http://www.eichlers.com/",
-        "http://vintageking.com/"
+        "http://www.mossberg.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.shoesensation.com/",
-        "http://www.borla.com/",
-        "http://www.justrite.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "cassie": {
     "DE": {
-      "sites": 13,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://sports.tipico.com/",
-        "http://www.itv.com/",
-        "http://games.tipico.de/",
-        "http://www.tipico.de/",
-        "http://www.open.ac.uk/"
+        "http://sports.tipico.de/",
+        "http://www.dfds.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://games.tipico.de/",
-        "http://www.chevroleteurope.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 29,
+      "sites": 10,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://about.open.ac.uk/",
-        "http://www.concordia.ca/",
-        "http://www.rnib.org.uk/",
-        "http://durhamrecordoffice.org.uk/",
-        "http://www.itv.com/"
+        "http://itv.com/",
+        "http://students.open.ac.uk/",
+        "http://university.open.ac.uk/",
+        "http://www.trustford.co.uk/",
+        "http://www.durham.gov.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 28,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.itv.com/",
-        "http://www.ihmvcu.org/",
-        "http://www.open.edu/",
-        "http://www.ucihealth.org/",
-        "http://us.davines.com/"
+        "http://www.mskcc.org/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -3043,45 +2051,37 @@
   },
   "cc-banner-springer": {
     "DE": {
-      "sites": 9,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.springer.com/",
-        "http://link.springer.com/",
-        "http://www.scientificamerican.com/",
-        "http://group.springernature.com/",
-        "http://www.researchsquare.com/"
+        "http://link.springer.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 5,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.springernature.com/",
         "http://link.springer.com/",
         "http://www.nature.com/",
-        "http://www.scientificamerican.com/",
-        "http://www.cureus.com/"
+        "http://www.scientificamerican.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 7,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.nature.com/",
-        "http://rd.springer.com/",
-        "http://www.cureus.com/",
         "http://link.springer.com/",
-        "http://www.springernature.com/"
+        "http://www.nature.com/",
+        "http://www.scientificamerican.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -3090,83 +2090,53 @@
   },
   "cc_banner": {
     "DE": {
-      "sites": 297,
+      "sites": 15,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.psychologie-aktuell.com/",
-        "http://www.ortho-seitz.de/",
-        "http://columbiahalle.berlin/",
-        "http://vorwahltelefon.de/",
-        "http://www.de-bedienungsanleitung.de/"
+        "http://www.ausbildungsmarkt.de/",
+        "http://www.ukw.de/",
+        "http://www.de-bedienungsanleitung.de/",
+        "http://gamcore.com/",
+        "http://www.schule-bw.de/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://forum.shotcut.org/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 207,
+      "sites": 9,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.mature-sexcontacts.com/",
-        "http://store.thegardensgroup.co.uk/",
-        "http://www.spirit-of-rock.com/",
-        "http://www.weightlossresources.co.uk/",
-        "http://www.icheckmovies.com/"
+        "http://111.wales.nhs.uk/",
+        "http://gamcore.com/",
+        "http://www.thegooddogguide.com/",
+        "http://www.ukcampsite.co.uk/",
+        "http://www.sevenoaks.gov.uk/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.kualo.co.uk/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 67,
+      "sites": 9,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://y99.me/",
-        "http://www.coinworld.com/",
         "http://gamcore.com/",
         "http://govsalaries.com/",
-        "http://www.universityreview.org/"
+        "http://www.corporationwiki.com/",
+        "http://nytminicrossword.com/",
+        "http://orteil.dashnet.org/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.lords-prayer-words.com/",
-        "http://forum.shotcut.org/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "channel4.com": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.channel4.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "GB": {
-      "sites": 2,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://channel4.com/",
-        "http://www.channel4.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
@@ -3180,11 +2150,10 @@
   },
   "check24-partnerprogramm-de": {
     "DE": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.tarifcheck.de/",
         "http://www.check24.net/"
       ],
       "failingSites": [],
@@ -3194,106 +2163,81 @@
   },
   "civic-cookie-control": {
     "DE": {
-      "sites": 84,
+      "sites": 15,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.esl.de/",
-        "http://www.etcconnect.com/",
-        "http://www.nice.org.uk/",
-        "http://f1exhibition.com/",
-        "http://www.kingspan.com/"
+        "http://www.gameswelt.de/",
+        "http://losteria.net/",
+        "http://www.msi.com/",
+        "http://www.nordicnest.de/",
+        "http://suzuki.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.biosphaerengebiet-alb.de/",
-        "http://www.gold.ac.uk/",
+        "http://de.msi.com/",
+        "http://nordicnest.de/",
+        "http://www.gigaset.com/",
         "http://www.msi.com/",
-        "http://forum-en.msi.com/",
-        "http://www.gigaset.com/"
+        "http://www.nordicnest.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 1369,
-      "errors": 0,
+      "sites": 240,
+      "errors": 1,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.warwickshirewildlifetrust.org.uk/",
-        "http://www.bemoto.uk/",
-        "http://www.sport.ox.ac.uk/",
-        "http://www.entrycentral.com/",
-        "http://www.insurance4carhire.com/"
+        "http://www.newcastle-staffs.gov.uk/",
+        "http://www.officeforstudents.org.uk/",
+        "http://www.sps.nhs.uk/",
+        "http://www.freedom-leisure.co.uk/",
+        "http://www.royalnavy.mod.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.nesta.org.uk/",
-        "http://www.nhsconfed.org/",
-        "http://www.gold.ac.uk/",
+        "http://www.utbank.co.uk/",
         "http://www.nhsemployers.org/",
-        "http://www.churchofengland.org/"
+        "http://www.energyombudsman.org/",
+        "http://play.tetris.com/",
+        "http://www.thepighotel.com/"
       ],
-      "errorSites": []
+      "errorSites": [
+        "http://play.tetris.com/"
+      ]
     },
     "US": {
-      "sites": 59,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.innovid.com/",
-        "http://courtauld.ac.uk/",
-        "http://totousaparts.com/",
-        "http://www.nordicnest.com/",
-        "http://nikwax.com/"
+        "http://www.msi.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://forum-en.msi.com/",
-        "http://www.entegris.com/",
-        "http://www.pcisecuritystandards.org/",
-        "http://www.twi-global.com/",
-        "http://historicengland.org.uk/"
+        "http://www.msi.com/"
       ],
       "errorSites": []
     }
   },
   "ckies": {
     "DE": {
-      "sites": 156,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.frankreich-in-wort-und-bild.de/",
-        "http://www.naehmaschinenverzeichnis.de/",
-        "http://www.mozarteumorchester.at/",
-        "http://www.senmotic-shoes.com/",
-        "http://www.abschiedsportal.de/"
+        "http://www.din-5008-richtlinien.de/",
+        "http://www.happy-mahlzeit.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 5,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://billdargue.jimdofree.com/",
-        "http://www.vag-hub.com/",
-        "http://www.automotive-manuals.net/",
-        "http://www.bimmer-service.com/",
-        "http://www.historyskills.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 2,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.downloadboatmanuals.com/",
         "http://www.historyskills.com/"
       ],
       "failingSites": [],
@@ -3303,104 +2247,49 @@
   },
   "click.io": {
     "DE": {
-      "sites": 27,
-      "errors": 0,
-      "selfTestFailures": 22,
-      "exampleSites": [
-        "http://www.treccani.it/",
-        "http://www.laleggepertutti.it/",
-        "http://www.dizy.com/",
-        "http://gold-preisvergleich.de/",
-        "http://www.theflightclub.it/"
-      ],
-      "failingSites": [
-        "http://www.unionesarda.it/",
-        "http://www.dizy.com/",
-        "http://www.name-generator.org.uk/",
-        "http://www.angolotesti.it/",
-        "http://www.gold-preisvergleich.de/"
-      ],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 72,
-      "errors": 0,
-      "selfTestFailures": 66,
-      "exampleSites": [
-        "http://www.tvdream.net/",
-        "http://britishseafishing.co.uk/",
-        "http://pocklingtonartscentre.co.uk/",
-        "http://library.avsim.net/",
-        "http://defence-blog.com/"
-      ],
-      "failingSites": [
-        "http://lacanche.co.uk/",
-        "http://www.calculators.org/",
-        "http://www.avsim.com/",
-        "http://thecelticstar.com/",
-        "http://vlc-media-player.macupdate.com/"
-      ],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 4,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 2,
       "exampleSites": [
-        "http://www.macupdate.com/",
-        "http://www.cadillacf1team.com/",
-        "http://www.greenmemag.com/",
-        "http://android-file-transfer.macupdate.com/"
+        "http://www.dizy.com/",
+        "http://www.songtextemania.com/",
+        "http://www.treccani.it/"
       ],
       "failingSites": [
-        "http://www.cadillacf1team.com/",
-        "http://android-file-transfer.macupdate.com/"
+        "http://www.dizy.com/",
+        "http://www.treccani.it/"
       ],
-      "unsuccessfulSites": [
-        "http://www.greenmemag.com/"
-      ],
-      "errorSites": []
-    }
-  },
-  "clinch": {
-    "DE": {
-      "sites": 411,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://weedseedsexpress.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://weedseedsexpress.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
       "sites": 7,
       "errors": 0,
-      "selfTestFailures": 0,
+      "selfTestFailures": 6,
       "exampleSites": [
-        "http://careers.southwesternrailway.com/",
-        "http://careers.sse.com/",
-        "http://www.amentumcareers.com/"
+        "http://politpro.eu/",
+        "http://www.treccani.it/",
+        "http://www.avsim.com/",
+        "http://www.shetnews.co.uk/",
+        "http://www.moneymagpie.com/"
       ],
-      "failingSites": [],
+      "failingSites": [
+        "http://www.aplaceinthesun.com/",
+        "http://www.avsim.com/",
+        "http://www.golfshake.com/",
+        "http://www.moneymagpie.com/",
+        "http://www.treccani.it/"
+      ],
       "unsuccessfulSites": [],
       "errorSites": []
-    },
-    "US": {
-      "sites": 4,
+    }
+  },
+  "clinch": {
+    "DE": {
+      "sites": 9,
       "errors": 0,
       "selfTestFailures": 0,
-      "exampleSites": [
-        "http://jobs.wisc.edu/",
-        "http://www.amentumcareers.com/",
-        "http://www.azstatejobs.gov/",
-        "http://www.jobs.virginia.gov/"
-      ],
+      "exampleSites": [],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
@@ -3408,82 +2297,41 @@
   },
   "cloudflare-zaraz": {
     "DE": {
-      "sites": 10,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.klett.de/",
-        "http://srbin.info/",
-        "http://wollke.shop/",
-        "http://www.cardsagainsthumanity.com/",
-        "http://www.tradinghours.com/"
+        "http://www.klett.de/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.adams-music.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 21,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://apextraderfunding.com/",
-        "http://www.vasculitis.org.uk/",
-        "http://swappa.com/",
-        "http://www.cardsagainsthumanity.com/",
-        "http://www.fcilondon.co.uk/"
+        "http://uk.bookshop.org/",
+        "http://www.myhsn.co.uk/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.thenewhumanitarian.org/",
-        "http://www.fcilondon.co.uk/",
-        "http://www.connexin.co.uk/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 9,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://swappa.com/",
-        "http://portal.buff.game/",
-        "http://farmflavor.com/",
-        "http://trupar.com/",
-        "http://apextraderfunding.com/"
+        "http://swappa.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://trupar.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "clustrmaps.com": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://clustrmaps.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://clustrmaps.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "US": {
       "sites": 1,
       "errors": 0,
@@ -3494,149 +2342,41 @@
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
-    }
-  },
-  "com_didomi.io": {
-    "DE": {
-      "sites": 608,
-      "errors": 576,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.largus.fr/",
-        "http://www.europapress.es/",
-        "http://play.qobuz.com/",
-        "http://www.tvnow.de/",
-        "http://www.engelvoelkers.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://maison123.de/",
-        "http://orovivo.de/",
-        "http://www.centerparcs.de/",
-        "http://www.bienici.com/",
-        "http://www.lacoste.com/"
-      ],
-      "errorSites": [
-        "http://www.tate.org.uk/",
-        "http://www.callofwar.com/",
-        "http://www.autoplus.fr/",
-        "http://www.sudouest.fr/",
-        "http://www.nrc.nl/"
-      ]
-    },
-    "GB": {
-      "sites": 496,
-      "errors": 468,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.euractiv.com/",
-        "http://4k-video-downloader.en.softonic.com/",
-        "http://www.dhnet.be/",
-        "http://francaisfacile.rfi.fr/",
-        "http://www.radiofrance.fr/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.traceparts.com/",
-        "http://en.newsner.com/",
-        "http://www.bricodepot.fr/",
-        "http://www.cope.es/",
-        "http://lacoste.com/"
-      ],
-      "errorSites": [
-        "http://www.boursorama.com/",
-        "http://www.yellohvillage.co.uk/",
-        "http://www.365scores.com/",
-        "http://www.goyard.com/",
-        "http://www.xataka.com/"
-      ]
-    },
-    "US": {
-      "sites": 280,
-      "errors": 138,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.veolianorthamerica.com/",
-        "http://www.leparisien.fr/",
-        "http://www.cinemacafe.com/",
-        "http://www.visitcalifornia.com/",
-        "http://www.elconfidencial.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.traceparts.com/",
-        "http://www.qobuz.com/",
-        "http://en.newsner.com/",
-        "http://www.doctolib.fr/",
-        "http://www.flightradar24.com/"
-      ],
-      "errorSites": [
-        "http://www.pernod-ricard.com/",
-        "http://www.moviepilot.de/",
-        "http://en.newsner.com/",
-        "http://guide.michelin.com/",
-        "http://www.sncf-connect.com/"
-      ]
     }
   },
   "com_oil": {
     "DE": {
-      "sites": 325,
-      "errors": 325,
+      "sites": 11,
+      "errors": 11,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.modellbauwelt.at/",
-        "http://euroschach.de/",
-        "http://www.laborshop24.de/",
-        "http://www.staudenspatz.de/",
-        "http://www.westwood-archery.de/"
+        "http://www.elektro4000.de/",
+        "http://www.ersatzteilfachmann.de/",
+        "http://www.tnc-hamburg.com/",
+        "http://www.metallparadies.de/",
+        "http://www.online-teile.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.original-autoradio.de/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": [
-        "http://www.wasserfilter-experten.de/",
-        "http://www.geschosse24.de/",
         "http://www.tnc-hamburg.com/",
-        "http://www.battery-direct.de/",
-        "http://www.steber.de/"
+        "http://www.metallparadies.de/",
+        "http://www.holtermann-shop.de/",
+        "http://www.kaerchershop-schreiber.de/",
+        "http://www.wolf-online-shop.de/"
       ]
     },
     "GB": {
-      "sites": 7,
-      "errors": 7,
+      "sites": 1,
+      "errors": 1,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.online-teile.com/",
-        "http://www.rai.it/",
-        "http://www.rainews.it/",
-        "http://www.bolognachildrensbookfair.com/",
-        "http://www.raiplaysound.it/"
+        "http://www.accessable.co.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": [
-        "http://www.online-teile.com/",
-        "http://www.rai.it/",
-        "http://www.rainews.it/",
-        "http://www.raiplay.it/",
-        "http://www.bolognachildrensbookfair.com/"
-      ]
-    },
-    "US": {
-      "sites": 2,
-      "errors": 2,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.rainews.it/",
-        "http://www.raiplay.it/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": [
-        "http://www.rainews.it/",
-        "http://www.raiplay.it/"
+        "http://www.accessable.co.uk/"
       ]
     }
   },
@@ -3657,80 +2397,34 @@
       ]
     },
     "GB": {
-      "sites": 2,
-      "errors": 2,
+      "sites": 1,
+      "errors": 1,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://staging.thenude.com/",
         "http://www.thenude.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": [
-        "http://staging.thenude.com/",
         "http://www.thenude.com/"
       ]
     },
     "US": {
-      "sites": 3,
-      "errors": 2,
+      "sites": 2,
+      "errors": 1,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.patelco.org/",
         "http://www.thenude.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": [
-        "http://www.patelco.org/",
         "http://www.thenude.com/"
       ]
     }
   },
   "com_springer": {
     "DE": {
-      "sites": 7,
-      "errors": 7,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://poczta.onet.pl/",
-        "http://wiadomosci.onet.pl/",
-        "http://businessinsider.com.pl/",
-        "http://www.fakt.pl/",
-        "http://www.onet.pl/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://gratka.pl/"
-      ],
-      "errorSites": [
-        "http://businessinsider.com.pl/",
-        "http://www.fakt.pl/",
-        "http://gratka.pl/",
-        "http://www.medonet.pl/",
-        "http://www.onet.pl/"
-      ]
-    },
-    "GB": {
-      "sites": 4,
-      "errors": 4,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://wiadomosci.onet.pl/",
-        "http://www.fakt.pl/",
-        "http://www.medonet.pl/",
-        "http://www.onet.pl/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": [
-        "http://wiadomosci.onet.pl/",
-        "http://www.fakt.pl/",
-        "http://www.medonet.pl/",
-        "http://www.onet.pl/"
-      ]
-    },
-    "US": {
       "sites": 1,
       "errors": 1,
       "selfTestFailures": 0,
@@ -3741,147 +2435,128 @@
       "unsuccessfulSites": [],
       "errorSites": [
         "http://www.onet.pl/"
-      ]
-    }
-  },
-  "com_wordpressgdpr": {
-    "DE": {
-      "sites": 2,
-      "errors": 2,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://enviolo.com/",
-        "http://www.pulse-and-spirit.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": [
-        "http://enviolo.com/",
-        "http://www.pulse-and-spirit.com/"
-      ]
-    },
-    "GB": {
-      "sites": 1,
-      "errors": 1,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://deliverycode.co.uk/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": [
-        "http://deliverycode.co.uk/"
-      ]
-    },
-    "US": {
-      "sites": 2,
-      "errors": 2,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://crewcarwash.com/",
-        "http://ammes.org/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": [
-        "http://crewcarwash.com/",
-        "http://ammes.org/"
       ]
     }
   },
   "consentmanager.net": {
     "DE": {
-      "sites": 3585,
+      "sites": 634,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.schrottplatz.org/",
-        "http://www.angocin.de/",
-        "http://www.alensa.de/",
-        "http://ewe-baskets.de/",
-        "http://www.longlife-led.de/"
+        "http://fragen.onmeda.de/",
+        "http://14-tage-wettervorhersage.de/",
+        "http://herzmedizin.de/",
+        "http://www.gratisparken.de/",
+        "http://all3dp.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://stardewguide.com/",
-        "http://www.gocomics.com/",
-        "http://barbend.com/",
-        "http://www.zfbkk.de/",
-        "http://www.lupus-electronics.de/"
+        "http://www.median-kliniken.de/",
+        "http://www.medimops.de/",
+        "http://www.swm.de/",
+        "http://tff-forum.de/",
+        "http://www.aponeo.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 3814,
-      "errors": 9,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://boredoflunch.com/",
-        "http://slangwise.com/",
-        "http://daxstreet.com/",
-        "http://www.backtothebay.net/",
-        "http://eatdelights.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://govfacts.org/",
-        "http://www.seascanner.com/",
-        "http://www.tectake.co.uk/",
-        "http://9meters.com/",
-        "http://www.themusicman.uk/"
-      ],
-      "errorSites": [
-        "http://chefjonwatts.com/",
-        "http://godsverse.org/",
-        "http://ranwhenparked.net/",
-        "http://www.itsoverflowing.com/",
-        "http://cancerrehabpt.com/"
-      ]
-    },
-    "US": {
-      "sites": 3310,
+      "sites": 375,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.finanzen.net/",
-        "http://www.chelseafc.com/",
-        "http://www.naxos.com/",
-        "http://piunikaweb.com/",
-        "http://drfone.wondershare.com/"
+        "http://sallysbakingaddiction.com/",
+        "http://www.uefa.com/",
+        "http://www.neff-home.com/",
+        "http://www.howtoexcel.org/",
+        "http://www.photrio.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
+        "http://all3dp.com/",
+        "http://www.tuasaude.com/",
+        "http://thevetdesk.com/",
+        "http://www.dogster.com/",
+        "http://www.gocomics.com/"
+      ],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 287,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://plantisima.com/",
+        "http://www.uefa.com/",
         "http://slashdot.org/",
-        "http://www.songfacts.com/",
-        "http://www.cellsignal.com/",
-        "http://www.ebth.com/",
-        "http://wildlifeinformer.com/"
+        "http://www.dw.com/",
+        "http://www.media.io/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    }
+  },
+  "consentmo": {
+    "DE": {
+      "sites": 3,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://prepmymeal.com/",
+        "http://rebike.com/",
+        "http://silberkraft.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 11,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.directdoors.com/",
+        "http://www.farmergracy.co.uk/",
+        "http://www.sewessential.co.uk/",
+        "http://www.allpondsolutions.co.uk/",
+        "http://www.bonnersmusic.co.uk/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://jaycotts.co.uk/",
+        "http://marshallsgarden.com/"
+      ],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 10,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://travelpro.com/",
+        "http://www.gouletpens.com/",
+        "http://freedomgorilla.com/",
+        "http://www.keenfootwear.com/",
+        "http://shop.panasonic.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://bicyclewarehouse.com/",
+        "http://www.ollies.com/",
+        "http://travelpro.com/",
+        "http://www.arhaus.com/",
+        "http://www.gouletpens.com/"
       ],
       "errorSites": []
     }
   },
   "cookie-consent-spice": {
     "DE": {
-      "sites": 8,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.thomann.at/",
-        "http://www.thomann.co.uk/",
-        "http://www.thomannmusic.com/",
-        "http://www.thomann.fr/",
-        "http://www.thomann.nl/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 3,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.thomann.co.uk/",
         "http://www.thomann.de/",
         "http://www.thomannmusic.com/"
       ],
@@ -3889,13 +2564,22 @@
       "unsuccessfulSites": [],
       "errorSites": []
     },
-    "US": {
-      "sites": 3,
+    "GB": {
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.thomann.co.uk/",
-        "http://www.thomann.de/",
+        "http://www.thomann.co.uk/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
         "http://www.thomannmusic.com/"
       ],
       "failingSites": [],
@@ -3905,407 +2589,280 @@
   },
   "cookie-law-info": {
     "DE": {
-      "sites": 443,
-      "errors": 2,
-      "selfTestFailures": 3,
+      "sites": 10,
+      "errors": 0,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.solitaire-palast.de/",
-        "http://www.cotton-club.de/",
-        "http://ruhrgebiet-info.de/",
-        "http://www.omas-gegen-rechts.org/",
-        "http://krisenvorsorge-treffen.de/"
+        "http://bioaufvorrat.de/",
+        "http://die-gesunde-wahrheit.de/",
+        "http://www.fitundattraktiv.de/",
+        "http://reihenfolge.org/",
+        "http://technischetipps.com/"
       ],
       "failingSites": [
-        "http://italien-nord.de/",
-        "http://www.snowtimes.de/",
         "http://www.e-mobileo.de/"
       ],
       "unsuccessfulSites": [
-        "http://www.sachsentourist-wittig.de/",
-        "http://typeschool.de/",
-        "http://www.techsavvy.de/",
-        "http://www.abtei-gerleve.de/",
-        "http://mindjazz-pictures.de/"
+        "http://www.mailhilfe.de/"
       ],
-      "errorSites": [
-        "http://aaai.org/",
-        "http://balticlivecam.com/"
-      ]
+      "errorSites": []
     },
     "GB": {
-      "sites": 983,
-      "errors": 5,
-      "selfTestFailures": 5,
+      "sites": 16,
+      "errors": 0,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://ropetacklecentre.co.uk/",
-        "http://museumofoxford.org/",
-        "http://daro-cane.co.uk/",
-        "http://www.taxrebates.co.uk/",
-        "http://youlean.co/"
+        "http://appliancehunter.co.uk/",
+        "http://teachmeanatomy.info/",
+        "http://craft.co/",
+        "http://patientsknowbest.com/",
+        "http://thirdspacelearning.com/"
       ],
-      "failingSites": [
-        "http://shellystore.co.uk/",
-        "http://www.thepianoshopbath.co.uk/",
-        "http://lacocinadegisele.com/",
-        "http://www.checkyourchange.co.uk/",
-        "http://www.chronicle.gi/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [
-        "http://radcliffechambers.com/",
-        "http://stthomasofcanterbury.com/",
-        "http://balticlivecam.com/",
-        "http://www.saks.co.uk/",
-        "http://www.sciencemediacentre.org/"
+        "http://teachmeanatomy.info/"
       ],
-      "errorSites": [
-        "http://balticlivecam.com/",
-        "http://theorycircuit.com/",
-        "http://resartis.org/",
-        "http://www.thebookbuyer.co.uk/",
-        "http://www.quiztriviagames.com/"
-      ]
+      "errorSites": []
     },
     "US": {
-      "sites": 331,
+      "sites": 6,
       "errors": 0,
-      "selfTestFailures": 3,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://biaggis.com/",
-        "http://dbeaver.io/",
-        "http://www.lifecoachmagazine.com/",
-        "http://www.penncommunitybank.com/",
-        "http://www.christcathedralcalifornia.org/"
+        "http://craft.co/",
+        "http://dailyhealthpost.com/",
+        "http://teachmeanatomy.info/",
+        "http://www.mysextoyguide.com/",
+        "http://www.uchealth.org/"
       ],
-      "failingSites": [
-        "http://www.uscreditcardguide.com/",
-        "http://lacocinadegisele.com/",
-        "http://billygraham.org.uk/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [
-        "http://eastontowncenter.com/",
-        "http://www.prb.org/",
-        "http://mybestgermanrecipes.com/",
-        "http://www.bajadesigns.com/",
-        "http://wwoof.net/"
+        "http://teachmeanatomy.info/"
       ],
       "errorSites": []
     }
   },
   "cookie-script": {
     "DE": {
-      "sites": 423,
+      "sites": 40,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.autogari.ro/",
-        "http://www.antikeo.com/",
-        "http://antwerpdiamonds.direct/",
-        "http://www.kaufmich.com/",
-        "http://www.soundsnap.com/"
+        "http://www.vrm-trauer.de/",
+        "http://visitsweden.de/",
+        "http://www.wlw.de/",
+        "http://docs.n8n.io/",
+        "http://www.handmadekultur.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.gesundheit-wissenschaft.de/",
-        "http://holidayonice.com/",
-        "http://www.radbag.de/",
-        "http://www.wlw.ch/",
-        "http://deepsearchai.co/"
+        "http://de.eurovelo.com/",
+        "http://www.aachen-gedenkt.de/",
+        "http://www.aktionspreis.de/",
+        "http://www.europages.de/",
+        "http://www.handmadekultur.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 923,
+      "sites": 72,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.filmhouse.org.uk/",
-        "http://motorrange.co.uk/",
-        "http://www.santafixie.co.uk/",
-        "http://www.mrlender.com/",
-        "http://www.miocreate.com/"
+        "http://www.gardenbuildingsdirect.co.uk/",
+        "http://www.mobilitysmart.co.uk/",
+        "http://sparxmaths.com/",
+        "http://www.visit-dorset.com/",
+        "http://www.hotfrog.co.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.visitisleofwight.co.uk/",
-        "http://www.pulselightclinic.co.uk/",
-        "http://www.damen.com/",
-        "http://newskillsacademy.co.uk/",
-        "http://community.investengine.com/"
+        "http://motionarray.com/",
+        "http://www.gardenbuildingsdirect.co.uk/",
+        "http://www.jurawatches.co.uk/",
+        "http://www.schoolguide.co.uk/",
+        "http://www.visit-hampshire.co.uk/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 162,
+      "sites": 14,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.ailabtools.com/",
-        "http://localliquidators.com/",
-        "http://www.theartnewspaper.com/",
-        "http://www.pivotcycles.com/",
-        "http://ak-interactive.com/"
+        "http://www.fluentu.com/",
+        "http://www.dietdoctor.com/",
+        "http://egopowerplus.com/",
+        "http://www.assistedlivingcenter.com/",
+        "http://www.watchmojo.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.123test.com/",
-        "http://dishpromotions.com/",
-        "http://samples.landr.com/",
-        "http://www.teledynevisionsolutions.com/",
-        "http://www.sermonsearch.com/"
+        "http://assistedlivingcenter.com/",
+        "http://www.assistedlivingcenter.com/"
       ],
-      "errorSites": []
-    }
-  },
-  "cookieacceptbar": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://justfor.fans/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 13,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://justfor.fans/",
-        "http://transair.co.uk/",
-        "http://www.pacific-lifestyle.co.uk/",
-        "http://www.maxflow.co.uk/",
-        "http://www.lssystems.co.uk/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 5,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.tysonfoods.com/",
-        "http://www.prucenter.com/",
-        "http://www.streamlight.com/",
-        "http://justfor.fans/",
-        "http://www.btimesonline.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "cookieconsent2": {
     "DE": {
-      "sites": 362,
-      "errors": 1,
-      "selfTestFailures": 111,
-      "exampleSites": [
-        "http://www.arhantayoga.org/",
-        "http://www.letitshine.de/",
-        "http://www.onlinedogshows.eu/",
-        "http://www.scala-kino.net/",
-        "http://www.brixton-forum.de/"
-      ],
-      "failingSites": [
-        "http://zid.univie.ac.at/",
-        "http://www.neuwied.de/",
-        "http://aufnahmeverfahren.univie.ac.at/",
-        "http://amberg.de/",
-        "http://www.kirche-mit-kindern.de/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.kundendienst-portal.de/",
-        "http://www.suncalc.org/",
-        "http://www.golfbrothers.de/",
-        "http://www.stadtentwaesserung-frankfurt.de/",
-        "http://www.sicherheitsdatenblatt-suche.de/"
-      ],
-      "errorSites": [
-        "http://robinkaiser.eu/"
-      ]
-    },
-    "GB": {
-      "sites": 314,
+      "sites": 21,
       "errors": 0,
-      "selfTestFailures": 153,
+      "selfTestFailures": 8,
       "exampleSites": [
-        "http://www.sruk.co.uk/",
-        "http://www.dailydot.com/",
-        "http://www.lind.co.uk/",
-        "http://www.librarieswest.org.uk/",
-        "http://sealantsupplies.co.uk/"
+        "http://www.elektrikerwissen.de/",
+        "http://www.kinoprogramm.com/",
+        "http://maclookup.app/",
+        "http://www.ausbildungsstellen.de/",
+        "http://www.hochschulkompass.de/"
       ],
       "failingSites": [
-        "http://www.crescent-motorcycles.co.uk/",
-        "http://libraries.derbyshire.gov.uk/",
-        "http://www.concept2.com/",
-        "http://www.berryrecruitment.co.uk/",
-        "http://www.rightsofwomen.org.uk/"
+        "http://www.scm-shop.de/",
+        "http://www.fh-aachen.de/",
+        "http://www.jesus.de/",
+        "http://www.kundendienst-portal.de/",
+        "http://www.proxmox.com/"
       ],
       "unsuccessfulSites": [
-        "http://www.mha.co.uk/",
-        "http://josepizarro.com/",
-        "http://www.thegolfshoponline.co.uk/",
-        "http://liftshare.com/",
-        "http://greatebike.eu/"
+        "http://www.daibau.de/"
       ],
       "errorSites": []
     },
-    "US": {
-      "sites": 90,
+    "GB": {
+      "sites": 24,
       "errors": 0,
-      "selfTestFailures": 40,
+      "selfTestFailures": 9,
       "exampleSites": [
-        "http://www.cushmanwakefield.com/",
-        "http://sniffies.com/",
-        "http://signature-healthcare.org/",
-        "http://www.alphavantage.co/",
-        "http://www.edf.org/"
+        "http://www.cuh.nhs.uk/",
+        "http://boardgamegeek.com/",
+        "http://www.theaudioinsights.com/",
+        "http://www.greatrun.org/",
+        "http://www.proxmox.com/"
       ],
       "failingSites": [
-        "http://www.confluenceoutdoor.com/",
-        "http://www.mvhealthsystem.org/",
-        "http://autocamp.com/",
-        "http://www.concept2.com/",
-        "http://rheumatologistoncall.com/"
+        "http://www.visitnorthumberland.com/",
+        "http://www.jcq.org.uk/",
+        "http://maclookup.app/",
+        "http://www.bikesinstock.co.uk/",
+        "http://www.cuh.nhs.uk/"
       ],
-      "unsuccessfulSites": [
-        "http://whentowork.com/",
-        "http://www.sellierbellot.us/",
-        "http://bimmer.work/",
-        "http://www.cushmanwakefield.com/",
-        "http://www.suncalc.org/"
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 7,
+      "errors": 0,
+      "selfTestFailures": 3,
+      "exampleSites": [
+        "http://maclookup.app/",
+        "http://medicine.yale.edu/",
+        "http://www.mhvillage.com/",
+        "http://www.proxmox.com/",
+        "http://www.yalemedicine.org/"
       ],
+      "failingSites": [
+        "http://maclookup.app/",
+        "http://www.mhvillage.com/",
+        "http://www.proxmox.com/"
+      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "cookieconsent3": {
     "DE": {
-      "sites": 362,
+      "sites": 31,
       "errors": 0,
-      "selfTestFailures": 57,
+      "selfTestFailures": 2,
       "exampleSites": [
-        "http://www.mondo-moebel.de/",
-        "http://www.prnewswire.com/",
-        "http://bitfocus.io/",
-        "http://www.motorparts-online.com/",
-        "http://www.st-maximilian.de/"
+        "http://www.rosenhof-schultheis.de/",
+        "http://www.modelle-hamburg.de/",
+        "http://www.eggert-baumschulen.de/",
+        "http://www.bildungsurlaub.de/",
+        "http://www.crealitycloud.com/"
       ],
       "failingSites": [
-        "http://www.primeros.de/",
-        "http://polizei.brandenburg.de/",
-        "http://doppeldorf.de/",
-        "http://hellobetter.de/",
-        "http://www.wfbb.de/"
+        "http://www.crealitycloud.com/",
+        "http://www.kuechen-atlas.de/"
       ],
       "unsuccessfulSites": [
-        "http://forms.app/",
-        "http://www.gridx.ai/",
-        "http://www.rtvslo.si/",
-        "http://powerrubber.com/",
-        "http://bookbot.at/"
+        "http://kurviger.com/",
+        "http://www.qnap.com/",
+        "http://www.yazio.com/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 382,
+      "sites": 25,
       "errors": 0,
-      "selfTestFailures": 56,
+      "selfTestFailures": 5,
       "exampleSites": [
-        "http://qualifications.gov.scot/",
-        "http://www.c4productiontrainingscheme.com/",
-        "http://www.lotu.uk/",
-        "http://property-filter.co.uk/",
-        "http://www.kingfisherdirect.co.uk/"
+        "http://adexa.co.uk/",
+        "http://app.opencve.io/",
+        "http://bestbuyersguide.org/",
+        "http://www.eufy.com/",
+        "http://www.anker.com/"
       ],
       "failingSites": [
-        "http://data.fitzmuseum.cam.ac.uk/",
-        "http://www.c4productiontrainingscheme.com/",
-        "http://www.soleretriever.com/",
-        "http://www.bmw-berlin-marathon.com/",
-        "http://www.generali-berliner-halbmarathon.de/"
+        "http://thebbqshop.co.uk/",
+        "http://www.canford.co.uk/",
+        "http://www.crealitycloud.com/",
+        "http://www.pitchero.com/",
+        "http://www.sqa.org.uk/"
       ],
       "unsuccessfulSites": [
-        "http://qnap.com/",
-        "http://zitadel.com/",
-        "http://casa.sapo.pt/",
-        "http://math-gpt.ai/",
+        "http://selfridges.com/",
+        "http://www.prnewswire.com/",
+        "http://www.qnap.com/",
         "http://www.selfridges.com/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 217,
+      "sites": 20,
       "errors": 0,
-      "selfTestFailures": 47,
+      "selfTestFailures": 2,
       "exampleSites": [
-        "http://www.businessoffashion.com/",
-        "http://lustery.com/",
-        "http://www.alaskacargo.com/",
-        "http://www.pbctax.gov/",
-        "http://www.scotsman-ice.com/"
+        "http://www.eufy.com/",
+        "http://www.hawaiianairlines.com/",
+        "http://pathfinderwiki.com/",
+        "http://www.breastcancer.org/",
+        "http://www.prnewswire.com/"
       ],
       "failingSites": [
-        "http://www.tgh.org/",
-        "http://www.elitesingles.com/",
-        "http://www.lodgecastiron.com/",
-        "http://www.silversingles.com/",
-        "http://uas.alaska.edu/"
+        "http://www.crealitycloud.com/",
+        "http://www.umms.org/"
       ],
       "unsuccessfulSites": [
-        "http://www.3daistudio.com/",
+        "http://cinemark.com/",
+        "http://www.alaskaair.com/",
+        "http://www.breastcancer.org/",
         "http://www.buildzoom.com/",
-        "http://thedieseldudes.com/",
-        "http://www.alaskacargo.com/",
-        "http://www.spaceneedle.com/"
+        "http://www.hawaiianairlines.com/"
       ],
       "errorSites": []
     }
   },
   "cookiecuttr": {
     "DE": {
-      "sites": 12,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.pollenstiftung.de/",
-        "http://www.esa.int/",
-        "http://www.elektrowelt24.eu/",
-        "http://bachtel.it-wms.com/",
-        "http://www.rarepalmseeds.com/"
+        "http://bachheimer.com/",
+        "http://www.esa.int/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 42,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.polfed.org/",
-        "http://onlinebutcher.co.uk/",
-        "http://www.colerainechronicle.co.uk/",
-        "http://www.driving-test-cancellations-4all.co.uk/",
-        "http://www.theberkshire.co.uk/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.williamsclassics.co.uk/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.cad-steel.com/"
+        "http://www.esa.int/",
+        "http://www.trafficengland.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -4314,177 +2871,107 @@
   },
   "cookiefirst.com": {
     "DE": {
-      "sites": 752,
+      "sites": 50,
       "errors": 0,
-      "selfTestFailures": 48,
+      "selfTestFailures": 4,
       "exampleSites": [
-        "http://mt-portal.de/",
-        "http://www.prooffice.de/",
-        "http://www.joker-jeans.de/",
-        "http://www.hal-privatbank.com/",
-        "http://www.hsg-wetzlar.de/"
+        "http://www.drk-blutspende.de/",
+        "http://www.doccheck.com/",
+        "http://www.astroshop.de/",
+        "http://www.bikes.de/",
+        "http://flexikon.doccheck.com/"
       ],
       "failingSites": [
-        "http://www.hellogetsafe.com/",
-        "http://www.leinenlodge.de/",
-        "http://www.allcura.de/",
-        "http://www.stralsundtourismus.de/",
-        "http://www.jena-veranstaltungen.de/"
+        "http://www.beltz.de/",
+        "http://www.krankenhaus.de/",
+        "http://www.smeg.com/",
+        "http://www.weinmann-schanz.de/"
       ],
       "unsuccessfulSites": [
-        "http://forum.checkmk.com/",
-        "http://www.piercingline.com/",
-        "http://www.gs1-germany.de/",
-        "http://safariland-stukenbrock.de/",
-        "http://www.gorillawear.com/"
+        "http://recording.de/",
+        "http://www.wunschgutschein.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 320,
+      "sites": 29,
       "errors": 0,
-      "selfTestFailures": 4,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.cytoplan.co.uk/",
-        "http://edinburgh-innovations.ed.ac.uk/",
-        "http://www.jasperconran.com/",
-        "http://www.justradiators.co.uk/",
-        "http://www.crownoil.co.uk/"
+        "http://rab.equipment/",
+        "http://www.jollyes.co.uk/",
+        "http://www.woolwarehouse.co.uk/",
+        "http://www.unbiased.co.uk/",
+        "http://lsengineers.co.uk/"
       ],
-      "failingSites": [
-        "http://file.org/",
-        "http://rspo.org/",
-        "http://www.smeg.com/",
-        "http://news.motability.co.uk/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [
-        "http://sqe.sra.org.uk/",
-        "http://tile.co.uk/",
-        "http://forum.checkmk.com/",
-        "http://www.radiushousing.org/",
-        "http://www.elizabethscarlett.com/"
+        "http://www.prodirectsport.com/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 50,
+      "sites": 1,
       "errors": 0,
-      "selfTestFailures": 1,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://gaijin.net/",
-        "http://www.lsengineers.co.uk/",
-        "http://borisfx.com/",
-        "http://warthunder.com/",
-        "http://www.4321property.com/"
+        "http://www.unbiased.com/"
       ],
-      "failingSites": [
-        "http://www.smeg.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.panmacmillan.com/",
-        "http://hevodata.com/",
-        "http://forum.warthunder.com/",
-        "http://www.goodwood.com/",
-        "http://meetergo.com/"
-      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "cookiehub": {
     "DE": {
-      "sites": 118,
+      "sites": 8,
       "errors": 0,
-      "selfTestFailures": 1,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.jamestown.de/",
-        "http://clarissakork.com/",
-        "http://ckeditor.com/",
-        "http://www.bossard.com/",
-        "http://www.urlaubambauernhof.at/"
+        "http://hager.com/",
+        "http://kotlinlang.org/",
+        "http://swagger.io/",
+        "http://www.jetbrains.com/",
+        "http://www.sautershop.de/"
       ],
-      "failingSites": [
-        "http://www.starline.de/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.hager.de/",
-        "http://www.slowdown-bottsand.de/",
-        "http://hagergroup.com/",
-        "http://kinderkraft.de/",
-        "http://kundenportal.deutsche-giganetz.de/"
+        "http://hager.com/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 173,
+      "sites": 13,
       "errors": 0,
-      "selfTestFailures": 4,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.nawt.org.uk/",
-        "http://coftonholidays.co.uk/",
         "http://clubhousegolf.co.uk/",
-        "http://www.atomos.com/",
-        "http://www.clothes2order.com/"
+        "http://dice.fm/",
+        "http://www.yha.org.uk/",
+        "http://restless.co.uk/",
+        "http://onlinedoctor.lloydspharmacy.com/"
       ],
       "failingSites": [
-        "http://www.victronenergy.co.uk/",
-        "http://www.finnlough.com/",
-        "http://kineto.app/",
-        "http://www.cicerone.co.uk/"
+        "http://onlinedoctor.lloydspharmacy.com/"
       ],
-      "unsuccessfulSites": [
-        "http://www.lordwandsworth.org/",
-        "http://www.omar.co.uk/",
-        "http://www.stpatricksoho.org/",
-        "http://www.fsb.org.uk/",
-        "http://www.ccn.ac.uk/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 42,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://cokertire.com/",
-        "http://youtrack.jetbrains.com/",
-        "http://interlightus.com/",
-        "http://forums.fatsharkgames.com/",
-        "http://www.atomos.com/"
+        "http://www.jetbrains.com/",
+        "http://www.victronenergy.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.nealcommunities.com/",
-        "http://www.commoninja.com/",
-        "http://joinit.com/",
-        "http://forums.fatsharkgames.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "cookiejs-banner": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.citizensinformation.ie/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "GB": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.citizensinformation.ie/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
@@ -4498,93 +2985,73 @@
   },
   "cookieyes": {
     "DE": {
-      "sites": 773,
+      "sites": 39,
       "errors": 0,
-      "selfTestFailures": 40,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.filmin.es/",
-        "http://welcome2jordan.com/",
-        "http://buchszene.de/",
-        "http://schlossfestspiele.de/",
-        "http://malsati.com/"
+        "http://www.kostenlose-vordrucke.de/",
+        "http://www.directferries.de/",
+        "http://towardsdatascience.com/",
+        "http://finwiss.de/",
+        "http://www.gigabyte.com/"
       ],
       "failingSites": [
-        "http://oeksound.com/",
-        "http://www.cynthiabarcomi.com/",
-        "http://motomorini.eu/",
-        "http://shop.berberich-papier.de/",
-        "http://www.putalocura.com/"
+        "http://www.usz.ch/"
       ],
       "unsuccessfulSites": [
-        "http://www.motionvfx.com/",
-        "http://www.oorlogsmuseum.nl/",
-        "http://www.pakete-verfolgen.de/",
-        "http://www.proximafusion.com/",
-        "http://www.unmannedsystemstechnology.com/"
+        "http://cybernews.com/",
+        "http://www.fontspace.com/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 3346,
-      "errors": 10,
-      "selfTestFailures": 132,
+      "sites": 190,
+      "errors": 0,
+      "selfTestFailures": 12,
       "exampleSites": [
-        "http://www.recycledevon.org/",
-        "http://www.bondtech.se/",
-        "http://garagefloorsdirect.co.uk/",
-        "http://www.raf-ff.org.uk/",
-        "http://www.kosher.org.uk/"
+        "http://heatable.co.uk/",
+        "http://www.sockshop.co.uk/",
+        "http://www.londonmarathonevents.co.uk/",
+        "http://butcombe.com/",
+        "http://blog.kinkly.com/"
       ],
       "failingSites": [
-        "http://www.directplastics.co.uk/",
         "http://www.sealey.co.uk/",
-        "http://buffer.com/",
-        "http://bandce.co.uk/",
-        "http://www.surreytimbers.co.uk/"
+        "http://firstfence.co.uk/",
+        "http://www.nbt.nhs.uk/",
+        "http://peacewiththewild.co.uk/",
+        "http://www.sockshop.co.uk/"
       ],
       "unsuccessfulSites": [
-        "http://www.eco-ess.co.uk/",
-        "http://switchity.co.uk/",
-        "http://www.grandprixgrandtours.com/",
-        "http://wearecrossfader.co.uk/",
-        "http://www.airhop.co.uk/"
+        "http://cybernews.com/",
+        "http://www.agriframes.co.uk/",
+        "http://www.gsfcarparts.com/",
+        "http://www.usedcarsni.com/"
       ],
-      "errorSites": [
-        "http://adventuremedia.co.uk/",
-        "http://crohns-disease.org.uk/",
-        "http://godsverse.org/",
-        "http://cancerrehabpt.com/",
-        "http://chefjonwatts.com/"
-      ]
+      "errorSites": []
     },
     "US": {
-      "sites": 1264,
-      "errors": 1,
-      "selfTestFailures": 250,
+      "sites": 51,
+      "errors": 0,
+      "selfTestFailures": 14,
       "exampleSites": [
-        "http://www.techsteel.net/",
-        "http://www.sifma.org/",
-        "http://www.rice.edu/",
-        "http://onohawaiianbbq.com/",
-        "http://reloadyourgear.com/"
+        "http://www.gigabyte.com/",
+        "http://www.murdochs.com/",
+        "http://www.kink.com/",
+        "http://www.astound.com/",
+        "http://opencorporates.com/"
       ],
       "failingSites": [
-        "http://continental.aero/",
-        "http://lovecrafts.com/",
-        "http://www.bottomlineinc.com/",
-        "http://nmu.edu/",
-        "http://www.mecoutdoors.com/"
+        "http://www.redgifs.com/",
+        "http://doheny.com/",
+        "http://eshop.macsales.com/",
+        "http://www.phoenix.gov/",
+        "http://traveloregon.com/"
       ],
       "unsuccessfulSites": [
-        "http://eatmorebutter.com/",
-        "http://trackbill.com/",
-        "http://www.wilderness.org/",
-        "http://www.thrustflight.com/",
-        "http://www.quickjack.com/"
+        "http://setapp.com/"
       ],
-      "errorSites": [
-        "http://www.redlodgemountain.com/"
-      ]
+      "errorSites": []
     }
   },
   "copilot-microsoft": {
@@ -4613,148 +3080,86 @@
   },
   "corona-in-zahlen.de": {
     "DE": {
-      "sites": 38,
+      "sites": 5,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://hobbyking.com/",
-        "http://liveingermany.de/",
-        "http://minipc-review.com/",
-        "http://bassenge.com/",
-        "http://webcamfiles.com/"
+        "http://camslib.com/",
+        "http://hubite.com/",
+        "http://radio-horen.de/",
+        "http://www.dv-treff-community.de/",
+        "http://www.modland.net/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://mobile-gutscheine.de/",
-        "http://freightfinders.com/",
-        "http://edalnice.cz/",
-        "http://www.almahoppe.de/",
-        "http://iptvcat.org/"
+        "http://camslib.com/",
+        "http://hubite.com/",
+        "http://radio-horen.de/",
+        "http://www.dv-treff-community.de/",
+        "http://www.modland.net/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 53,
+      "sites": 8,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://www.huntingdonshire.gov.uk/",
+        "http://hubite.com/",
         "http://www.modland.net/",
-        "http://liveingermany.de/",
-        "http://www.e-consystems.com/",
-        "http://yorkshire-list.com/",
-        "http://shop4fasteners.co.uk/"
+        "http://www.ukclimbing.com/",
+        "http://www.houseofnames.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.earwaxremoval.uk/",
-        "http://blog.openreplay.com/",
-        "http://www.pictolic.com/",
-        "http://privatecamz.com/",
-        "http://radio-live-uk.com/"
+        "http://www.huntingdonshire.gov.uk/",
+        "http://hubite.com/",
+        "http://www.modland.net/",
+        "http://radio-live-uk.com/",
+        "http://www.ukclimbing.com/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 50,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.allstarhealth.com/",
-        "http://www.cityparkgames.com/",
-        "http://www.contourairlines.com/",
-        "http://www.pictolic.com/",
-        "http://webcamfiles.com/"
+        "http://hubite.com/",
+        "http://www.lsu.edu/",
+        "http://www.modland.net/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.dmacc.edu/",
-        "http://www.elandelwoodproducts.com/",
-        "http://www.allstarhealth.com/",
-        "http://www.hbtbank.com/",
-        "http://www.bellarmine.edu/"
+        "http://hubite.com/",
+        "http://www.lsu.edu/",
+        "http://www.modland.net/"
       ],
-      "errorSites": []
-    }
-  },
-  "csu-landtag-de": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.csu-landtag.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "ct-ultimate-gdpr": {
-    "DE": {
-      "sites": 2,
+    "US": {
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://ls2helmets.com/",
-        "http://unser-kgv-online.de/"
+        "http://topclassactions.com/"
       ],
       "failingSites": [
-        "http://unser-kgv-online.de/"
+        "http://topclassactions.com/"
       ],
       "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 7,
-      "errors": 0,
-      "selfTestFailures": 3,
-      "exampleSites": [
-        "http://ls2helmets.com/",
-        "http://compasshousemedical.com/",
-        "http://portsmouthdiocese.org.uk/",
-        "http://prepareforchange.net/",
-        "http://qsensor.co/"
-      ],
-      "failingSites": [
-        "http://swallows-jag.co.uk/",
-        "http://prepareforchange.net/",
-        "http://compasshousemedical.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://hedonism.com/",
-        "http://portsmouthdiocese.org.uk/",
-        "http://qsensor.co/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 4,
-      "errors": 0,
-      "selfTestFailures": 1,
-      "exampleSites": [
-        "http://qsensor.co/",
-        "http://hedonism.com/",
-        "http://artistasycuadros.com/",
-        "http://neilmed.com/"
-      ],
-      "failingSites": [
-        "http://artistasycuadros.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://qsensor.co/",
-        "http://hedonism.com/",
-        "http://neilmed.com/"
-      ],
       "errorSites": []
     }
   },
   "curseforge": {
     "DE": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://support.curseforge.com/",
         "http://www.curseforge.com/"
       ],
       "failingSites": [],
@@ -4762,11 +3167,10 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://support.curseforge.com/",
         "http://www.curseforge.com/"
       ],
       "failingSites": [],
@@ -4774,12 +3178,11 @@
       "errorSites": []
     },
     "US": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.curseforge.com/",
-        "http://support.curseforge.com/"
+        "http://www.curseforge.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -4834,16 +3237,68 @@
       "errorSites": []
     }
   },
-  "dji": {
+  "didomi": {
     "DE": {
-      "sites": 5,
+      "sites": 101,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://store.dji.com/",
-        "http://support.dji.com/",
-        "http://dl.djicdn.com/",
-        "http://enterprise.dji.com/",
+        "http://backmarket.de/",
+        "http://giphy.com/",
+        "http://www.netzwelt.de/",
+        "http://plus.rtl.de/",
+        "http://www.hermes.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://www.qobuz.com/",
+        "http://www.willhaben.at/"
+      ],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 80,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://getemoji.com/",
+        "http://www.michelin.co.uk/",
+        "http://uk.news.yahoo.com/",
+        "http://www.viamichelin.com/",
+        "http://english.elpais.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://www.melia.com/",
+        "http://www.pizzaexpress.com/",
+        "http://www.qobuz.com/"
+      ],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 34,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.logos.com/",
+        "http://www.rajce.idnes.cz/",
+        "http://www.webnovel.com/",
+        "http://hibid.com/",
+        "http://uk.news.yahoo.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://www.qobuz.com/"
+      ],
+      "errorSites": []
+    }
+  },
+  "dji": {
+    "DE": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
         "http://www.dji.com/"
       ],
       "failingSites": [],
@@ -4851,29 +3306,13 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 5,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://store.dji.com/",
         "http://support.dji.com/",
-        "http://dl.djicdn.com/",
-        "http://enterprise.dji.com/",
         "http://www.dji.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 4,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.dji.com/",
-        "http://dl.djicdn.com/",
-        "http://enterprise.dji.com/",
-        "http://support.dji.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -4881,50 +3320,30 @@
     }
   },
   "dmgmedia": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.newscientist.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.newscientist.com/"
-      ],
-      "errorSites": []
-    },
     "GB": {
-      "sites": 6,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://subscription.newscientist.com/",
         "http://www.mailplus.co.uk/",
-        "http://www.mailsubscriptions.co.uk/",
-        "http://www.newscientist.com/",
-        "http://www.dmgmedia.co.uk/"
+        "http://www.newscientist.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://subscription.newscientist.com/",
-        "http://www.newscientist.com/",
-        "http://www.newzit.com/",
-        "http://www.dmgmedia.co.uk/"
+        "http://www.newscientist.com/"
       ],
       "errorSites": []
     }
   },
   "dmgmedia-us": {
     "US": {
-      "sites": 4,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.newscientist.com/",
+        "http://metro.co.uk/",
         "http://www.dailymail.co.uk/",
-        "http://www.dailymail.com/",
-        "http://metro.co.uk/"
+        "http://www.dailymail.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -4933,68 +3352,44 @@
   },
   "ebay": {
     "DE": {
-      "sites": 16,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.ebay.at/",
-        "http://pages.ebay.com/",
-        "http://www.ebay.es/",
-        "http://www.ebay.com/",
-        "http://www.ebay.ie/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://ebay.de/",
-        "http://www.ebay.de/",
-        "http://www.ebay.fr/",
-        "http://www.ebay.it/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 12,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.ebay.co.uk/",
-        "http://www.ebay.com.au/",
-        "http://ebay.co.uk/",
-        "http://ebay.com/",
-        "http://www.ebay.it/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.ebay.fr/",
-        "http://www.ebay.it/"
-      ],
-      "errorSites": []
-    },
-    "US": {
       "sites": 7,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://ebay.de/",
         "http://www.ebay.at/",
-        "http://www.ebay.co.uk/",
-        "http://www.ebay.de/",
-        "http://www.ebay.es/",
-        "http://www.ebay.it/"
+        "http://www.ebay.ca/",
+        "http://www.ebay.ch/",
+        "http://www.ebay.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.ebay.it/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
-    }
-  },
-  "ecosia": {
-    "US": {
-      "sites": 1,
+    },
+    "GB": {
+      "sites": 8,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.ecosia.org/"
+        "http://ebay.co.uk/",
+        "http://pages.ebay.co.uk/",
+        "http://www.ebay.com/",
+        "http://www.ebay.co.uk/",
+        "http://www.ebay.de/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://www.ebay.de/"
+      ],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 2,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.ebay.co.uk/",
+        "http://www.ebay.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -5002,17 +3397,6 @@
     }
   },
   "ef-ccpa": {
-    "GB": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://eforms.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "US": {
       "sites": 1,
       "errors": 0,
@@ -5025,13 +3409,15 @@
       "errorSites": []
     }
   },
-  "etsy": {
+  "elsevier-pure": {
     "GB": {
-      "sites": 1,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://etsy.app.link/"
+        "http://experts.exeter.ac.uk/",
+        "http://profiles.sussex.ac.uk/",
+        "http://profiles.ucl.ac.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -5040,173 +3426,171 @@
   },
   "eu-cookie-compliance-banner": {
     "DE": {
-      "sites": 245,
+      "sites": 24,
       "errors": 0,
-      "selfTestFailures": 46,
+      "selfTestFailures": 5,
       "exampleSites": [
-        "http://www.baks.bund.de/",
-        "http://www.om.org/",
-        "http://objektkatalog.gnm.de/",
-        "http://mundraub.org/",
-        "http://www.herzbach.com/"
+        "http://www.qua-lis.nrw.de/",
+        "http://www.tim-online.nrw.de/",
+        "http://www.schulministerium.nrw/",
+        "http://www.hausundgrund.de/",
+        "http://www.schulministerium.nrw.de/"
       ],
       "failingSites": [
-        "http://www.1und1.net/",
+        "http://www.bra.nrw.de/",
         "http://www.easa.europa.eu/",
-        "http://www.digitales-deutsches-frauenarchiv.de/",
-        "http://www.teilhabeberatung.de/",
-        "http://www.linenme.de/"
+        "http://www.epo.org/",
+        "http://www.schulministerium.nrw.de/",
+        "http://www.schulministerium.nrw/"
       ],
       "unsuccessfulSites": [
-        "http://www.usccb.org/",
-        "http://www.goruma.de/",
-        "http://www.uvp-portal.de/",
-        "http://kultur-online.net/",
-        "http://www.artec3d.com/"
+        "http://www.bfn.de/",
+        "http://www.d-trust.net/",
+        "http://www.statistikportal.de/",
+        "http://www.ub.tum.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 347,
+      "sites": 37,
       "errors": 0,
-      "selfTestFailures": 51,
+      "selfTestFailures": 4,
       "exampleSites": [
-        "http://www.euda.europa.eu/",
-        "http://www.hseni.gov.uk/",
-        "http://www.alumni.cam.ac.uk/",
-        "http://www.justice-ni.gov.uk/",
-        "http://www.lotusbiscoff.com/"
+        "http://www.rbwm.gov.uk/",
+        "http://www.elmbridge.gov.uk/",
+        "http://www.wokingham.gov.uk/",
+        "http://www.rbkc.gov.uk/",
+        "http://www.ebu.co.uk/"
       ],
       "failingSites": [
-        "http://www.soudal.co.uk/",
-        "http://www.iter.org/",
-        "http://www.easa.europa.eu/",
-        "http://www.actiontogether.org.uk/",
-        "http://www.emta.ee/"
+        "http://selectra.co.uk/",
+        "http://www.bto.org/",
+        "http://www.local.gov.uk/",
+        "http://www.nature.scot/"
       ],
       "unsuccessfulSites": [
-        "http://democracy.croydon.gov.uk/",
-        "http://www.uk.coop/",
-        "http://www.theploughartscentre.org.uk/",
-        "http://www.uottawa.ca/",
-        "http://psychoanalysis.org.uk/"
+        "http://www.croydon.gov.uk/",
+        "http://www.essex.gov.uk/",
+        "http://www.northdevon.gov.uk/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 230,
+      "sites": 17,
       "errors": 0,
-      "selfTestFailures": 11,
+      "selfTestFailures": 2,
       "exampleSites": [
-        "http://www.sju.edu/",
-        "http://www.fredonia.edu/",
-        "http://www.sanfranciscofcu.com/",
-        "http://math.ucr.edu/",
-        "http://www.brandywine.org/"
+        "http://www.stereophile.com/",
+        "http://www.battlefields.org/",
+        "http://healthcare.utah.edu/",
+        "http://www.mcgill.ca/",
+        "http://www.escort-ads.com/"
       ],
       "failingSites": [
-        "http://www.mcgill.ca/",
-        "http://milkeninstitute.org/",
         "http://www.honorhealth.com/",
-        "http://www.ipsosisay.com/",
-        "http://www.baincapital.com/"
+        "http://www.mcgill.ca/"
       ],
       "unsuccessfulSites": [
-        "http://www.ucalgary.ca/",
-        "http://www.bcaresearch.com/",
-        "http://www.sdstate.edu/",
-        "http://www.gc.cuny.edu/",
-        "http://georgia.org/"
+        "http://bible.usccb.org/",
+        "http://www.escort-ads.com/",
+        "http://www.adventhealth.com/",
+        "http://www.uvm.edu/",
+        "http://www.dar.org/"
       ],
       "errorSites": []
     }
   },
-  "fastcmp": {
+  "facebook": {
     "DE": {
-      "sites": 12,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://rundumdeutschland.de/",
-        "http://www.supersoluce.com/",
-        "http://histoiresroyales.fr/",
-        "http://www.w3schools.com/",
-        "http://www.laculturegenerale.com/"
+        "http://www.facebook.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 15,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.w3schools.com/",
-        "http://jamieolivereats.uk/",
-        "http://www.paddock-gp.com/",
-        "http://physicsandmathstutor.com/",
-        "http://royalcentral.co.uk/"
+        "http://l.facebook.com/",
+        "http://www.facebook.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://jamieolivereats.uk/"
+      "unsuccessfulSites": [],
+      "errorSites": []
+    }
+  },
+  "fastcmp": {
+    "DE": {
+      "sites": 4,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://kathisgenusskueche.de/",
+        "http://www.astroportal.com/",
+        "http://www.kingmods.net/",
+        "http://www.w3schools.com/"
       ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 4,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://britishbakingrecipes.co.uk/",
+        "http://www.nigella.com/",
+        "http://www.physicsandmathstutor.com/",
+        "http://www.w3schools.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "fides": {
     "DE": {
-      "sites": 43,
+      "sites": 12,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.bonappetit.com/",
-        "http://www.gq.com/",
-        "http://nextjs.org/",
-        "http://www.surveymonkey.com/",
-        "http://vercel.com/"
+        "http://arstechnica.com/",
+        "http://www.gq-magazin.de/",
+        "http://www.nytimes.com/",
+        "http://www.ironman.com/",
+        "http://www.cntraveller.de/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.self.com/",
-        "http://www.vanityfair.com/",
-        "http://www.gq.com/",
-        "http://www.bonappetit.com/",
-        "http://www.teenvogue.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 53,
+      "sites": 22,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.self.com/",
-        "http://www.justpark.com/",
-        "http://www.tatler.com/",
-        "http://www.them.us/",
-        "http://www.hemmings.com/"
+        "http://arstechnica.com/",
+        "http://www.newyorker.com/",
+        "http://www.codecademy.com/",
+        "http://pitchfork.com/",
+        "http://www.cntraveler.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://pitchfork.com/",
-        "http://www.vogue.com/",
-        "http://www.condenast.com/",
-        "http://www.epicurious.com/",
-        "http://www.wired.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 10,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.vogue.co.uk/",
-        "http://www.runrocknroll.com/",
-        "http://www.skillsoft.com/",
-        "http://www.glamourmagazine.co.uk/",
         "http://www.ironman.com/"
       ],
       "failingSites": [],
@@ -5215,80 +3599,37 @@
     }
   },
   "financestrategists.com": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "US": {
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
-      "exampleSites": [],
+      "exampleSites": [
+        "http://www.financestrategists.com/"
+      ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "finsweet": {
-    "DE": {
-      "sites": 12,
+    "GB": {
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://brainhub.eu/",
-        "http://www.telekonnekt.de/",
-        "http://originality.ai/",
-        "http://www.myarchitectai.com/",
-        "http://www.codewars.com/"
+        "http://www.boltpharmacy.co.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
-    },
-    "GB": {
-      "sites": 20,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://originality.ai/",
-        "http://www.urbanpubsandbars.com/",
-        "http://www.physitrack.com/",
-        "http://www.carsa.co.uk/",
-        "http://www.fellahealth.co.uk/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.mclarengroup.com/",
-        "http://www.physitrack.com/",
-        "http://www.carsa.co.uk/"
-      ],
-      "errorSites": []
-    },
+    }
+  },
+  "fullertonhotels.com": {
     "US": {
-      "sites": 16,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.baddie.health/",
-        "http://originality.ai/",
-        "http://teamliquid.com/",
-        "http://www.physitrack.com/",
-        "http://www.bkfc.com/"
-      ],
+      "exampleSites": [],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
@@ -5296,105 +3637,91 @@
   },
   "funding-choices": {
     "DE": {
-      "sites": 2362,
-      "errors": 3,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://whatismyip.org/",
-        "http://pokepath.gg/",
-        "http://timesofindia.indiatimes.com/",
-        "http://deutsch-mit-anna.de/",
-        "http://electrek.co/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://artvoice.com/",
-        "http://www.netquel.com/",
-        "http://www.kostenlose-strickanleitungen.de/",
-        "http://cartermatt.com/",
-        "http://viennahipsterguide.com/"
-      ],
-      "errorSites": [
-        "http://gewinnspiele-heute.com/",
-        "http://www.news24.com/",
-        "http://balticlivecam.com/"
-      ]
-    },
-    "GB": {
-      "sites": 5857,
-      "errors": 15,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.stadiumgaming.gg/",
-        "http://www.ageratingjuju.com/",
-        "http://whocalled.co.uk/",
-        "http://www.poultryhatch.com/",
-        "http://whoiscallingyou.co.uk/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://nasaspacenews.com/",
-        "http://www.quizprep.co.uk/",
-        "http://chordseasy.com/",
-        "http://weatherandclimate.com/",
-        "http://paperio.site/"
-      ],
-      "errorSites": [
-        "http://www.pickupbrain.com/",
-        "http://www.theatermania.com/",
-        "http://gulfnews.com/",
-        "http://finescale.com/",
-        "http://theorycircuit.com/"
-      ]
-    },
-    "US": {
-      "sites": 5,
+      "sites": 271,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.meteoblue.com/",
-        "http://www.cyclingelectric.com/",
-        "http://www.cyclist.co.uk/",
-        "http://www.airnavradar.com/",
-        "http://www.auto123.com/"
+        "http://eurovisionworld.com/",
+        "http://u.gg/",
+        "http://www.digitalkamera.de/",
+        "http://schoggikurs.ch/",
+        "http://alphacoders.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://7flamme.com/",
+        "http://www.digminecraft.com/",
+        "http://spieleboom.com/",
+        "http://playhop.com/",
+        "http://makeitmeme.com/"
+      ],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 575,
+      "errors": 2,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.tech2geek.net/",
+        "http://is-this-legal.com/",
+        "http://www.distancesfrom.com/",
+        "http://kerrydalestreet.co.uk/",
+        "http://www.tvinsider.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://www.whatsafterthemovie.com/",
+        "http://www.ispreview.co.uk/",
+        "http://flight-status.com/",
+        "http://ukdefencejournal.org.uk/",
+        "http://www.azmovies.net/"
+      ],
+      "errorSites": [
+        "http://play.tetris.com/",
+        "http://www.pgachampionship.com/"
+      ]
+    },
+    "US": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.meteoblue.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     }
   },
-  "gdpr-legal-cookie": {
+  "geni.com": {
     "DE": {
-      "sites": 23,
-      "errors": 1,
-      "selfTestFailures": 2,
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://fothermo.com/",
-        "http://www.mobyvan.de/",
-        "http://landundkarte.de/",
-        "http://www.langehosen.de/",
-        "http://solinger-messer.de/"
+        "http://www.geni.com/"
       ],
-      "failingSites": [
-        "http://stilkontor.com/",
-        "http://www.langehosen.de/"
-      ],
-      "unsuccessfulSites": [
-        "http://carbonphone.de/",
-        "http://www.langehosen.de/"
-      ],
-      "errorSites": [
-        "http://www.langehosen.de/"
-      ]
-    }
-  },
-  "glastonburyfestivals": {
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
     "GB": {
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.glastonburyfestivals.co.uk/"
+        "http://www.geni.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.geni.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -5403,30 +3730,29 @@
   },
   "google-consent-standalone": {
     "DE": {
-      "sites": 13,
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://translate.google.at/",
-        "http://maps.google.it/",
-        "http://translate.google.com/",
-        "http://translate.google.pl/",
-        "http://translate.google.hu/"
+        "http://chromewebstore.google.com/",
+        "http://maps.google.com/",
+        "http://store.google.com/",
+        "http://translate.google.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 32,
+      "sites": 11,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://local.google.com/",
+        "http://chromewebstore.google.com/",
+        "http://translate.google.co.uk/",
+        "http://music.youtube.com/",
         "http://maps.google.co.uk/",
-        "http://translate.google.com.hk/",
-        "http://translate.google.fr/",
-        "http://adwords.google.co.uk/"
+        "http://store.google.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -5435,110 +3761,98 @@
   },
   "google-cookiebar": {
     "DE": {
-      "sites": 37,
+      "sites": 12,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://doodles.google/",
-        "http://www.tensorflow.org/",
-        "http://grow.google/",
-        "http://myaccount.google.com/",
-        "http://blog.google/"
+        "http://workspace.google.com/",
+        "http://firebase.google.com/",
+        "http://www.android.com/",
+        "http://developers.google.com/",
+        "http://labs.google/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://search.google/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 68,
+      "sites": 25,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://web.dev/",
-        "http://tv.google/",
-        "http://messages.google.com/",
-        "http://doodles.google/",
-        "http://families.google/"
+        "http://knowledge.workspace.google.com/",
+        "http://docs.cloud.google.com/",
+        "http://classroom.google.com/",
+        "http://calendar.google.com/",
+        "http://lens.google/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://aistudio.google.com/",
-        "http://search.google/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "google.com": {
     "DE": {
-      "sites": 27,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://en.pornohd.porn/",
-        "http://grafundfrey.de/",
-        "http://www.google.co.uk/",
-        "http://www.googleapps.com/",
-        "http://affect3d.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 106,
-      "errors": 2,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://heavy-r.name/",
-        "http://www.google.de/",
-        "http://www.tvsubtitles.net/",
-        "http://www.google.com.ai/",
-        "http://www.shemale6.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": [
-        "http://fleshbot.com/",
-        "http://www.fright-rags.com/"
-      ]
-    }
-  },
-  "gov.uk": {
-    "DE": {
       "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://find-and-update.company-information.service.gov.uk/",
-        "http://www.civilservicepensionscheme.org.uk/",
-        "http://www.gov.uk/"
+        "http://images.google.de/",
+        "http://www.google.com/",
+        "http://www.google.de/",
+        "http://www.google.es/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.civilservicepensionscheme.org.uk/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 136,
+      "sites": 6,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://powerofattorney.campaign.gov.uk/",
-        "http://customerhelp.landregistry.gov.uk/",
-        "http://www.tring.gov.uk/",
-        "http://www.medr.cymru/",
-        "http://www.regulated-professions.service.gov.uk/"
+        "http://fleshbot.com/",
+        "http://www.google.com/",
+        "http://images.google.com/",
+        "http://search.google.com/",
+        "http://www.google.co.uk/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    }
+  },
+  "gov.uk": {
+    "DE": {
+      "sites": 2,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://find-and-update.company-information.service.gov.uk/",
+        "http://www.gov.uk/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 29,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://get-information-schools.service.gov.uk/",
+        "http://www.northlincs.gov.uk/",
+        "http://www.sign-in.service.gov.uk/",
+        "http://www.camden.gov.uk/",
+        "http://www.find-tender.service.gov.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.uhsussex.nhs.uk/",
         "http://studentfinance.campaign.gov.uk/",
-        "http://taxconfident.campaign.gov.uk/",
         "http://teaching-vacancies.service.gov.uk/",
-        "http://changestoukcompanylaw.campaign.gov.uk/"
+        "http://www.civilservicepensionscheme.org.uk/",
+        "http://www.thepensionsregulator.gov.uk/",
+        "http://www.uhsussex.nhs.uk/"
       ],
       "errorSites": []
     },
@@ -5547,8 +3861,8 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.gov.uk/",
-        "http://find-and-update.company-information.service.gov.uk/"
+        "http://find-and-update.company-information.service.gov.uk/",
+        "http://www.gov.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -5557,30 +3871,38 @@
   },
   "healthline-media": {
     "DE": {
-      "sites": 4,
-      "errors": 0,
-      "selfTestFailures": 0,
+      "sites": 2,
+      "errors": 2,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://psychcentral.com/",
-        "http://greatist.com/",
-        "http://www.medicalnewstoday.com/",
+        "http://www.healthline.com/",
+        "http://www.medicalnewstoday.com/"
+      ],
+      "failingSites": [
         "http://www.healthline.com/"
       ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
+      "unsuccessfulSites": [
+        "http://www.healthline.com/",
+        "http://www.medicalnewstoday.com/"
+      ],
+      "errorSites": [
+        "http://www.healthline.com/",
+        "http://www.medicalnewstoday.com/"
+      ]
     },
     "GB": {
       "sites": 4,
       "errors": 2,
-      "selfTestFailures": 0,
+      "selfTestFailures": 1,
       "exampleSites": [
         "http://greatist.com/",
         "http://psychcentral.com/",
         "http://www.healthline.com/",
         "http://www.medicalnewstoday.com/"
       ],
-      "failingSites": [],
+      "failingSites": [
+        "http://www.healthline.com/"
+      ],
       "unsuccessfulSites": [
         "http://www.healthline.com/",
         "http://www.medicalnewstoday.com/"
@@ -5595,10 +3917,27 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.medicalnewstoday.com/",
-        "http://psychcentral.com/",
         "http://greatist.com/",
-        "http://www.healthline.com/"
+        "http://psychcentral.com/",
+        "http://www.healthline.com/",
+        "http://www.medicalnewstoday.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    }
+  },
+  "hearst-us": {
+    "US": {
+      "sites": 20,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.bestproducts.com/",
+        "http://www.bicycling.com/",
+        "http://www.womenshealthmag.com/",
+        "http://www.harpersbazaar.com/",
+        "http://www.roadandtrack.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -5607,193 +3946,90 @@
   },
   "hl.co.uk": {
     "DE": {
-      "sites": 4,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://zutun.de/",
         "http://www.ihk-muenchen.de/",
-        "http://www.ihk-niederbayern.de/",
         "http://www.sanitaetshaus-24.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://zutun.de/",
         "http://www.ihk-muenchen.de/",
-        "http://www.ihk-niederbayern.de/",
         "http://www.sanitaetshaus-24.de/"
       ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.fortiusclinic.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.fortiusclinic.com/"
-      ],
-      "errorSites": []
-    }
-  },
-  "holidaymedia": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.breezandvakanties.nl/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "hu-manity": {
-    "DE": {
-      "sites": 23,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://histaminhexe.de/",
-        "http://westkreuzpark.de/",
-        "http://coachingfederation.org/",
-        "http://keramik-atlas.de/",
-        "http://paultec.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "GB": {
-      "sites": 64,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://keep2shares.net/",
-        "http://electoral-reform.org.uk/",
-        "http://walx.co.uk/",
-        "http://www.activenottingham.com/",
-        "http://worshipwords.co.uk/"
+        "http://electoral-reform.org.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
-    },
-    "US": {
-      "sites": 47,
-      "errors": 1,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.prairiefarms.com/",
-        "http://pinehurstcoins.com/",
-        "http://eaacorp.com/",
-        "http://tokyocentral.com/",
-        "http://simpleforms.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.redlodgemountain.com/",
-        "http://defamationdefenders.com/",
-        "http://tokyocentral.com/",
-        "http://nysba.org/",
-        "http://admissions.vanderbilt.edu/"
-      ],
-      "errorSites": [
-        "http://www.redlodgemountain.com/"
-      ]
     }
   },
   "hubspot": {
     "DE": {
-      "sites": 112,
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.autopsy.com/",
-        "http://www.sprungraum.de/",
-        "http://ki-verband.de/",
-        "http://knowledge.hubspot.com/",
-        "http://www.serverschrank24.de/"
+        "http://blog.hubspot.de/",
+        "http://element.io/",
+        "http://www.paulcamper.de/",
+        "http://www.xe.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://feedly.com/",
-        "http://immocation.de/",
-        "http://www.pleo.io/",
-        "http://www.nordakademie.de/",
-        "http://antworten.seibert.group/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 205,
-      "errors": 1,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.thesecurityevent.co.uk/",
-        "http://www.goodlord.com/",
-        "http://fuuse.io/",
-        "http://www.valksolarsystems.com/",
-        "http://kirkwoodhomes.co.uk/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://jfautomotive.co.uk/",
-        "http://www.pemnet.com/",
-        "http://www.avisonyoung.co.uk/",
-        "http://feedly.com/",
-        "http://goalhanger.com/"
-      ],
-      "errorSites": [
-        "http://learn.g2.com/"
-      ]
-    },
-    "US": {
-      "sites": 268,
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.tropitone.com/",
-        "http://www.peoplekeep.com/",
-        "http://www.crews.bank/",
-        "http://www.phantomscreens.com/",
-        "http://www.keywestexpress.net/"
+        "http://secure.hushmail.com/",
+        "http://www.epubor.com/",
+        "http://www.localgov.co.uk/",
+        "http://www.sunsave.energy/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 9,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://blog.hubspot.com/",
+        "http://www.supermicro.com/",
+        "http://secure.hushmail.com/",
+        "http://www.hancockwhitney.com/",
+        "http://www.kff.org/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://surfinternet.com/",
-        "http://regrid.com/",
-        "http://www.closeknit.com/",
-        "http://www.copperstatecu.org/",
-        "http://www.jobcorps.gov/"
+        "http://www.hancockwhitney.com/",
+        "http://www.kff.org/",
+        "http://www.tileshop.com/"
       ],
       "errorSites": []
     }
   },
   "imdb": {
     "DE": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://m.imdb.com/",
         "http://www.imdb.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 2,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.imdb.com/",
-        "http://m.imdb.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -5826,23 +4062,19 @@
   },
   "ionos.de": {
     "DE": {
-      "sites": 6,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://login.ionos.de/",
         "http://id.ionos.de/",
-        "http://www.ionos.de/",
-        "http://cloud.ionos.de/",
-        "http://www.ionos.at/"
+        "http://login.ionos.de/",
+        "http://www.ionos.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.ionos.de/",
         "http://id.ionos.de/",
-        "http://ionos.blog/",
-        "http://cloud.ionos.de/",
-        "http://www.ionos.at/"
+        "http://login.ionos.de/",
+        "http://www.ionos.de/"
       ],
       "errorSites": []
     },
@@ -5864,84 +4096,52 @@
   },
   "iubenda": {
     "DE": {
-      "sites": 405,
+      "sites": 22,
       "errors": 0,
-      "selfTestFailures": 70,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.deesup.com/",
-        "http://gehaltsvergleiche.com/",
-        "http://www.craftery.de/",
-        "http://thomasipunkt.de/",
-        "http://www.ansa.it/"
+        "http://balumed.com/",
+        "http://docs.arduino.cc/",
+        "http://www.arduino.cc/",
+        "http://madena.de/",
+        "http://www.bavarian-bike.de/"
       ],
       "failingSites": [
-        "http://www.vob.de/",
-        "http://campingamsonnenberg.com/",
-        "http://www.archiproducts.com/",
-        "http://fuehrerscheinumtausch.com/",
-        "http://gehaltsvergleiche.com/"
+        "http://kfzversicherungsvergleich1.de/"
       ],
-      "unsuccessfulSites": [
-        "http://www.gamma-fahrzeuge.de/",
-        "http://prontopro.de/",
-        "http://www.shapr3d.com/",
-        "http://www.domusweb.it/",
-        "http://blazingboost.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 418,
+      "sites": 19,
       "errors": 0,
-      "selfTestFailures": 96,
+      "selfTestFailures": 4,
       "exampleSites": [
-        "http://hertfordcampers.co.uk/",
-        "http://guitargeargiveaway.co.uk/",
-        "http://www.frolicme.com/",
-        "http://sapere.virgilio.it/",
-        "http://www.sorrentoinsider.com/"
+        "http://www.infinitymotorcycles.com/",
+        "http://www.elastic.co/",
+        "http://www.arduino.cc/",
+        "http://www.tradingdepot.co.uk/",
+        "http://www.marinesuperstore.com/"
       ],
       "failingSites": [
-        "http://www.rbst.org.uk/",
-        "http://www.britishecologicalsociety.org/",
-        "http://loxleyarts.com/",
-        "http://serato.com/",
-        "http://allcheckedup.co.uk/"
+        "http://paintnuts.co.uk/",
+        "http://www.empressmills.co.uk/",
+        "http://www.howdeninsurance.co.uk/",
+        "http://www.rightbiz.co.uk/"
       ],
-      "unsuccessfulSites": [
-        "http://bikebook.co.uk/",
-        "http://postquantum.com/",
-        "http://offwestend.com/",
-        "http://daily.dev/",
-        "http://sapling.ai/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 133,
+      "sites": 2,
       "errors": 0,
-      "selfTestFailures": 19,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://weiman.com/",
-        "http://sjsuspartans.com/",
-        "http://psychplus.com/",
-        "http://fightingirish.com/",
-        "http://us.maxmara.com/"
+        "http://docs.arduino.cc/",
+        "http://forum.arduino.cc/"
       ],
-      "failingSites": [
-        "http://www.lifealert.com/",
-        "http://www.upperroom.org/",
-        "http://www.umcdiscipleship.org/",
-        "http://sjsuspartans.com/",
-        "http://odusports.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://yacht-supply24.com/",
-        "http://forum.arduino.cc/",
-        "http://huskers.com/",
-        "http://ifamnews.com/",
-        "http://jerrygarcia.com/"
-      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
@@ -5958,12 +4158,11 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 3,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://jdsports.co.uk/",
-        "http://m.jdsports.co.uk/",
         "http://www.jdsports.co.uk/"
       ],
       "failingSites": [],
@@ -5973,47 +4172,35 @@
   },
   "jetpack-eu-cookie-law": {
     "DE": {
-      "sites": 38,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://matheportal.com/",
-        "http://lapati.eu/",
-        "http://zimtundchili.com/",
-        "http://van-magazin.de/",
-        "http://shelvin.de/"
+        "http://terraherz.wordpress.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 67,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://bigdave44.com/",
         "http://insidecroydon.com/",
-        "http://iaingould.co.uk/",
-        "http://wattsupwiththat.com/",
-        "http://dna-explained.com/",
-        "http://www.blaenbran.uk/"
+        "http://ipsaloquitur.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://myvegpatch.co.uk/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 79,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://nickcady.org/",
-        "http://jumbleanswer.com/",
-        "http://genesismodlist.com/",
-        "http://conandaily.com/",
-        "http://flrmalediscipline.wordpress.com/"
+        "http://hip2save.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -6021,17 +4208,6 @@
     }
   },
   "johnlewis.com": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.johnlewis.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "GB": {
       "sites": 2,
       "errors": 0,
@@ -6043,72 +4219,58 @@
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
-    },
-    "US": {
-      "sites": 1,
+    }
+  },
+  "jquery.cookieBar": {
+    "DE": {
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.johnlewis.com/"
+        "http://www.intensx.com/",
+        "http://www.pp39.cn/",
+        "http://www.reifetube.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 3,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://joiparadise.com/",
+        "http://onlybokep.com/",
+        "http://www.pp39.cn/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 2,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://onlybokep.com/",
+        "http://www.pp39.cn/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     }
   },
-  "jquery.cookieBar": {
-    "DE": {
-      "sites": 56,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.hutbreiter.de/",
-        "http://www.derdachstein.at/",
-        "http://www.andersartig.de/",
-        "http://www.fraron.de/",
-        "http://www.schokoladen-outlet.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://kletterbude.de/",
-        "http://www.kletterbude.de/"
-      ],
-      "errorSites": []
-    },
+  "justgiving.com": {
     "GB": {
-      "sites": 28,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://femdomu.com/",
-        "http://pantyhose4u.net/",
-        "http://www.myersbriggs.org/",
-        "http://naughtyjerks.net/",
-        "http://www.hornyleak.me/"
+        "http://www.justgiving.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.tube-safari.com/",
-        "http://www.pp39.cn/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 17,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://femdomu.com/",
-        "http://baddiehub.run/",
-        "http://hentaividsfh.com/",
-        "http://vb-audio.com/",
-        "http://efukt.tv/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.pp39.cn/",
-        "http://mattparkerbearscolorado.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
@@ -6118,52 +4280,40 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.zenarmor.com/",
-        "http://sports.justwatch.com/",
-        "http://guides.justwatch.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.zenarmor.com/",
-        "http://sports.justwatch.com/",
-        "http://guides.justwatch.com/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 3,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://sports.justwatch.com/",
         "http://guides.justwatch.com/",
-        "http://www.continuing-healthcare.co.uk/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
         "http://sports.justwatch.com/",
-        "http://guides.justwatch.com/",
-        "http://www.continuing-healthcare.co.uk/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 5,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://sports.justwatch.com/",
-        "http://www.zenarmor.com/",
-        "http://guides.justwatch.com/",
-        "http://www.jaquishbiomedical.com/",
         "http://www.justwatch.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://sports.justwatch.com/",
-        "http://www.zenarmor.com/",
         "http://guides.justwatch.com/",
-        "http://www.jaquishbiomedical.com/",
+        "http://sports.justwatch.com/",
+        "http://www.justwatch.com/"
+      ],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://sports.justwatch.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://sports.justwatch.com/"
+      ],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.justwatch.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
         "http://www.justwatch.com/"
       ],
       "errorSites": []
@@ -6171,83 +4321,101 @@
   },
   "ketch": {
     "DE": {
-      "sites": 45,
+      "sites": 7,
       "errors": 0,
-      "selfTestFailures": 4,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.cbinsights.com/",
+        "http://www.forbes.com/",
+        "http://magic.wizards.com/",
         "http://tailscale.com/",
-        "http://www.southpark.de/",
-        "http://www.qnx.com/",
-        "http://www.coderabbit.ai/"
+        "http://time.com/",
+        "http://www.accuweather.com/"
       ],
       "failingSites": [
-        "http://spelltable.wizards.com/",
-        "http://brainly.com/",
-        "http://www.hasbropulse.com/",
-        "http://www.dndbeyond.com/"
+        "http://magic.wizards.com/"
       ],
       "unsuccessfulSites": [
-        "http://rivian.com/",
-        "http://smallbusiness.chron.com/",
-        "http://www.forbes.com/",
-        "http://komonews.com/",
-        "http://www.sfgate.com/"
+        "http://tailscale.com/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 77,
+      "sites": 16,
       "errors": 0,
-      "selfTestFailures": 6,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.pret.com/",
-        "http://help.smartsheet.com/",
-        "http://www.cbsnews.com/",
-        "http://tailscale.com/",
-        "http://freetrade.io/"
+        "http://www.sra.org.uk/",
+        "http://www.channel5.com/",
+        "http://freetrade.io/",
+        "http://www.cbssports.com/",
+        "http://tailscale.com/"
       ],
       "failingSites": [
-        "http://brainly.com/",
-        "http://www.dndbeyond.com/",
-        "http://www.hasbropulse.com/",
-        "http://marketplace.dndbeyond.com/",
-        "http://www.multiverse.io/"
+        "http://brainly.com/"
       ],
       "unsuccessfulSites": [
-        "http://smallbusiness.chron.com/",
-        "http://www.sfgate.com/",
-        "http://www.pret.co.uk/",
-        "http://www.warbyparker.com/",
-        "http://www.tennis.com/"
+        "http://6sense.com/",
+        "http://tailscale.com/",
+        "http://www.pret.co.uk/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 204,
+      "sites": 43,
       "errors": 0,
-      "selfTestFailures": 5,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://rivian.com/",
-        "http://www.outdoorchannel.com/",
-        "http://www.aircraftspruce.com/",
-        "http://www.wjcl.com/",
-        "http://help.smartsheet.com/"
+        "http://www.sonicdrivein.com/",
+        "http://www.kcci.com/",
+        "http://www.wyff4.com/",
+        "http://www.pbs.org/",
+        "http://tailscale.com/"
       ],
       "failingSites": [
-        "http://spelltable.wizards.com/",
-        "http://www.dndbeyond.com/",
-        "http://www.hasbropulse.com/",
-        "http://company.wizards.com/",
         "http://magic.wizards.com/"
       ],
       "unsuccessfulSites": [
-        "http://asever.com/",
-        "http://ada.com/",
-        "http://www.altec.com/",
-        "http://www.speechpathology.com/",
-        "http://thelink.ascensus.com/"
+        "http://www.pbs.org/",
+        "http://tailscale.com/",
+        "http://www.warbyparker.com/",
+        "http://www.functionhealth.com/",
+        "http://www.newsweek.com/"
       ],
+      "errorSites": []
+    }
+  },
+  "kickstarter.com": {
+    "DE": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.kickstarter.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.kickstarter.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.kickstarter.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
@@ -6286,121 +4454,32 @@
       "errorSites": []
     }
   },
-  "lia": {
-    "DE": {
-      "sites": 4,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://live.paloaltonetworks.com/",
-        "http://community.bosch-smarthome.com/",
-        "http://community.checkpoint.com/",
-        "http://community.medion.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 5,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://community.checkpoint.com/",
-        "http://community.medion.com/",
-        "http://community.ruckuswireless.com/",
-        "http://live.paloaltonetworks.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 3,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://live.paloaltonetworks.com/",
-        "http://community.checkpoint.com/",
-        "http://community.ruckuswireless.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
-  "lineagrafica": {
-    "DE": {
-      "sites": 13,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.ipscstore.com/",
-        "http://www.guitarfromspain.com/",
-        "http://www.flashrc.com/",
-        "http://www.piher.com/",
-        "http://www.celinni.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 15,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://singkeefoods.co.uk/",
-        "http://vital-parts.co.uk/",
-        "http://www.guitarfromspain.com/",
-        "http://www.cleaningspot.co.uk/",
-        "http://www.thewritingdesk.co.uk/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
   "linkedin.com": {
     "DE": {
-      "sites": 53,
+      "sites": 12,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://ie.linkedin.com/",
-        "http://nl.linkedin.com/",
-        "http://cl.linkedin.com/",
-        "http://kr.linkedin.com/",
-        "http://fr.linkedin.com/"
+        "http://es.linkedin.com/",
+        "http://in.linkedin.com/",
+        "http://uk.linkedin.com/",
+        "http://it.linkedin.com/",
+        "http://www.linkedin.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 68,
+      "sites": 27,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://im.linkedin.com/",
-        "http://lu.linkedin.com/",
+        "http://es.linkedin.com/",
+        "http://pt.linkedin.com/",
         "http://tr.linkedin.com/",
-        "http://www.linkedin.com/",
-        "http://au.linkedin.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
-  "macaron": {
-    "GB": {
-      "sites": 2,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.sofitelheathrow.com/",
-        "http://www.fairmont-windsorpark.com/"
+        "http://uk.linkedin.com/",
+        "http://za.linkedin.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -6409,159 +4488,96 @@
   },
   "mediamarkt.de": {
     "DE": {
-      "sites": 10,
+      "sites": 5,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://mediamarkt.de/",
+        "http://saturn.de/",
         "http://www.mediamarkt.at/",
-        "http://www.mediamarkt.be/",
-        "http://saturn.de/",
         "http://www.mediamarkt.de/",
-        "http://www.mediaworld.it/"
+        "http://www.saturn.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
+        "http://mediamarkt.de/",
         "http://saturn.de/",
-        "http://www.mediamarkt.be/",
-        "http://www.mediamarkt.ch/",
+        "http://www.mediamarkt.at/",
         "http://www.mediamarkt.de/",
-        "http://www.mediamarkt.es/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 4,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://mediamarkt.pl/",
-        "http://www.mediamarkt.be/",
-        "http://www.mediamarkt.es/",
-        "http://www.mediamarkt.nl/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://mediamarkt.pl/",
-        "http://www.mediamarkt.be/",
-        "http://www.mediamarkt.es/",
-        "http://www.mediamarkt.nl/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.mediamarkt.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.mediamarkt.de/"
+        "http://www.saturn.de/"
       ],
       "errorSites": []
     }
   },
   "medium": {
     "DE": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://medium.com/",
-        "http://iritt.medium.com/"
+        "http://medium.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://medium.com/",
-        "http://iritt.medium.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 6,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://avi-loeb.medium.com/",
-        "http://steve-yegge.medium.com/",
-        "http://medium.com/",
-        "http://hexshift.medium.com/",
-        "http://cloudmersive.medium.com/"
+        "http://medium.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://avi-loeb.medium.com/",
-        "http://steve-yegge.medium.com/",
-        "http://travisnicholson.medium.com/",
-        "http://hexshift.medium.com/",
-        "http://cloudmersive.medium.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "microsoft.com": {
     "DE": {
-      "sites": 63,
+      "sites": 31,
       "errors": 0,
-      "selfTestFailures": 2,
+      "selfTestFailures": 1,
       "exampleSites": [
+        "http://account.microsoft.com/",
         "http://devblogs.microsoft.com/",
-        "http://techcommunity.microsoft.com/",
-        "http://vcpkg.io/",
-        "http://containers.dev/",
-        "http://xbox.com/"
+        "http://m365.cloud.microsoft/",
+        "http://microsoft.github.io/",
+        "http://code.visualstudio.com/"
       ],
       "failingSites": [
-        "http://windows.microsoft.com/",
-        "http://devblogs.microsoft.com/"
+        "http://windows.microsoft.com/"
       ],
       "unsuccessfulSites": [
-        "http://microsoft.github.io/",
-        "http://docs.azure.cn/",
-        "http://forums.ageofempires.com/",
         "http://community.fabric.microsoft.com/",
-        "http://www.flightsimulator.com/"
+        "http://microsoft.github.io/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 70,
+      "sites": 35,
       "errors": 0,
-      "selfTestFailures": 2,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://forms.microsoft.com/",
-        "http://edusupport.minecraft.net/",
-        "http://xbox.com/",
-        "http://to-do.office.com/",
-        "http://microsoftedge.microsoft.com/"
+        "http://www.typescriptlang.org/",
+        "http://www.xbox.com/",
+        "http://support.xbox.com/",
+        "http://dotnet.microsoft.com/",
+        "http://help.minecraft.net/"
       ],
       "failingSites": [
-        "http://devblogs.microsoft.com/",
         "http://windows.microsoft.com/"
       ],
       "unsuccessfulSites": [
-        "http://www.flightsimulator.com/",
-        "http://teams.live.com/",
-        "http://docs.azure.cn/",
-        "http://forums.obsidian.net/",
-        "http://www.halowaypoint.com/"
+        "http://community.fabric.microsoft.com/",
+        "http://microsoft.github.io/"
       ],
       "errorSites": []
     }
   },
   "midway-usa": {
-    "GB": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "US": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [],
@@ -6571,37 +4587,13 @@
     }
   },
   "moneysavingexpert.com": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://forums.moneysavingexpert.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "GB": {
-      "sites": 4,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://blog.moneysavingexpert.com/",
-        "http://travelmoney.moneysavingexpert.com/",
         "http://forums.moneysavingexpert.com/",
         "http://www.moneysavingexpert.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://forums.moneysavingexpert.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -6609,38 +4601,12 @@
     }
   },
   "nba.com": {
-    "DE": {
+    "GB": {
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://www.nba.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.nba.com/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.nba.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
-  "netbeat.de": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.netbeat.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -6660,21 +4626,15 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 19,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://nshcs.hee.nhs.uk/",
-        "http://bridgewater.nhs.uk/",
-        "http://transform.england.nhs.uk/",
-        "http://pcse.england.nhs.uk/",
-        "http://overseas-healthcare.nhsbsa.nhs.uk/"
+        "http://settings.login.nhs.uk/",
+        "http://www.nhs.uk/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://transparency.ndsp.gpconnect.nhs.uk/",
-        "http://pcse.england.nhs.uk/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
@@ -6711,17 +4671,6 @@
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
-    },
-    "US": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://nos.nl/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
     }
   },
   "obi.de": {
@@ -6740,48 +4689,40 @@
   },
   "ok": {
     "DE": {
-      "sites": 3,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://ok.ru/",
-        "http://www.odnoklassniki.ru/",
-        "http://www.ok.ru/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://ok.ru/",
-        "http://www.odnoklassniki.ru/",
-        "http://www.ok.ru/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 2,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://ok.ru/",
-        "http://www.ok.ru/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://ok.ru/",
-        "http://www.ok.ru/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 2,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.ok.ru/",
         "http://ok.ru/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.ok.ru/",
+        "http://ok.ru/"
+      ],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://ok.ru/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://ok.ru/"
+      ],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://ok.ru/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
         "http://ok.ru/"
       ],
       "errorSites": []
@@ -6789,31 +4730,15 @@
   },
   "om": {
     "DE": {
-      "sites": 73,
+      "sites": 7,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.eam-netz.de/",
-        "http://www.vorsorge-online.de/",
-        "http://gi.de/",
-        "http://kreisklinik-roth.de/",
-        "http://www.bauckhof.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.achensee.com/",
-        "http://www.dga-ag.de/",
-        "http://www.fridolfing.de/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 2,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.innsbruck-airport.com/",
-        "http://www.myhermes.at/"
+        "http://www.ash-berlin.eu/",
+        "http://www.uni-kiel.de/",
+        "http://www.bergsteigen.com/",
+        "http://www.malteser.de/",
+        "http://www.tedi.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -6858,33 +4783,14 @@
   "openai": {
     "DE": {
       "sites": 1,
-      "errors": 1,
+      "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://openai.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://openai.com/"
-      ],
-      "errorSites": [
-        "http://openai.com/"
-      ]
-    },
-    "GB": {
-      "sites": 1,
-      "errors": 1,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://openai.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://openai.com/"
-      ],
-      "errorSites": [
-        "http://openai.com/"
-      ]
+      "unsuccessfulSites": [],
+      "errorSites": []
     }
   },
   "opera.com": {
@@ -6917,77 +4823,60 @@
   },
   "osano": {
     "DE": {
-      "sites": 200,
+      "sites": 19,
       "errors": 0,
-      "selfTestFailures": 5,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.newegg.com/",
-        "http://www.sharpie.com/",
-        "http://www.ted.com/",
-        "http://www.wiley-vch.de/",
-        "http://www.wiley.com/"
+        "http://www.alltrails.com/",
+        "http://thepornmap.com/",
+        "http://plotly.com/",
+        "http://ieeexplore.ieee.org/",
+        "http://www.slideshare.net/"
       ],
-      "failingSites": [
-        "http://universe.leagueoflegends.com/",
-        "http://www.tequipment.net/",
-        "http://acsparagonplus.acs.org/",
-        "http://www.ieee.org/",
-        "http://www.fender.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://you.com/",
-        "http://360.articulate.com/",
-        "http://www.airahome.com/",
-        "http://www.aloyoga.com/",
-        "http://ground.news/"
-      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 403,
-      "errors": 1,
-      "selfTestFailures": 0,
+      "sites": 46,
+      "errors": 0,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.summithealth.com/",
-        "http://training.linuxfoundation.org/",
-        "http://www.bobsredmill.com/",
-        "http://data.energizer.com/",
-        "http://www.formica.com/"
+        "http://www.sportsshoes.com/",
+        "http://www.scottishpower.com/",
+        "http://clubspark.lta.org.uk/",
+        "http://thepornmap.com/",
+        "http://ground.news/"
       ],
-      "failingSites": [],
+      "failingSites": [
+        "http://www.fender.com/"
+      ],
       "unsuccessfulSites": [
-        "http://juicebox.ai/",
-        "http://www.costar.com/",
-        "http://web.ground.news/",
-        "http://www.airahome.com/",
-        "http://www.amctheatres.com/"
+        "http://ground.news/",
+        "http://www.ebsco.com/"
       ],
-      "errorSites": [
-        "http://learn.g2.com/"
-      ]
+      "errorSites": []
     },
     "US": {
-      "sites": 1146,
-      "errors": 1,
+      "sites": 138,
+      "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.bigagnes.com/",
-        "http://magicvalley.com/",
-        "http://shop.id.me/",
-        "http://www.paycomcenter.com/",
-        "http://www.comfortcolors.com/"
+        "http://www.wyze.com/",
+        "http://www.thenewstribune.com/",
+        "http://www.leagueoflegends.com/",
+        "http://www.wsbtv.com/",
+        "http://www.orientaltrading.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://nonpareilonline.com/",
-        "http://www.percona.com/",
-        "http://www.entrust.com/",
-        "http://www.aadvantagedining.com/",
-        "http://turo.com/"
+        "http://ground.news/",
+        "http://turo.com/",
+        "http://www.wyze.com/",
+        "http://www.totousa.com/",
+        "http://www.ebsco.com/"
       ],
-      "errorSites": [
-        "http://www.petsupermarket.com/"
-      ]
+      "errorSites": []
     }
   },
   "ourworldindata": {
@@ -7033,7 +4922,7 @@
   },
   "overleaf": {
     "DE": {
-      "sites": 3,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
@@ -7069,103 +4958,59 @@
   },
   "pandectes": {
     "DE": {
-      "sites": 406,
-      "errors": 35,
-      "selfTestFailures": 20,
+      "sites": 10,
+      "errors": 0,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://isolierhandel24.de/",
-        "http://besserimglas.de/",
-        "http://birgitengel-fashion.com/",
-        "http://www.tallows.de/",
-        "http://bandwerk.de/"
+        "http://snocks.com/",
+        "http://waldlaeufer.de/",
+        "http://naturtreu.de/",
+        "http://de.ugreen.com/",
+        "http://nas-de.ugreen.com/"
       ],
       "failingSites": [
-        "http://deskspace.de/",
-        "http://shop.hak5.org/",
-        "http://www.maniko-nails.de/",
-        "http://taiga-store.de/",
-        "http://www.jansensamen.de/"
+        "http://snocks.com/"
       ],
-      "unsuccessfulSites": [
-        "http://jacks-beautyline.com/",
-        "http://www.faberge.com/",
-        "http://volane.de/",
-        "http://olivenzauber.de/",
-        "http://vlippy.de/"
-      ],
-      "errorSites": [
-        "http://hubermuehle.de/",
-        "http://www.thatskimchi.de/",
-        "http://juice.world/",
-        "http://m1-sporttechnik.eu/",
-        "http://www.gripgrab.com/"
-      ]
+      "unsuccessfulSites": [],
+      "errorSites": []
     },
     "GB": {
-      "sites": 468,
-      "errors": 57,
-      "selfTestFailures": 21,
+      "sites": 18,
+      "errors": 1,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://numbersmarket.co.uk/",
-        "http://stirlingtimepieces.com/",
-        "http://realfoodsource.co.uk/",
-        "http://www.uk-water-filters.co.uk/",
-        "http://caninenaturalcures.co.uk/"
+        "http://www.aluminiumwarehouse.co.uk/",
+        "http://www.panelcompany.co.uk/",
+        "http://www.completecareshop.co.uk/",
+        "http://www.keenfootwear.co.uk/",
+        "http://rokalondon.com/"
       ],
       "failingSites": [
-        "http://shop.royalalberthall.com/",
-        "http://www.patisserie-valerie.co.uk/",
-        "http://donaghys.co.uk/",
-        "http://onlinedoorstore.co.uk/",
-        "http://www.porcelainsuperstore.co.uk/"
+        "http://www.sam-turner.co.uk/"
       ],
       "unsuccessfulSites": [
-        "http://shop.meridianfoods.co.uk/",
-        "http://scribblers.co.uk/",
-        "http://www.emmawillis.com/",
-        "http://www.strengthshop.co.uk/",
-        "http://www.stewartandgibson.co.uk/"
+        "http://tradewarehouse.co.uk/",
+        "http://www.preppersshop.co.uk/"
       ],
       "errorSites": [
-        "http://jansport.co.uk/",
-        "http://haiths.com/",
-        "http://showery.co.uk/",
-        "http://www.emmawillis.com/",
         "http://www.preppersshop.co.uk/"
       ]
     },
     "US": {
-      "sites": 222,
-      "errors": 27,
-      "selfTestFailures": 37,
+      "sites": 5,
+      "errors": 0,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.coyuchi.com/",
-        "http://feetures.com/",
-        "http://nas.ugreen.com/",
-        "http://aloha.com/",
-        "http://upfitsupply.com/"
+        "http://olukai.com/",
+        "http://vegogarden.com/",
+        "http://www.ryobitools.com/",
+        "http://www.theproscloset.com/"
       ],
       "failingSites": [
-        "http://thehappyplanner.com/",
-        "http://www.houseofdenial.com/",
-        "http://www.varley.com/",
-        "http://powertools.ridgid.com/",
-        "http://shadyrays.com/"
+        "http://olukai.com/"
       ],
-      "unsuccessfulSites": [
-        "http://www.sixzeropickleball.com/",
-        "http://kurufootwear.com/",
-        "http://bfbooks.com/",
-        "http://www.runinrabbit.com/",
-        "http://cgfordparts.com/"
-      ],
-      "errorSites": [
-        "http://treadlabs.com/",
-        "http://www.tirediscounters.com/",
-        "http://bitsysbikinis.com/",
-        "http://bossaudio.com/",
-        "http://www.thefryecompany.com/"
-      ]
+      "unsuccessfulSites": [],
+      "errorSites": []
     }
   },
   "paychex": {
@@ -7184,107 +5029,40 @@
     }
   },
   "paypal-us": {
-    "DE": {
-      "sites": 4,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.xoom.com/",
-        "http://newsroom.deatch.paypal-corp.com/",
-        "http://developer.paypal.com/",
-        "http://www.paypal-community.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.xoom.com/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 7,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://developer.paypal.com/",
-        "http://venmo.com/",
-        "http://www-v2.sandbox.paypal.com/",
-        "http://newsroom.paypal-corp.com/",
-        "http://www.joinhoney.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www-v2.sandbox.paypal.com/",
-        "http://www.paypal-status.com/"
-      ],
-      "errorSites": []
-    },
     "US": {
-      "sites": 9,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.paypal-community.com/",
-        "http://www.paypal.com/",
-        "http://securepayments.paypal.com/",
-        "http://get.venmo.com/",
-        "http://www-v2.sandbox.paypal.com/"
+        "http://help.venmo.com/",
+        "http://venmo.com/",
+        "http://www.paypal.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://help.venmo.com/",
-        "http://www-v2.sandbox.paypal.com/"
+        "http://help.venmo.com/"
       ],
       "errorSites": []
     }
   },
   "paypal.com": {
     "DE": {
-      "sites": 8,
+      "sites": 1,
       "errors": 0,
-      "selfTestFailures": 3,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://securepayments.paypal.com/",
-        "http://www.elektroniknetzteil.de/",
-        "http://www.paypal.com/",
-        "http://www.netzteiledirekt.de/",
-        "http://www.notebooknetzteileshop.de/"
+        "http://www.paypal.com/"
       ],
-      "failingSites": [
-        "http://www.netzteiledirekt.de/",
-        "http://www.notebooknetzteileshop.de/",
-        "http://www.elektroniknetzteil.de/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.sandbox.paypal.com/"
-      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
-    "GB": {
-      "sites": 4,
-      "errors": 0,
-      "selfTestFailures": 1,
-      "exampleSites": [
-        "http://history.paypal.com/",
-        "http://www.ukpowerdepot.co.uk/",
-        "http://www.paypal.com/",
-        "http://www.xoom.com/"
-      ],
-      "failingSites": [
-        "http://www.ukpowerdepot.co.uk/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.xoom.com/"
-      ],
-      "errorSites": []
-    }
-  },
-  "pinterest-business": {
     "GB": {
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://create.pinterest.com/"
+        "http://www.paypal.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -7328,66 +5106,62 @@
   },
   "pmc": {
     "US": {
-      "sites": 17,
+      "sites": 13,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://robbreport.com/",
-        "http://www.theflowspace.com/",
-        "http://www.vibe.com/",
-        "http://www.sportico.com/",
+        "http://www.goldderby.com/",
+        "http://www.artnews.com/",
+        "http://soaps.sheknows.com/",
+        "http://www.indiewire.com/",
         "http://variety.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.indiewire.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "pornhat": {
     "DE": {
-      "sites": 14,
+      "sites": 7,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.myporn.tube/",
-        "http://www.porn4fans.com/",
-        "http://www.perfectgirls.xxx/",
+        "http://de.porn4fans.com/",
+        "http://hello.porn/",
         "http://homo.xxx/",
-        "http://www.pornhat.com/"
+        "http://www.txxx.porn/",
+        "http://www.perfektdamen.co/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.myporn.tube/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 14,
+      "sites": 6,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.perfektdamen.co/",
-        "http://www.pornhat.one/",
-        "http://www.perfectgirls.xxx/",
-        "http://max.porn/",
-        "http://www.freepornvideos.xxx/"
+        "http://hello.porn/",
+        "http://many.xxx/",
+        "http://ok.xxx/",
+        "http://www.pornhat.com/",
+        "http://www.pornhat.one/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 12,
+      "sites": 7,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://ok.porn/",
-        "http://www.porn4fans.com/",
+        "http://hello.porn/",
         "http://www.pornhat.com/",
-        "http://www.pornhat.one/",
-        "http://ok.xxx/"
+        "http://many.xxx/",
+        "http://www.txxx.porn/",
+        "http://www.porn4fans.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -7396,12 +5170,11 @@
   },
   "pornhub.com": {
     "DE": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://ww.pornhub.com/",
-        "http://www.pornhub.com/"
+        "http://www.pornhits.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -7412,55 +5185,26 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.thumbzilla.com/",
         "http://ww.pornhub.com/",
-        "http://www.fanhub.com/",
-        "http://www.pornhub.com/"
+        "http://www.pornhits.com/",
+        "http://www.pornhub.com/",
+        "http://www.thumbzilla.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 2,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.pornhub.com/",
-        "http://ww.pornhub.com/"
+        "http://ww.pornhub.com/",
+        "http://www.pornhits.com/",
+        "http://www.pornhub.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
-  "postnl": {
-    "DE": {
-      "sites": 2,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://tracking.postnl.nl/",
-        "http://www.postnl.nl/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://tracking.postnl.nl/",
-        "http://www.postnl.nl/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.postnl.nl/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.postnl.nl/"
-      ],
       "errorSites": []
     }
   },
@@ -7500,80 +5244,26 @@
     }
   },
   "pride.com": {
-    "DE": {
-      "sites": 3,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.advocate.com/",
-        "http://www.out.com/",
-        "http://www.pride.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "GB": {
-      "sites": 3,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.advocate.com/",
-        "http://www.out.com/",
-        "http://www.pride.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 3,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.out.com/",
-        "http://www.pride.com/",
-        "http://www.advocate.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
-  "privado": {
-    "DE": {
       "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://textrapp.com/",
-        "http://www.brlo.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.brlo.de/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 3,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://textrapp.com/",
-        "http://www.olneytowncouncil.gov.uk/",
-        "http://www.brownandbrown.studio/"
+        "http://www.out.com/",
+        "http://www.pride.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 1,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://textrapp.com/"
+        "http://www.advocate.com/",
+        "http://www.out.com/",
+        "http://www.pride.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -7581,29 +5271,12 @@
     }
   },
   "pubtech": {
-    "DE": {
-      "sites": 6,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://moto.motorionline.com/",
-        "http://www.artribune.com/",
-        "http://guidatv.quotidiano.net/",
-        "http://www.dagospia.com/",
-        "http://www.firstonline.info/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "GB": {
-      "sites": 3,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://housesforsaletorent.co.uk/",
-        "http://www.hdblog.it/",
-        "http://www.dagospia.com/"
+        "http://housesforsaletorent.co.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -7612,77 +5285,67 @@
   },
   "quantcast": {
     "DE": {
-      "sites": 723,
+      "sites": 114,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://vide-greniers.org/",
-        "http://ioverlander.com/",
-        "http://wpolityce.pl/",
-        "http://www.onthisday.com/",
-        "http://instazoomer.de/"
+        "http://www.tudorwatch.com/",
+        "http://hh-autos.com/",
+        "http://archidekt.com/",
+        "http://www.bluestacks.com/",
+        "http://www.bleepingcomputer.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.gamezop.com/",
-        "http://www.playmox.com/",
-        "http://www.irishmirror.ie/",
-        "http://www.digwebinterface.com/",
-        "http://portfolioslab.com/"
+        "http://companiesmarketcap.com/",
+        "http://www.cpubenchmark.net/",
+        "http://www.unknowncheats.me/",
+        "http://www.kreuzwort-raetsel.net/",
+        "http://www.misterwhat.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 1247,
-      "errors": 1,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.xonecole.com/",
-        "http://www.mindmegette.hu/",
-        "http://calibre-ebook.com/",
-        "http://www.assettoworld.com/",
-        "http://games.express.co.uk/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.accuradio.com/",
-        "http://punfinity.com/",
-        "http://growjo.com/",
-        "http://www.gold-eagle.com/",
-        "http://cooljugator.com/"
-      ],
-      "errorSites": [
-        "http://ranwhenparked.net/"
-      ]
-    },
-    "US": {
-      "sites": 134,
+      "sites": 268,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.total-motorsport.com/",
-        "http://www.wurstclient.net/",
-        "http://play.fancade.com/",
-        "http://dnd5e.info/",
-        "http://narrow.one/"
+        "http://www.tenforums.com/",
+        "http://www.mini2.com/",
+        "http://www.trustedreviews.com/",
+        "http://www.plotaroute.com/",
+        "http://haringeycommunitypress.co.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://retrobowlofficial.com/",
-        "http://rockhall.com/",
-        "http://swordmasters.io/"
+        "http://www.scottishdailyexpress.co.uk/",
+        "http://www.thelondoneconomic.com/",
+        "http://wsup.ai/",
+        "http://www.football.london/",
+        "http://www.business-live.co.uk/"
       ],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 15,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.drivemad.com/",
+        "http://www.iphonelife.com/",
+        "http://www.trustedreviews.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "raspberrypi.com": {
     "DE": {
-      "sites": 3,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://magazine.raspberrypi.com/",
-        "http://pip.raspberrypi.com/",
         "http://www.raspberrypi.com/"
       ],
       "failingSites": [],
@@ -7690,12 +5353,10 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 3,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://pip.raspberrypi.com/",
-        "http://magazine.raspberrypi.com/",
         "http://www.raspberrypi.com/"
       ],
       "failingSites": [],
@@ -7703,13 +5364,11 @@
       "errorSites": []
     },
     "US": {
-      "sites": 3,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://pip.raspberrypi.com/",
-        "http://www.raspberrypi.com/",
-        "http://magazine.raspberrypi.com/"
+        "http://www.raspberrypi.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -7718,97 +5377,48 @@
   },
   "real-cookie-banner": {
     "DE": {
-      "sites": 780,
+      "sites": 30,
       "errors": 0,
-      "selfTestFailures": 28,
+      "selfTestFailures": 2,
       "exampleSites": [
-        "http://music-on-net.de/",
-        "http://www.n-k-t.de/",
-        "http://www.kita-turnen.de/",
-        "http://www.kanzlei-heskamp.de/",
-        "http://www.donauschifffahrt.eu/"
+        "http://www.hausarztpraxis-am-romanplatz.de/",
+        "http://rm-kurier.de/",
+        "http://philosophia-perennis.com/",
+        "http://www.pflanzen-vielfalt.net/",
+        "http://gpsradler.de/"
       ],
       "failingSites": [
-        "http://www.elisazunder.de/",
-        "http://www.reizdarmblog.de/",
-        "http://www.eispiraten-crimmitschau.de/",
-        "http://www.1000-haushaltstipps.de/",
-        "http://www.sparweise.de/"
+        "http://auswandern-info.com/",
+        "http://fobizz.com/"
       ],
       "unsuccessfulSites": [
-        "http://teslawissen.ch/",
-        "http://gpaed.de/",
-        "http://www.polyas.de/",
-        "http://www.minimax.ch/",
-        "http://www.seffani.de/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 19,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.chu.cam.ac.uk/",
-        "http://www.nhsdg.co.uk/",
-        "http://saxonship.org/",
-        "http://www.heathrobinsonmuseum.org/",
-        "http://howtostudygerman.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.rolser.com/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 3,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.prestigeonline.com/",
-        "http://eraser.heidi.ie/",
-        "http://airportwebcams.net/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.prestigeonline.com/"
+        "http://hoehle-loewen.de/",
+        "http://www.hausarztpraxis-am-romanplatz.de/",
+        "http://www.tutonaut.de/",
+        "http://www.windowspower.de/"
       ],
       "errorSites": []
     }
   },
   "ring": {
-    "DE": {
-      "sites": 1,
+    "GB": {
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://en-uk.ring.com/",
         "http://ring.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
-    "GB": {
-      "sites": 3,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://ring.com/",
-        "http://community-ring.sprinklr.com/",
-        "http://en-uk.ring.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "US": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://ring.com/",
-        "http://community-ring.sprinklr.com/"
+        "http://ring.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -7848,53 +5458,7 @@
       "errorSites": []
     }
   },
-  "rog-forum.asus.com": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://rog-forum.asus.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://rog-forum.asus.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://rog-forum.asus.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
   "rt": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.rt.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "GB": {
       "sites": 1,
       "errors": 0,
@@ -7940,17 +5504,6 @@
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
-    },
-    "US": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.ryanair.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
     }
   },
   "samsung.com": {
@@ -7971,88 +5524,42 @@
     }
   },
   "sandhills": {
-    "DE": {
-      "sites": 4,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.machinerytrader.com/",
-        "http://www.tractor-house.de/",
-        "http://www.tractorhouse.com/",
-        "http://www.controller.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "GB": {
-      "sites": 8,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.trucklocator.co.uk/",
-        "http://www.aircraft.com/",
-        "http://www.needturfequipment.co.uk/",
-        "http://www.machinerytrader.co.uk/",
-        "http://www.controlleremea.co.uk/"
+        "http://www.farmmachinerylocator.co.uk/",
+        "http://www.machinerytrader.co.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 18,
+      "sites": 6,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://www.truckpaper.com/",
         "http://www.machinerytrader.com/",
-        "http://www.rentalyard.com/",
-        "http://www.equipmentfacts.com/",
-        "http://www.auctiontime.com/",
-        "http://www.rvuniverse.com/"
+        "http://www.rvuniverse.com/",
+        "http://www.tractorhouse.com/",
+        "http://www.treetrader.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
-  "schoolhouse-com": {
-    "US": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.schoolhouse.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.schoolhouse.com/"
-      ],
       "errorSites": []
     }
   },
   "shein.com": {
     "DE": {
-      "sites": 3,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://shein.com/",
-        "http://us.shein.com/",
-        "http://de.shein.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 3,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://us.shein.com/",
-        "http://eur.shein.com/",
-        "http://roe.shein.com/"
+        "http://de.shein.com/",
+        "http://shein.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -8073,190 +5580,158 @@
   },
   "shopify": {
     "DE": {
-      "sites": 673,
-      "errors": 1,
-      "selfTestFailures": 626,
+      "sites": 14,
+      "errors": 0,
+      "selfTestFailures": 14,
       "exampleSites": [
-        "http://www.ridetronic.de/",
-        "http://www.vegavero.de/",
-        "http://www.fangamer.com/",
-        "http://lilygo.cc/",
-        "http://evniculus.eu/"
+        "http://armedangels.com/",
+        "http://www.armedangels.com/",
+        "http://kleineskraftwerk.de/",
+        "http://sonoff.tech/",
+        "http://graefin-von-zeppelin.de/"
       ],
       "failingSites": [
-        "http://wollmeisterei.de/",
-        "http://shop.soulspin.de/",
-        "http://3drifter-miniatures.de/",
-        "http://spacegarden.de/",
-        "http://noni-mode.de/"
+        "http://www.armedangels.com/",
+        "http://stretta-music.de/",
+        "http://day-1.com/",
+        "http://florage.de/",
+        "http://kleineskraftwerk.de/"
       ],
-      "unsuccessfulSites": [
-        "http://freiluftkind.de/",
-        "http://weidewild.de/",
-        "http://crystalparadise.de/",
-        "http://etzrestaurant.de/",
-        "http://klapp-skincare.com/"
-      ],
-      "errorSites": [
-        "http://www.langehosen.de/"
-      ]
+      "unsuccessfulSites": [],
+      "errorSites": []
     },
     "GB": {
-      "sites": 2104,
-      "errors": 8,
-      "selfTestFailures": 1956,
+      "sites": 37,
+      "errors": 0,
+      "selfTestFailures": 32,
       "exampleSites": [
-        "http://consciouscraft.uk/",
-        "http://nonnatonda.co.uk/",
-        "http://zyliss.co.uk/",
-        "http://helensclosetpatterns.com/",
-        "http://theinsulationshop.co.uk/"
+        "http://uk.renogy.com/",
+        "http://www.harrisoncameras.co.uk/",
+        "http://www.ornamental-trees.co.uk/",
+        "http://www.thesoapery.co.uk/",
+        "http://www.ashridgetrees.co.uk/"
       ],
       "failingSites": [
-        "http://goodlookers.co.uk/",
-        "http://shop.lastnightfromglasgow.com/",
-        "http://idcwoodcraft.com/",
-        "http://rubadub.co.uk/",
-        "http://localhoneyman.co.uk/"
+        "http://shop.pimoroni.com/",
+        "http://labyrinthos.co/",
+        "http://thefoldline.com/",
+        "http://www.biketart.com/",
+        "http://hatsandcaps.co.uk/"
       ],
       "unsuccessfulSites": [
-        "http://www.longforte.com/",
-        "http://www.bamcases.com/",
-        "http://hodmedods.co.uk/",
-        "http://viwoods.com/",
-        "http://www.gisela-mayer.com/"
+        "http://www.jadlamracingmodels.com/",
+        "http://www.ornamental-trees.co.uk/",
+        "http://www.rieker.co.uk/",
+        "http://www.rutlands.com/"
       ],
-      "errorSites": [
-        "http://www.vanguardworld.co.uk/",
-        "http://uk.walkingpad.com/",
-        "http://gibsonsgames.co.uk/",
-        "http://www.kitandkaboodal.com/",
-        "http://www.stewartandgibson.co.uk/"
-      ]
+      "errorSites": []
     },
     "US": {
-      "sites": 120,
+      "sites": 6,
       "errors": 0,
-      "selfTestFailures": 110,
+      "selfTestFailures": 6,
       "exampleSites": [
-        "http://greenhousemegastore.com/",
-        "http://www.mintrx.com/",
-        "http://enchroma.com/",
-        "http://chilewich.com/",
-        "http://terrycycling.com/"
+        "http://blackstoneproducts.com/",
+        "http://www.goodandbeautiful.com/",
+        "http://www.groworganic.com/",
+        "http://www.hunterfan.com/",
+        "http://www.muji.us/"
       ],
       "failingSites": [
-        "http://ds18.com/",
-        "http://smegstore.us/",
-        "http://www.straightdown.com/",
-        "http://masienda.com/",
-        "http://terrycycling.com/"
+        "http://blackstoneproducts.com/",
+        "http://yakima.com/",
+        "http://www.groworganic.com/",
+        "http://www.hunterfan.com/",
+        "http://www.muji.us/"
       ],
-      "unsuccessfulSites": [
-        "http://snagtights.com/",
-        "http://www.westportbigandtall.com/",
-        "http://www.3dxtech.com/",
-        "http://cerwinvega.com/",
-        "http://nextlevelapparel.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "skyscanner": {
-    "DE": {
-      "sites": 6,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.skyscanner.de/",
-        "http://www.skyscanner.pl/",
-        "http://www.skyscanner.it/",
-        "http://www.skyscanner.net/",
-        "http://www.skyscanner.nl/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.skyscanner.fr/",
-        "http://www.skyscanner.pl/"
-      ],
-      "errorSites": []
-    },
     "GB": {
-      "sites": 7,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.skyscanner.com/",
-        "http://www.skyscanner.de/",
-        "http://www.skyscanner.es/",
-        "http://www.skyscanner.it/",
-        "http://skyscanner.net/"
+        "http://www.skyscanner.net/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.skyscanner.de/"
+        "http://www.skyscanner.net/"
       ],
       "errorSites": []
     }
   },
   "snigel": {
     "DE": {
-      "sites": 82,
+      "sites": 21,
       "errors": 0,
-      "selfTestFailures": 21,
+      "selfTestFailures": 6,
       "exampleSites": [
-        "http://www.ultimatespecs.com/",
-        "http://www.linguee.de/",
-        "http://www.puzzle-bridges.com/",
-        "http://browse.dict.cc/",
-        "http://www.notebookcheck.net/"
+        "http://www.manualslib.de/",
+        "http://www.buchstaben.com/",
+        "http://de.windfinder.com/",
+        "http://www.isitdownrightnow.com/",
+        "http://www.kreuzwortraetsellexikon.de/"
       ],
       "failingSites": [
-        "http://www.wordle.at/",
         "http://cardcluster.de/",
-        "http://musicnoteslib.com/",
-        "http://icdlist.com/",
-        "http://charactercalculator.com/"
+        "http://civitai.com/",
+        "http://geotrivia.com/",
+        "http://steamcharts.com/",
+        "http://www.geoguessr.com/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 86,
+      "sites": 23,
       "errors": 0,
-      "selfTestFailures": 35,
+      "selfTestFailures": 6,
       "exampleSites": [
-        "http://calculator-online.net/",
-        "http://www.fontget.com/",
         "http://www.trueachievements.com/",
-        "http://classicdb.ch/",
-        "http://cornhub.website/"
+        "http://www.wordhippo.com/",
+        "http://worldle.teuteuf.fr/",
+        "http://steamcharts.com/",
+        "http://www.isitdownrightnow.com/"
       ],
       "failingSites": [
-        "http://www.geoguessr.com/",
         "http://www.veganfoodandliving.com/",
-        "http://www.purposegames.com/",
-        "http://truesteamachievements.com/",
-        "http://plantbasednews.org/"
+        "http://steamcharts.com/",
+        "http://www.engineeringtoolbox.com/",
+        "http://www.geoguessr.com/",
+        "http://www.trueachievements.com/"
       ],
       "unsuccessfulSites": [
-        "http://who-called.co.uk/",
-        "http://www.classicpopmag.com/",
-        "http://www.womensrunning.co.uk/"
+        "http://who-called.co.uk/"
       ],
       "errorSites": []
     }
   },
-  "squiz": {
+  "squarespace-cookie-banner": {
+    "GB": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.electriccarscheme.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
     "US": {
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://news.stanford.edu/"
+        "http://www.treelinereview.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [],
+      "unsuccessfulSites": [
+        "http://www.treelinereview.com/"
+      ],
       "errorSites": []
     }
   },
@@ -8264,12 +5739,14 @@
     "DE": {
       "sites": 2,
       "errors": 0,
-      "selfTestFailures": 0,
+      "selfTestFailures": 1,
       "exampleSites": [
         "http://steamcommunity.com/",
         "http://store.steampowered.com/"
       ],
-      "failingSites": [],
+      "failingSites": [
+        "http://steamcommunity.com/"
+      ],
       "unsuccessfulSites": [],
       "errorSites": []
     },
@@ -8292,44 +5769,15 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://shop.strato.de/"
+        "http://www.strato.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     }
   },
-  "stripchat.com": {
-    "DE": {
-      "sites": 13,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 16,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 12,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
   "substack": {
-    "DE": {
+    "GB": {
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
@@ -8339,65 +5787,15 @@
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
-    },
-    "GB": {
-      "sites": 9,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.natesilver.net/",
-        "http://www.themikegrahamshow.com/",
-        "http://www.theshortcut.com/",
-        "http://www.dropsitenews.com/",
-        "http://www.lennysnewsletter.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.dropsitenews.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
     }
   },
   "summitracing": {
-    "DE": {
-      "sites": 2,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.summitracing.com/",
-        "http://www.dxengineering.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 2,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.summitracing.com/",
-        "http://www.dxengineering.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "US": {
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.trickflow.com/"
+        "http://www.dxengineering.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -8406,244 +5804,127 @@
   },
   "synology": {
     "DE": {
-      "sites": 4,
+      "sites": 2,
       "errors": 0,
-      "selfTestFailures": 2,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://global.download.synology.com/",
         "http://kb.synology.com/",
-        "http://www.synology.com/",
-        "http://c2.synology.com/"
+        "http://www.synology.com/"
       ],
       "failingSites": [
-        "http://global.download.synology.com/",
         "http://www.synology.com/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 4,
+      "sites": 2,
       "errors": 0,
-      "selfTestFailures": 3,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://bee.synology.com/",
-        "http://global.download.synology.com/",
-        "http://www.synology.com/",
-        "http://kb.synology.com/"
+        "http://kb.synology.com/",
+        "http://www.synology.com/"
       ],
       "failingSites": [
-        "http://bee.synology.com/",
-        "http://global.download.synology.com/",
         "http://www.synology.com/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 3,
+      "sites": 2,
       "errors": 0,
-      "selfTestFailures": 2,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.synology.com/",
-        "http://global.download.synology.com/",
-        "http://kb.synology.com/"
+        "http://kb.synology.com/",
+        "http://www.synology.com/"
       ],
       "failingSites": [
-        "http://www.synology.com/",
-        "http://global.download.synology.com/"
+        "http://www.synology.com/"
       ],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
-  "takealot.com": {
-    "GB": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.takealot.com/"
-      ],
-      "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "tarteaucitron deny": {
     "DE": {
-      "sites": 199,
+      "sites": 3,
       "errors": 0,
-      "selfTestFailures": 52,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.lofer.com/",
-        "http://www.nrw-kultur.de/",
-        "http://www.info.gouv.fr/",
-        "http://www.france-education-international.fr/",
-        "http://catalogue.bnf.fr/"
+        "http://de.geneanet.org/",
+        "http://gw.geneanet.org/",
+        "http://www.uni-osnabrueck.de/"
       ],
-      "failingSites": [
-        "http://samenbau-nordost.de/",
-        "http://volta-motors.de/",
-        "http://parlamentjobs.de/",
-        "http://gfds.de/",
-        "http://blog.admin-intelligence.de/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.mtgo.com/",
-        "http://www.inpi.fr/"
-      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 84,
+      "sites": 2,
       "errors": 0,
-      "selfTestFailures": 16,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.planfor.co.uk/",
-        "http://www.info.gouv.fr/",
-        "http://lingvanex.com/",
-        "http://www.prazsurarly.com/",
-        "http://www.sainte-chapelle.fr/"
+        "http://en.geneanet.org/",
+        "http://gw.geneanet.org/"
       ],
-      "failingSites": [
-        "http://uk.diplomatie.gouv.fr/",
-        "http://uk.emrlocal.com/",
-        "http://www.pth.org.uk/",
-        "http://www.thameshospice.org.uk/",
-        "http://shop.season-of-mist.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.mtgo.com/",
-        "http://www.musee-rodin.fr/"
-      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 26,
+      "sites": 2,
       "errors": 0,
-      "selfTestFailures": 5,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://collections.louvre.fr/",
-        "http://www.green-acres.fr/",
-        "http://en.chateauversailles.fr/",
-        "http://www.rockboard.de/",
-        "http://www.everquest2.com/"
+        "http://en.geneanet.org/",
+        "http://gw.geneanet.org/"
       ],
-      "failingSites": [
-        "http://www.manitowoc.com/",
-        "http://www.green-acres.fr/",
-        "http://gallica.bnf.fr/",
-        "http://us.diplomatie.gouv.fr/",
-        "http://us.mersen.com/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "tarteaucitron.js": {
     "DE": {
-      "sites": 199,
+      "sites": 3,
       "errors": 0,
-      "selfTestFailures": 52,
-      "exampleSites": [
-        "http://edelstahl-express.de/",
-        "http://www.parkplatz-treffen.de/",
-        "http://www.einfachfahrradfahren.de/",
-        "http://www.bund-niedersachsen.de/",
-        "http://firstreview.de/"
-      ],
-      "failingSites": [
-        "http://www.universite-paris-saclay.fr/",
-        "http://www.bandofboats.com/",
-        "http://de.diplomatie.gouv.fr/",
-        "http://www.post-hinterriss.info/",
-        "http://www.tierheim-witten.de/"
-      ],
-      "unsuccessfulSites": [
-        "http://e-steel.arcelormittal.com/",
-        "http://my.knx.org/",
-        "http://whatchareadin.de/",
-        "http://www.berenn.com/",
-        "http://credit-agricole.de/"
-      ],
+      "selfTestFailures": 0,
+      "exampleSites": [],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 84,
+      "sites": 2,
       "errors": 0,
-      "selfTestFailures": 16,
-      "exampleSites": [
-        "http://www.olympiahall.com/",
-        "http://www.ifecosse.org.uk/",
-        "http://www.institut-francais.org.uk/",
-        "http://marathondessables.com/",
-        "http://www.les3vallees.com/"
-      ],
-      "failingSites": [
-        "http://liberon.co.uk/",
-        "http://www.thameshospice.org.uk/",
-        "http://gallica.bnf.fr/",
-        "http://www.offi.fr/",
-        "http://www.pth.org.uk/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.alldiecast.co.uk/",
-        "http://www.lhommeinvisible.com/",
-        "http://www.institut-francais.org.uk/",
-        "http://marathondessables.com/",
-        "http://www.les3vallees.com/"
-      ],
+      "selfTestFailures": 0,
+      "exampleSites": [],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 26,
+      "sites": 2,
       "errors": 0,
-      "selfTestFailures": 5,
+      "selfTestFailures": 0,
       "exampleSites": [],
-      "failingSites": [
-        "http://www.manitowoc.com/",
-        "http://www.green-acres.fr/",
-        "http://gallica.bnf.fr/",
-        "http://us.diplomatie.gouv.fr/",
-        "http://us.mersen.com/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "taunton": {
-    "GB": {
+    "US": {
       "sites": 3,
       "errors": 0,
       "selfTestFailures": 3,
       "exampleSites": [
-        "http://www.threadsmagazine.com/",
-        "http://www.finehomebuilding.com/",
-        "http://www.finewoodworking.com/"
-      ],
-      "failingSites": [
-        "http://www.threadsmagazine.com/",
-        "http://www.finehomebuilding.com/",
-        "http://www.finewoodworking.com/"
-      ],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 5,
-      "errors": 0,
-      "selfTestFailures": 5,
-      "exampleSites": [
-        "http://www.threadsmagazine.com/",
-        "http://www.finegardening.com/",
         "http://www.finehomebuilding.com/",
         "http://www.finewoodworking.com/",
         "http://www.greenbuildingadvisor.com/"
       ],
       "failingSites": [
-        "http://www.threadsmagazine.com/",
-        "http://www.finegardening.com/",
         "http://www.finehomebuilding.com/",
         "http://www.finewoodworking.com/",
         "http://www.greenbuildingadvisor.com/"
@@ -8654,183 +5935,75 @@
   },
   "termsfeed": {
     "DE": {
-      "sites": 80,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.linuxbash.sh/",
-        "http://www.tschechische-gebirge.de/",
-        "http://portforward.com/",
-        "http://projectsam.com/",
-        "http://www.apm-telescopes.net/"
+        "http://www.alle-noten.de/",
+        "http://www.campingplatz-suche.com/",
+        "http://www.youtv.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 138,
+      "sites": 5,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://dundeefundee.com/",
-        "http://www.watdon.co.uk/",
-        "http://www.manchesterdigital.com/",
-        "http://www.stgeorgescathedral.org.uk/",
-        "http://www.bowlandstoves.co.uk/"
+        "http://www.greeka.com/",
+        "http://www.leedsunited.com/",
+        "http://www.manchestertheatres.com/",
+        "http://www.mowermagic.co.uk/",
+        "http://www.useyourlocal.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.visitguernsey.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 37,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.theconnecticutscoop.com/",
-        "http://www.greeka.com/",
-        "http://www.destaco.com/",
-        "http://www.ssldragon.com/",
-        "http://www.missingandunsolved.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
         "http://concretecaptain.com/"
       ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "termsfeed3": {
     "DE": {
-      "sites": 74,
+      "sites": 5,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://trauer.bnn.de/",
-        "http://www.verlageste.de/",
-        "http://anhaengerverleih24.net/",
-        "http://www.gemuesekiste.com/",
-        "http://digital.katalogfinder.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
         "http://worldtabletennis.com/",
-        "http://www.file-upload.net/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 22,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.podmanagement.co.uk/",
-        "http://www.seniormatch.com/",
-        "http://camping.uk-directory.com/",
-        "http://www.suite-world.co.uk/",
-        "http://www.stbarnabascathedral.org.uk/"
+        "http://www.6profis.de/",
+        "http://www.flugplan-flughafen.de/",
+        "http://www.namenfinden.de/",
+        "http://www.songtexte.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://worldtabletennis.com/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 11,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.themeasureofthings.com/",
-        "http://sugardaddymeet.com/",
-        "http://worldtabletennis.com/",
-        "http://www.silvertowne.com/",
-        "http://corvettestory.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.cati.com/",
         "http://worldtabletennis.com/"
       ],
       "errorSites": []
     }
   },
   "tesco": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.tesco.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "GB": {
-      "sites": 3,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://tesco.com/",
-        "http://secure.tesco.com/",
         "http://www.tesco.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.tesco.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
-  "tesla": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.tesla.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.tesla.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.tesla.com/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.tesla.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.tesla.com/"
-      ],
       "errorSites": []
     }
   },
@@ -8851,27 +6024,21 @@
   },
   "tiktok.com": {
     "DE": {
-      "sites": 3,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://support.tiktok.com/",
-        "http://www.tiktok.com/",
-        "http://ads.tiktok.com/"
+        "http://www.tiktok.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 5,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://ads.tiktok.com/",
-        "http://support.tiktok.com/",
-        "http://seller-uk-accounts.tiktok.com/",
-        "http://shop.tiktok.com/",
         "http://www.tiktok.com/"
       ],
       "failingSites": [],
@@ -8879,7 +6046,7 @@
       "errorSites": []
     },
     "US": {
-      "sites": 7,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [],
@@ -8889,41 +6056,25 @@
     }
   },
   "toyota": {
-    "DE": {
+    "GB": {
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.lexus.com/"
+        "http://www.toyota.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
-    "GB": {
+    "US": {
       "sites": 3,
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
         "http://autoparts.toyota.com/",
-        "http://www.toyota.com/",
-        "http://www.lexus.com/"
-      ],
-      "failingSites": [
-        "http://autoparts.toyota.com/"
-      ],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 4,
-      "errors": 0,
-      "selfTestFailures": 1,
-      "exampleSites": [
-        "http://www.toyota.com/",
         "http://www.lexus.com/",
-        "http://autoparts.toyota.com/",
-        "http://toyota.com/"
+        "http://www.toyota.com/"
       ],
       "failingSites": [
         "http://autoparts.toyota.com/"
@@ -8940,18 +6091,7 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://support.omadanetworks.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://support.omadanetworks.com/"
+        "http://www.tp-link.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -8959,17 +6099,6 @@
     }
   },
   "trader-joes-com": {
-    "GB": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.traderjoes.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "US": {
       "sites": 1,
       "errors": 0,
@@ -8984,118 +6113,76 @@
   },
   "transcend": {
     "DE": {
-      "sites": 76,
+      "sites": 12,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://theordinary.com/",
-        "http://www.pluralsight.com/",
-        "http://vimeopro.com/",
-        "http://www.fashionnova.com/",
-        "http://www.apollo.io/"
+        "http://1password.com/",
+        "http://www.notion.so/",
+        "http://www.notion.com/",
+        "http://www.mayoclinic.org/",
+        "http://www.anaconda.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://superhuman.com/",
-        "http://community.postman.com/",
         "http://vimeo.com/",
-        "http://vimeopro.com/",
-        "http://www.benchling.com/"
+        "http://www.mayoclinic.org/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 125,
+      "sites": 25,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://www.udiscovermusic.com/",
-        "http://shop.paulmccartney.com/",
-        "http://www.kfc.co.uk/",
-        "http://www.postman.com/",
-        "http://www.harvey.ai/"
+        "http://www.eventbrite.co.uk/",
+        "http://www.anaconda.com/",
+        "http://theordinary.com/",
+        "http://www.eventbrite.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.mayoclinic.org/",
-        "http://community.postman.com/",
         "http://vimeo.com/",
-        "http://vimeopro.com/",
-        "http://www.abbeyroad.com/"
+        "http://www.depop.com/",
+        "http://www.hipcamp.com/",
+        "http://www.mayoclinic.org/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 495,
+      "sites": 46,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://unfospreys.com/",
-        "http://mgoblue.com/",
-        "http://smumustangs.com/",
-        "http://stoutbluedevils.com/",
-        "http://costconext.com/"
+        "http://uclabruins.com/",
+        "http://www.fashionnova.com/",
+        "http://customerservice.costco.com/",
+        "http://www.visible.com/",
+        "http://www.columbiabank.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
+        "http://big12sports.com/",
         "http://www.mayoclinic.org/",
-        "http://superhuman.com/",
-        "http://goshippo.com/",
-        "http://www.hagertyagent.com/",
-        "http://sameday.costco.com/"
-      ],
-      "errorSites": []
-    }
-  },
-  "truecar": {
-    "US": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.truecar.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.truecar.com/"
+        "http://vimeo.com/",
+        "http://www.depop.com/",
+        "http://www.hipcamp.com/"
       ],
       "errorSites": []
     }
   },
   "truyo": {
-    "GB": {
+    "US": {
       "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://gear.blizzard.com/",
-        "http://wilton.com/"
+        "http://locations.oreillyauto.com/",
+        "http://www.oreillyauto.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://gear.blizzard.com/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 29,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.skibluemt.com/",
-        "http://locations.mcalistersdeli.com/",
-        "http://www.seavees.com/",
-        "http://www.pfchangs.com/",
-        "http://www.jamba.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://locations.pfchangs.com/",
-        "http://mdenshop.com/",
-        "http://locations.massageenvy.com/",
-        "http://www.ethanallen.com/",
-        "http://locations.mcalistersdeli.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
@@ -9114,40 +6201,15 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 13,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://alwaysspanking.tumblr.com/",
-        "http://auntdominant.tumblr.com/",
-        "http://jmp2103.tumblr.com/",
-        "http://www.tumblr.com/",
-        "http://welcometomuscleville.tumblr.com/"
+        "http://www.tumblr.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://alwaysspanking.tumblr.com/",
-        "http://welcometomuscleville.tumblr.com/",
-        "http://stepmothersandaunts.tumblr.com/",
-        "http://luvgrann.tumblr.com/",
-        "http://jmp2103.tumblr.com/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 3,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://qualitycandids.tumblr.com/",
-        "http://www.tumblr.com/",
-        "http://luvgrann.tumblr.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://qualitycandids.tumblr.com/",
-        "http://www.tumblr.com/",
-        "http://luvgrann.tumblr.com/"
+        "http://www.tumblr.com/"
       ],
       "errorSites": []
     }
@@ -9165,12 +6227,11 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://wise.com/",
-        "http://wise.jobs/"
+        "http://wise.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -9179,12 +6240,11 @@
   },
   "twitch.tv": {
     "DE": {
-      "sites": 3,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://de.twitch.tv/",
-        "http://fr.twitch.tv/",
         "http://www.twitch.tv/"
       ],
       "failingSites": [],
@@ -9205,24 +6265,11 @@
     }
   },
   "u12-data-protection-notice": {
-    "DE": {
-      "sites": 2,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://help.x.com/",
-        "http://about.x.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "GB": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://about.x.com/",
         "http://help.x.com/"
       ],
       "failingSites": [],
@@ -9247,25 +6294,27 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://snapcraft.io/",
-        "http://design.ubuntu.com/",
+        "http://canonical.com/",
+        "http://discourse.ubuntu.com/",
         "http://documentation.ubuntu.com/",
-        "http://canonical.com/"
+        "http://snapcraft.io/",
+        "http://ubuntu.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [],
+      "unsuccessfulSites": [
+        "http://discourse.ubuntu.com/"
+      ],
       "errorSites": []
     },
     "GB": {
-      "sites": 5,
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://snapcraft.io/",
-        "http://ubuntu.com/",
-        "http://canonical.com/",
         "http://discourse.ubuntu.com/",
-        "http://documentation.ubuntu.com/"
+        "http://documentation.ubuntu.com/",
+        "http://snapcraft.io/",
+        "http://ubuntu.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
@@ -9274,143 +6323,115 @@
       "errorSites": []
     },
     "US": {
-      "sites": 4,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://snapcraft.io/",
         "http://discourse.ubuntu.com/",
-        "http://canonical.com/",
         "http://ubuntu.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://snapcraft.io/",
         "http://discourse.ubuntu.com/"
       ],
       "errorSites": []
     }
   },
+  "unicourt": {
+    "US": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://unicourt.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    }
+  },
   "usercentrics-api": {
     "DE": {
-      "sites": 4435,
+      "sites": 610,
       "errors": 0,
-      "selfTestFailures": 27,
+      "selfTestFailures": 3,
       "exampleSites": [
-        "http://support.cpanel.net/",
-        "http://www.sparmed.de/",
-        "http://www.vag.de/",
-        "http://www.hirmer-grosse-groessen.de/",
-        "http://www.mondigroup.com/"
+        "http://www.eis.de/",
+        "http://www.union-investment.de/",
+        "http://www.penny.de/",
+        "http://www.hama.com/",
+        "http://www.adacreisen.de/"
       ],
       "failingSites": [
-        "http://vakuum-ev.de/",
-        "http://versicherungen.mercedes-benz.com/",
-        "http://www.bad-woerishofen.info/",
-        "http://www.sufw.de/",
+        "http://mytheresa.com/",
+        "http://www.myheimat.de/",
         "http://www.mytheresa.com/"
       ],
       "unsuccessfulSites": [
-        "http://www.maerklineum.de/",
-        "http://www.dadosens.com/",
-        "http://www.data-unplugged.de/",
-        "http://www.raisin.com/",
-        "http://sportscheck.com/"
+        "http://forums.steinberg.net/",
+        "http://www.fissler.com/",
+        "http://meine.norisbank.de/",
+        "http://www.knuspr.de/",
+        "http://www.gotools.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 683,
+      "sites": 84,
       "errors": 0,
-      "selfTestFailures": 4,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://mason.zoopla.co.uk/",
-        "http://www.sartorius.com/",
-        "http://www.ledvance.com/",
-        "http://www.suedtirol.info/",
-        "http://www.datasheetarchive.com/"
+        "http://www.wrenkitchens.com/",
+        "http://mytheresa.com/",
+        "http://www.hoseasons.co.uk/",
+        "http://www.southeasternrailway.co.uk/",
+        "http://www.hugoboss.com/"
       ],
       "failingSites": [
-        "http://www.stevensonskiphire.co.uk/",
-        "http://www.ullapopken.co.uk/",
-        "http://mytheresa.com/",
-        "http://www.mytheresa.com/"
+        "http://mytheresa.com/"
       ],
       "unsuccessfulSites": [
-        "http://www.ihlondon.com/",
-        "http://firmeneintrag.creditreform.de/",
-        "http://www.marshall.com/",
-        "http://www.uponor.com/",
-        "http://idealo.de/"
+        "http://forums.truenas.com/",
+        "http://www.raisin.com/",
+        "http://www.thomascook.com/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 342,
+      "sites": 31,
       "errors": 0,
-      "selfTestFailures": 3,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://californialabor.law/",
-        "http://www.meilleursagents.com/",
-        "http://myaccount.amig.com/",
-        "http://blog.dorico.com/",
-        "http://trivago.com/"
+        "http://www.mbusa.com/",
+        "http://www.getyourguide.com/",
+        "http://forums.steinberg.net/",
+        "http://www.mdpi.com/",
+        "http://www.vitadox.com/"
       ],
-      "failingSites": [
-        "http://www.mytheresa.com/",
-        "http://www.feeonlynetwork.com/",
-        "http://mytheresa.com/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.kidde.com/",
-        "http://www.deutschebahn.com/",
-        "http://www.uponor.com/",
-        "http://neptuneflood.com/",
-        "http://snyk.io/"
+        "http://forums.steinberg.net/",
+        "http://www.mbusa.com/"
       ],
       "errorSites": []
     }
   },
   "usercentrics-button": {
     "DE": {
-      "sites": 161,
+      "sites": 5,
       "errors": 0,
-      "selfTestFailures": 11,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.hamsterrausch.de/",
-        "http://www.orafol.com/",
-        "http://www.worldrobotolympiad.de/",
-        "http://www.nahverkehrspraxis.de/",
-        "http://koelnerzoo.de/"
+        "http://bos-fahrzeuge.info/",
+        "http://docs.typo3.org/",
+        "http://www.bsb.de/",
+        "http://www.landtag.sachsen.de/",
+        "http://www.staerkergegenkrebs.de/"
       ],
       "failingSites": [
-        "http://api.typo3.org/",
-        "http://docs.typo3.org/",
-        "http://www.pch-shop.de/",
-        "http://typo3.com/",
-        "http://typo3.org/"
+        "http://docs.typo3.org/"
       ],
-      "unsuccessfulSites": [
-        "http://augenpraxisklinik.com/",
-        "http://www.folienschnitte24.de/",
-        "http://www.peter-suesse.de/",
-        "http://www.humboldt.de/",
-        "http://cittimarkt.de/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 2,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://spares.sennheiser.com/",
-        "http://www.hba1cnet.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://spares.sennheiser.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
@@ -9426,33 +6447,35 @@
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
-    },
-    "US": {
-      "sites": 1,
+    }
+  },
+  "vodafone.de": {
+    "DE": {
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.uswitch.com/"
+        "http://kabel.vodafone.de/",
+        "http://vodafone.de/",
+        "http://www.vodafone.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     }
   },
-  "vodafone.de": {
+  "volvocars-com": {
     "DE": {
-      "sites": 5,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://zuhauseplus.vodafone.de/",
-        "http://vodafone.de/",
-        "http://hotspot.vodafone.de/",
-        "http://kabel.vodafone.de/",
-        "http://www.vodafone.de/"
+        "http://www.volvocars.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [],
+      "unsuccessfulSites": [
+        "http://www.volvocars.com/"
+      ],
       "errorSites": []
     },
     "GB": {
@@ -9460,48 +6483,39 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.vodafone.de/"
+        "http://www.volvocars.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [],
+      "unsuccessfulSites": [
+        "http://www.volvocars.com/"
+      ],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.volvocars.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://www.volvocars.com/"
+      ],
       "errorSites": []
     }
   },
   "web.de": {
     "DE": {
-      "sites": 15,
+      "sites": 7,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://freephone.gmx.net/",
-        "http://meinaccount.gmx.net/",
-        "http://millionenklick.gmx.net/",
-        "http://anmelden.gmx.net/",
-        "http://mlogin.gmx.net/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 3,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://anmelden.gmx.net/",
-        "http://web.de/",
-        "http://www.gmx.net/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.gmx.net/"
+        "http://www.gmx.at/",
+        "http://anmelden.web.de/",
+        "http://www.gmx.net/",
+        "http://hilfe.web.de/",
+        "http://web.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -9510,109 +6524,69 @@
   },
   "webflow": {
     "DE": {
-      "sites": 55,
+      "sites": 1,
       "errors": 0,
-      "selfTestFailures": 5,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.relume.io/",
-        "http://www.kanzlei-depenbrock.de/",
-        "http://www.ki-company.ai/",
-        "http://deutsche-energie.de/",
-        "http://www.simon-schnetzer.com/"
+        "http://www.whk-controlling.de/"
       ],
-      "failingSites": [
-        "http://moqo.de/",
-        "http://www.ultralytics.com/",
-        "http://coinfinity.co/",
-        "http://www.relume.io/",
-        "http://www.evtwin.de/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 45,
+      "sites": 1,
       "errors": 0,
-      "selfTestFailures": 8,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://redokun.com/",
-        "http://www.sojo.uk/",
-        "http://street.co.uk/",
-        "http://gtowizard.com/",
-        "http://www.trustguide.ai/"
+        "http://www.conservatives.com/"
       ],
-      "failingSites": [
-        "http://street.co.uk/",
-        "http://www.sojo.uk/",
-        "http://www.acresoftware.com/",
-        "http://www.londonbuddhistcentre.com/",
-        "http://www.getthursday.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.yonder.com/"
-      ],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 18,
-      "errors": 0,
-      "selfTestFailures": 2,
-      "exampleSites": [
-        "http://www.stickerit.co/",
-        "http://www.sdmi-lv.com/",
-        "http://www.worldofmouth.app/",
-        "http://www.datawallet.com/",
-        "http://www.sierracentral.com/"
-      ],
-      "failingSites": [
-        "http://www.eaglepharmacy.com/",
-        "http://www.evercast.us/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "wiki.gg": {
     "DE": {
-      "sites": 98,
+      "sites": 10,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://madipedia.de/",
-        "http://www.potsdam-wiki.de/",
-        "http://fieldsofmistria.wiki.gg/",
-        "http://wiibrew.org/",
-        "http://riskofrain2.wiki.gg/"
+        "http://satisfactory.wiki.gg/",
+        "http://unterrichten.zum.de/",
+        "http://klexikon.zum.de/",
+        "http://wuerzburgwiki.de/",
+        "http://pve.proxmox.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 81,
+      "sites": 10,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://ark.wiki.gg/",
-        "http://sunhaven.wiki.gg/",
-        "http://hellokittyislandadventure.wiki.gg/",
         "http://limbuscompany.wiki.gg/",
-        "http://oxygennotincluded.wiki.gg/"
+        "http://calamitymod.wiki.gg/",
+        "http://consolemods.org/",
+        "http://enshrouded.wiki.gg/",
+        "http://helldivers.wiki.gg/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 84,
+      "sites": 7,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://sonsoftheforest.wiki.gg/",
-        "http://7daystodie.wiki.gg/",
-        "http://warcraft.wiki.gg/",
-        "http://wonderland.wiki.gg/",
-        "http://www.psdevwiki.com/"
+        "http://pve.proxmox.com/",
+        "http://calamitymod.wiki.gg/",
+        "http://helldivers.wiki.gg/",
+        "http://limbuscompany.wiki.gg/",
+        "http://palia.wiki.gg/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -9621,13 +6595,48 @@
   },
   "wix": {
     "DE": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://de.wix.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://support.wix.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.wix.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    }
+  },
+  "wpcc": {
+    "DE": {
       "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://support.wix.com/",
-        "http://de.wix.com/",
-        "http://www.wix.com/"
+        "http://fr.thisvid.com/",
+        "http://it.thisvid.com/",
+        "http://thisvid.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -9638,94 +6647,20 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://support.wix.com/",
-        "http://www.wix.com/"
+        "http://thisvid.com/",
+        "http://www.askmid.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 1,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.wix.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
-  "woo-commerce-com": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://woocommerce.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://woocommerce.com/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://woocommerce.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://woocommerce.com/"
-      ],
-      "errorSites": []
-    }
-  },
-  "wpcc": {
-    "DE": {
-      "sites": 12,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://fr.thisvid.com/",
-        "http://it.thisvid.com/",
-        "http://www.365chess.com/",
-        "http://es.thisvid.com/",
-        "http://tr.thisvid.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 19,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.rugb.co.uk/",
-        "http://mummakingmoney.com/",
-        "http://fr.thisvid.com/",
-        "http://homecoffeeexpert.com/",
-        "http://security-guidance.service.justice.gov.uk/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 21,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.maxwell.syr.edu/",
-        "http://ja.thisvid.com/",
-        "http://pt.thisvid.com/",
-        "http://www.koreanporn.tube/",
-        "http://www.langmuirsystems.com/"
+        "http://thisvid.com/",
+        "http://www.thisvid.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -9734,30 +6669,28 @@
   },
   "xgroovy": {
     "DE": {
-      "sites": 12,
+      "sites": 5,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://anysex.com/",
+        "http://de.mylust.com/",
         "http://de.xgroovy.com/",
-        "http://rt.xgroovy.com/",
-        "http://ru.anysex.com/",
         "http://mylust.com/",
-        "http://nl.xgroovy.com/"
+        "http://xgroovy.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 6,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://rt.xgroovy.com/",
         "http://anysex.com/",
-        "http://de.xgroovy.com/",
-        "http://fr.xgroovy.com/",
-        "http://mylust.com/"
+        "http://mylust.com/",
+        "http://xgroovy.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -9766,15 +6699,15 @@
   },
   "xhamster-us": {
     "US": {
-      "sites": 15,
+      "sites": 6,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://fi.xhamster.com/",
-        "http://pt.xhamster.com/",
+        "http://xhamster3.com/",
         "http://fra.xhamster.com/",
-        "http://jp.xhamster.com/",
-        "http://ge.xhamster.com/"
+        "http://id.xhamster.com/",
+        "http://xhamster.com/",
+        "http://xhamster2.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -9783,12 +6716,10 @@
   },
   "xvideos": {
     "GB": {
-      "sites": 3,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://fr.xvideos.com/",
-        "http://it.xvideos.com/",
         "http://www.xvideos.com/"
       ],
       "failingSites": [],
@@ -9797,29 +6728,21 @@
     }
   },
   "youtube-desktop": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.youtube.co.uk/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "GB": {
       "sites": 5,
       "errors": 0,
-      "selfTestFailures": 0,
+      "selfTestFailures": 2,
       "exampleSites": [
-        "http://uk.youtube.com/",
-        "http://m.youtube.com/",
-        "http://www.youtube.co.uk/",
-        "http://www.youtube.com/",
-        "http://youtube.com/"
+        "http://courtslistings.co.uk/",
+        "http://luckydraw.tcl.com/",
+        "http://thumbstacks.com/",
+        "http://tossthecoin.tcl.com/",
+        "http://www.youtube.com/"
       ],
-      "failingSites": [],
+      "failingSites": [
+        "http://courtslistings.co.uk/",
+        "http://thumbstacks.com/"
+      ],
       "unsuccessfulSites": [],
       "errorSites": []
     }
@@ -9840,43 +6763,8 @@
       "errorSites": []
     }
   },
-  "zentralruf-de": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.zentralruf.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
   "zinio": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.zinio.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "GB": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.zinio.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,


### PR DESCRIPTION
Rule coverage stats from the latest crawl.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Updates a generated coverage stats dataset only; no application logic changes or security-sensitive code touched.
> 
> **Overview**
> Refreshes `data/coverage.json` with the latest rule coverage crawl results, updating per-rule/per-country counts and the associated example/failing/unsuccessful site lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86d09248f05ddf3085203768aa23e643a7e92472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->