### PR TITLE
Fix tesco.com cookie popup race condition

### DIFF
--- a/rules/autoconsent/tesco.json
+++ b/rules/autoconsent/tesco.json
@@ -5,7 +5,7 @@
     "runContext": {
         "urlPattern": "^https://(www\\.)?tesco\\.com/"
     },
-    "prehideSelectors": ["[class*=CookieBanner__Sizer]"],
+    "prehideSelectors": ["[aria-label=consent-banner]"],
     "detectCmp": [
         {
             "exists": "[aria-label=consent-banner]"
@@ -18,7 +18,7 @@
     ],
     "optIn": [
         {
-            "wait": 1000
+            "waitFor": "#onetrust-pc-sdk"
         },
         {
             "waitForThenClick": "xpath///button[contains(., 'Accept all')]"
@@ -26,10 +26,15 @@
     ],
     "optOut": [
         {
-            "wait": 1000
+            "waitFor": "#onetrust-pc-sdk"
         },
         {
             "waitForThenClick": "xpath///button[contains(., 'Reject all')]"
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "interactionCount=1"
         }
     ]
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1214978304418861?focus=true

## Description:
Replace the arbitrary 1s wait with a wait for #onetrust-pc-sdk to appear, which signals that the OneTrust SDK has finished loading. Clicking the 'Reject all' / 'Accept all' buttons before this fires the React onClick handler but the underlying OneTrust.RejectAll()/AllowAll() call no-ops, so the consent isn't registered and the popup stays visible.

Also:
- Update prehideSelectors to match the current banner markup ([class*=CookieBanner__Sizer] no longer exists on the page).
- Add a cookieContains self-test for the OptanonConsent interactionCount flag, which only flips to 1 after the SDK successfully records consent.


## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, limited to a single site’s JSON rule and intended to reduce flaky/racy consent clicks. Main risk is selector changes causing the Tesco rule to stop matching if the site markup differs.
> 
> **Overview**
> Fixes a Tesco consent-popup race by replacing the fixed 1s delay with a `waitFor` on `#onetrust-pc-sdk` before triggering **Accept all**/**Reject all** clicks.
> 
> Updates `prehideSelectors` to match the current banner (`[aria-label=consent-banner]`) and adds a `test` assertion that the consent cookie reflects a successful interaction (`interactionCount=1`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f5499029309a6647aa7fb04c99d9969a43d1a3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->