### PR TITLE
Add escaparium.ca site-specific rule

### DIFF
--- a/rules/autoconsent/escaparium.ca.json
+++ b/rules/autoconsent/escaparium.ca.json
@@ -1,0 +1,35 @@
+{
+    "name": "escaparium.ca",
+    "vendorUrl": "https://www.escaparium.ca/",
+    "runContext": {
+        "urlPattern": "^https://(www\\.)?escaparium\\.ca/"
+    },
+    "detectCmp": [
+        {
+            "exists": "div#klaro"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "xpath///div[contains(@class,'pointer-events-none')]//button[normalize-space()='Accept all' or normalize-space()='Tout accepter']"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "xpath///button[normalize-space()='Accept all' or normalize-space()='Tout accepter']"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "xpath///button[normalize-space()='Customize' or normalize-space()='Personnaliser']"
+        },
+        {
+            "waitForThenClick": "xpath///button[normalize-space()='Decline' or normalize-space()='Refuser']"
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "escaparium_cookie_consent_decided=1"
+        }
+    ]
+}

--- a/tests/escaparium.ca.spec.ts
+++ b/tests/escaparium.ca.spec.ts
@@ -1,0 +1,8 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('escaparium.ca', [
+    'https://www.escaparium.ca/laval/book',
+    'https://www.escaparium.ca/',
+    'https://www.escaparium.ca/sherbrooke/book',
+    'https://www.escaparium.ca/saguenay/book',
+]);

--- a/tests/escaparium.ca.spec.ts
+++ b/tests/escaparium.ca.spec.ts
@@ -1,8 +1,3 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('escaparium.ca', [
-    'https://www.escaparium.ca/laval/book',
-    'https://www.escaparium.ca/',
-    'https://www.escaparium.ca/sherbrooke/book',
-    'https://www.escaparium.ca/saguenay/book',
-]);
+generateCMPTests('escaparium.ca', ['https://www.escaparium.ca/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1214877176180557?focus=true

## Description:

The cookie popup on https://www.escaparium.ca/ is a custom (non-CMP) banner that exposes only 'Customize' / 'Accept all' on the initial banner; the reject path requires opening the 'Customize' modal and clicking 'Decline'. The default heuristic rule does not handle this because the visible reject affordance is hidden behind a second step.

Adds a site-scoped JSON rule that:
- detects the always-present #klaro placeholder div for detectCmp
- detects the visible banner via the 'Accept all'/'Tout accepter' button
- opts out by clicking 'Customize'/'Personnaliser', then 'Decline'/'Refuser'
- opts in by clicking 'Accept all'/'Tout accepter'
- verifies consent via the escaparium_cookie_consent_decided cookie

Supports both English and French strings (the site auto-switches by locale and via /fr/ paths).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new site-scoped autoconsent rule and a Playwright spec without changing shared consent engine behavior.
> 
> **Overview**
> Adds a new `rules/autoconsent/escaparium.ca.json` site rule to detect the Escaparium banner and drive **opt-in** (click “Accept all”/“Tout accepter”) and **opt-out** via a two-step flow (open “Customize”/“Personnaliser”, then “Decline”/“Refuser”), with validation via `escaparium_cookie_consent_decided=1`.
> 
> Introduces `tests/escaparium.ca.spec.ts` to run the standard Playwright CMP test runner against `https://www.escaparium.ca/` using the new rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c67be3313788017d1a1e665edb76569f5fe93d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->