### PR TITLE
Handle USP/MSPA variant of Quantcast/InMobi Choice CMP

### DIFF
--- a/rules/autoconsent/quantcast.json
+++ b/rules/autoconsent/quantcast.json
@@ -8,71 +8,99 @@
     ],
     "detectPopup": [
         {
-            "visible": "#qc-cmp2-ui"
+            "any": [{ "visible": "#qc-cmp2-ui" }, { "visible": "#qc-cmp2-usp" }]
         }
     ],
     "optOut": [
         {
             "if": {
-                "exists": "#disagree-btn"
+                "exists": "#qc-cmp2-usp"
             },
             "then": [
                 {
-                    "click": "#disagree-btn"
+                    "click": "#qc-cmp2-usp .qc-cmp2-scrollable-section button.qc-cmp2-toggle[aria-checked=\"false\"]",
+                    "all": true,
+                    "optional": true
+                },
+                {
+                    "click": "#qc-cmp2-usp .qc-cmp2-expandable-list button.qc-cmp2-toggle[aria-checked=\"true\"]",
+                    "all": true,
+                    "optional": true
+                },
+                {
+                    "waitForThenClick": "#qc-cmp2-usp button[mode=\"primary\"]",
+                    "timeout": 5000
+                },
+                {
+                    "waitForThenClick": "button[aria-label=\"Close success modal\"]",
+                    "timeout": 5000,
+                    "optional": true
                 }
             ],
             "else": [
                 {
-                    "waitFor": ".qc-cmp2-summary-buttons > button[mode=\"secondary\"]",
-                    "timeout": 2000
-                },
-                {
                     "if": {
-                        "exists": ".qc-cmp2-summary-buttons > button[mode=\"secondary\"]:nth-of-type(2)"
+                        "exists": "#disagree-btn"
                     },
                     "then": [
                         {
-                            "click": ".qc-cmp2-summary-buttons > button[mode=\"secondary\"]:nth-of-type(2)"
+                            "click": "#disagree-btn"
                         }
                     ],
                     "else": [
                         {
-                            "click": ".qc-cmp2-summary-buttons > button[mode=\"secondary\"]:nth-of-type(1)"
-                        },
-                        {
-                            "waitForVisible": "#qc-cmp2-ui .qc-cmp2-consent-info"
-                        },
-                        {
-                            "click": ".qc-cmp2-toggle-switch > button[aria-checked=\"true\"]",
-                            "all": true,
-                            "optional": true
-                        },
-                        {
-                            "click": [
-                                ".qc-cmp2-main",
-                                "xpath///button[contains(., 'REJECT ALL') or contains(., 'ALLE VERWERPEN') or contains(., 'ΑΠΟΡΡΙΠΤΩ ΤΑ ΠΑΝΤΑ') or contains(., 'RESPINGERE TOTALĂ') or contains(., 'ALLE ABLEHNEN') or contains(., 'ODRZUCENIE') or contains(., 'BLOQUEAR TODO') or contains(., 'REJEITAR TODOS') or contains(., 'RIFIUTA TUTTO') or contains(., 'TOUT REFUSER') or contains(., 'ОТКЛОНИТЬ ВСЕХ')]"
-                            ],
-                            "optional": true
-                        },
-                        {
-                            "wait": 500
+                            "waitFor": ".qc-cmp2-summary-buttons > button[mode=\"secondary\"]",
+                            "timeout": 2000
                         },
                         {
                             "if": {
-                                "exists": ".qc-cmp2-buttons-desktop > button[mode=primary]"
+                                "exists": ".qc-cmp2-summary-buttons > button[mode=\"secondary\"]:nth-of-type(2)"
                             },
                             "then": [
                                 {
-                                    "click": ".qc-cmp2-buttons-desktop > button[mode=primary]"
+                                    "click": ".qc-cmp2-summary-buttons > button[mode=\"secondary\"]:nth-of-type(2)"
                                 }
                             ],
                             "else": [
                                 {
-                                    "waitForThenClick": [
+                                    "click": ".qc-cmp2-summary-buttons > button[mode=\"secondary\"]:nth-of-type(1)"
+                                },
+                                {
+                                    "waitForVisible": "#qc-cmp2-ui .qc-cmp2-consent-info"
+                                },
+                                {
+                                    "click": ".qc-cmp2-toggle-switch > button[aria-checked=\"true\"]",
+                                    "all": true,
+                                    "optional": true
+                                },
+                                {
+                                    "click": [
                                         ".qc-cmp2-main",
-                                        "xpath///button[contains(.,'SAVE & EXIT') or contains(.,'SALVA ED ESCI') or contains(.,'GUARDAR Y SALIR') or contains(.,'SPEICHERN & VERLASSEN')"
+                                        "xpath///button[contains(., 'REJECT ALL') or contains(., 'ALLE VERWERPEN') or contains(., 'ΑΠΟΡΡΙΠΤΩ ΤΑ ΠΑΝΤΑ') or contains(., 'RESPINGERE TOTALĂ') or contains(., 'ALLE ABLEHNEN') or contains(., 'ODRZUCENIE') or contains(., 'BLOQUEAR TODO') or contains(., 'REJEITAR TODOS') or contains(., 'RIFIUTA TUTTO') or contains(., 'TOUT REFUSER') or contains(., 'ОТКЛОНИТЬ ВСЕХ')]"
                                     ],
-                                    "timeout": 5000
+                                    "optional": true
+                                },
+                                {
+                                    "wait": 500
+                                },
+                                {
+                                    "if": {
+                                        "exists": ".qc-cmp2-buttons-desktop > button[mode=primary]"
+                                    },
+                                    "then": [
+                                        {
+                                            "click": ".qc-cmp2-buttons-desktop > button[mode=primary]"
+                                        }
+                                    ],
+                                    "else": [
+                                        {
+                                            "waitForThenClick": [
+                                                ".qc-cmp2-main",
+                                                "xpath///button[contains(.,'SAVE & EXIT') or contains(.,'SALVA ED ESCI') or contains(.,'GUARDAR Y SALIR') or contains(.,'SPEICHERN & VERLASSEN')"
+                                            ],
+                                            "timeout": 5000
+                                        }
+                                    ]
                                 }
                             ]
                         }
@@ -83,7 +111,35 @@
     ],
     "optIn": [
         {
-            "click": ".qc-cmp2-summary-buttons > button[mode=\"primary\"]"
+            "if": {
+                "exists": "#qc-cmp2-usp"
+            },
+            "then": [
+                {
+                    "click": "#qc-cmp2-usp .qc-cmp2-scrollable-section button.qc-cmp2-toggle[aria-checked=\"true\"]",
+                    "all": true,
+                    "optional": true
+                },
+                {
+                    "click": "#qc-cmp2-usp .qc-cmp2-expandable-list button.qc-cmp2-toggle[aria-checked=\"false\"]",
+                    "all": true,
+                    "optional": true
+                },
+                {
+                    "waitForThenClick": "#qc-cmp2-usp button[mode=\"primary\"]",
+                    "timeout": 5000
+                },
+                {
+                    "waitForThenClick": "button[aria-label=\"Close success modal\"]",
+                    "timeout": 5000,
+                    "optional": true
+                }
+            ],
+            "else": [
+                {
+                    "click": ".qc-cmp2-summary-buttons > button[mode=\"primary\"]"
+                }
+            ]
         }
     ]
 }

--- a/tests/quantcast.spec.ts
+++ b/tests/quantcast.spec.ts
@@ -23,6 +23,6 @@ generateCMPTests('com_quantcast2', ['https://www.fandom.com/'], {
 
 // USP/MSPA variant of InMobi (Quantcast) Choice CMP.
 generateCMPTests('quantcast', ['https://secretldn.com/'], {
-    onlyRegions: ['US'],
+    onlyRegions: ['US', 'DE', 'GB'],
     testSelfTest: false,
 });

--- a/tests/quantcast.spec.ts
+++ b/tests/quantcast.spec.ts
@@ -20,3 +20,9 @@ generateCMPTests('com_quantcast2', ['https://www.fandom.com/'], {
     testSelfTest: false,
     skipRegions: ['US'],
 });
+
+// USP/MSPA variant of InMobi (Quantcast) Choice CMP.
+generateCMPTests('quantcast', ['https://secretldn.com/'], {
+    onlyRegions: ['US'],
+    testSelfTest: false,
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1214917582275773?focus=true

## Description:
The InMobi Choice CMP (formerly Quantcast Choice) renders a different popup for US visitors (#qc-cmp2-usp) compared to GDPR visitors (#qc-cmp2-ui). The existing rule only detected and handled the GDPR variant, leaving the USP popup on secretldn.com and other sites unhandled.

- detectPopup now matches either #qc-cmp2-ui or #qc-cmp2-usp.
- optOut/optIn branch on #qc-cmp2-usp to flip toggles in the scrollable opt-out section and the Google Basic Consents expandable list, then click the primary CONFIRM button and dismiss the resulting MSPA success modal.
- Added secretldn.com as a US-only test target.

## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates core Quantcast autoconsent rules with new selector logic and toggle-click flows, which could change consent behavior across sites using this CMP. Risk is moderate due to selector brittleness and branching between GDPR vs USP variants.
> 
> **Overview**
> Extends the Quantcast/InMobi Choice autoconsent rule to treat the popup as visible when either GDPR (`#qc-cmp2-ui`) *or* USP/MSPA (`#qc-cmp2-usp`) UIs are shown.
> 
> Adds explicit USP/MSPA `optOut`/`optIn` flows that toggle consent switches in the USP UI, confirm via the primary button, and optionally dismiss the success modal; existing GDPR handling is preserved as the fallback path.
> 
> Adds a new Playwright test target (`secretldn.com`) to exercise the USP/MSPA variant in selected regions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db3ae25c06f7edfd4c84365b8e4e91aef8095194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->