### PR TITLE
Add sostereo.com rule

### DIFF
--- a/rules/autoconsent/sostereo.json
+++ b/rules/autoconsent/sostereo.json
@@ -1,0 +1,21 @@
+{
+    "name": "sostereo.com",
+    "vendorUrl": "https://sostereo.com/",
+    "runContext": {
+        "urlPattern": "^https://(www\\.)?sostereo\\.com/"
+    },
+    "prehideSelectors": ["app-cookie-consent"],
+    "detectCmp": [{ "exists": "app-cookie-consent" }],
+    "detectPopup": [{ "visible": "app-cookie-consent" }],
+    "optIn": [{ "waitForThenClick": "app-cookie-consent app-btn button" }],
+    "optOut": [
+        { "waitForThenClick": "app-cookie-consent button.underline" },
+        { "waitFor": "app-cookie-consent ui-switch button.switch" },
+        {
+            "click": "app-cookie-consent ui-switch button.switch.checked:not(.disabled)",
+            "all": true,
+            "optional": true
+        },
+        { "waitForThenClick": "app-cookie-consent app-btn button" }
+    ]
+}

--- a/tests/sostereo.spec.ts
+++ b/tests/sostereo.spec.ts
@@ -1,0 +1,7 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('sostereo.com', [
+    'https://sostereo.com/spaces/pitch/b58c388677?slide=1',
+    'https://sostereo.com/',
+    'https://sostereo.com/about',
+]);

--- a/tests/sostereo.spec.ts
+++ b/tests/sostereo.spec.ts
@@ -1,7 +1,3 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('sostereo.com', [
-    'https://sostereo.com/spaces/pitch/b58c388677?slide=1',
-    'https://sostereo.com/',
-    'https://sostereo.com/about',
-]);
+generateCMPTests('sostereo.com', ['https://sostereo.com/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1214989288071288?focus=true

## Description:
Adds a site-specific JSON rule for the custom Angular cookie popup on sostereo.com (app-cookie-consent). Opt-out opens the Preferences view, toggles off Analytics and Marketing switches, then clicks Save Preferences.


## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new site-specific autoconsent rule and a Playwright test without changing shared consent-handling logic.
> 
> **Overview**
> Adds a new `rules/autoconsent/sostereo.json` rule to detect and interact with sostereo.com's `app-cookie-consent` popup, including explicit *opt-in* and multi-step *opt-out* flows (open preferences, toggle switches off, save).
> 
> Adds a minimal Playwright spec (`tests/sostereo.spec.ts`) to run the standard CMP test suite against `https://sostereo.com/` using this rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fc89d6947bd6ae6e6341187b87283337eb3a253. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->