### PR TITLE
Add rule for eltax.lta.go.jp payment portal cookie popup

### DIFF
--- a/rules/autoconsent/eltax-lta-go-jp.json
+++ b/rules/autoconsent/eltax-lta-go-jp.json
@@ -1,0 +1,12 @@
+{
+    "name": "eltax-lta-go-jp",
+    "vendorUrl": "https://portal.payment.eltax.lta.go.jp/",
+    "runContext": {
+        "urlPattern": "^https://(?:[^/]+\\.)?eltax\\.lta\\.go\\.jp/"
+    },
+    "prehideSelectors": [".modal:has(> .modal-content > .cookie-consent)"],
+    "detectCmp": [{ "exists": ".cookie-consent #cookieDisagree" }],
+    "detectPopup": [{ "visible": ".cookie-consent #cookieDisagree" }],
+    "optIn": [{ "waitForThenClick": ".cookie-consent #cookieAgree" }],
+    "optOut": [{ "waitForThenClick": ".cookie-consent #cookieDisagree" }]
+}

--- a/tests/eltax-lta-go-jp.spec.ts
+++ b/tests/eltax-lta-go-jp.spec.ts
@@ -1,0 +1,9 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests(
+    'eltax-lta-go-jp',
+    ['https://portal.payment.eltax.lta.go.jp/efp/xnd/index', 'https://portal.payment.eltax.lta.go.jp/efp/xnd/inputkey'],
+    {
+        testSelfTest: false,
+    },
+);

--- a/tests/eltax-lta-go-jp.spec.ts
+++ b/tests/eltax-lta-go-jp.spec.ts
@@ -1,9 +1,5 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests(
-    'eltax-lta-go-jp',
-    ['https://portal.payment.eltax.lta.go.jp/efp/xnd/index', 'https://portal.payment.eltax.lta.go.jp/efp/xnd/inputkey'],
-    {
-        testSelfTest: false,
-    },
-);
+generateCMPTests('eltax-lta-go-jp', ['https://portal.payment.eltax.lta.go.jp/efp/xnd/index'], {
+    testSelfTest: false,
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1215042198136921?focus=true

## Description:


## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new site-specific autoconsent rule and a corresponding Playwright test without modifying shared consent logic.
> 
> **Overview**
> Adds a new autoconsent rule `eltax-lta-go-jp` to detect and pre-hide the `eltax.lta.go.jp` payment portal cookie-consent modal and automate **agree**/**disagree** clicks.
> 
> Introduces a Playwright spec that runs the standard CMP test suite against `https://portal.payment.eltax.lta.go.jp/efp/xnd/index` (with `testSelfTest` disabled) to validate the new rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b742c3dab13b13352b3fe9cc7a1b01bcce450b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->