### PR TITLE
Add TrustArc-newcm rule for new shadow-DOM consent format

### DIFF
--- a/rules/autoconsent/trustarc-newcm.json
+++ b/rules/autoconsent/trustarc-newcm.json
@@ -24,8 +24,7 @@
         }
     ],
     "test": [
-        {
-            "cookieContains": "cmapi_cookie_privacy=permit 1"
-        }
+        { "cookieContains": "cmapi_cookie_privacy=permit 1" },
+        { "cookieContains": "cmapi_cookie_privacy=permit 1,2", "negated": true }
     ]
 }

--- a/rules/autoconsent/trustarc-newcm.json
+++ b/rules/autoconsent/trustarc-newcm.json
@@ -1,0 +1,31 @@
+{
+    "name": "TrustArc-newcm",
+    "vendorUrl": "https://trustarc.com/",
+    "prehideSelectors": [".truste_popframe.trustarc_newcm_container"],
+    "detectCmp": [
+        {
+            "exists": [".truste_popframe.trustarc_newcm_container", "a.required, a.call"]
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": [".truste_popframe.trustarc_newcm_container", "a.required, a.call"],
+            "check": "any"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": [".truste_popframe.trustarc_newcm_container", "a.call"]
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": [".truste_popframe.trustarc_newcm_container", "a.required"]
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "cmapi_cookie_privacy=permit 1"
+        }
+    ]
+}

--- a/tests/trustarc-newcm.spec.ts
+++ b/tests/trustarc-newcm.spec.ts
@@ -1,0 +1,7 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('TrustArc-newcm', ['https://www.gwr.com/'], {
+    testOptOut: true,
+    testOptIn: false,
+    testSelfTest: false,
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1214959609540002?focus=true

## Description:
The new TrustArc Consent Manager renders the cookie banner inside an open shadow root attached to .truste_popframe.trustarc_newcm_container. The existing TrustArc-top rule looks for #truste-show-consent / #truste-consent-track in the light DOM and therefore does not detect this variant (e.g. on https://www.gwr.com/), and the heuristic rule cannot pierce shadow boundaries either.

Add a generic JSON rule that pierces the shadow root and clicks a.required (reject all) or a.call (accept all).

## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new, standalone autoconsent rule and a targeted Playwright test without modifying existing CMP logic or shared infrastructure.
> 
> **Overview**
> Adds a new `TrustArc-newcm` autoconsent rule to detect the updated TrustArc Consent Manager variant (using `.truste_popframe.trustarc_newcm_container`) and automate accept (`a.call`) / reject (`a.required`) actions with cookie-based assertions.
> 
> Introduces a Playwright spec (`trustarc-newcm.spec.ts`) that exercises this rule against `https://www.gwr.com/` (currently validating opt-out only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d37423bd3ce726c90ed4f7e419927ed746d4cc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->