### PR TITLE
Add lucozade.com rule for custom cookie popup

### DIFF
--- a/rules/autoconsent/lucozade.json
+++ b/rules/autoconsent/lucozade.json
@@ -1,0 +1,33 @@
+{
+    "name": "lucozade.com",
+    "vendorUrl": "https://lucozade.com/",
+    "runContext": {
+        "urlPattern": "^https://(www\\.)?lucozade\\.com/"
+    },
+    "prehideSelectors": ["#cookiePopup", ".cookie-overlay"],
+    "detectCmp": [
+        {
+            "exists": "#cookiePopup"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#cookiePopup"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "#cookiePopup .acceptCookie"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "#cookiePopup .reject-cookie"
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "_site_acceptance=0"
+        }
+    ]
+}

--- a/tests/lucozade.spec.ts
+++ b/tests/lucozade.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('lucozade.com', ['https://lucozade.com/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1215064869632829?focus=true

## Description:


## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds only a new site-specific consent rule and test file; no changes to shared consent logic or security-sensitive code.
> 
> **Overview**
> Adds **autoconsent** support for **lucozade.com**’s site-specific cookie banner (`#cookiePopup`), including prehide for the popup and overlay, accept/reject click paths, and an opt-out assertion on `_site_acceptance=0`.
> 
> A **Playwright** spec wires the rule to `https://lucozade.com/` via the shared `generateCMPTests` runner, matching other CMP entries in the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7064477d7789b5d8ad673d02b33b487940aa9225. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->