### PR TITLE
Document a caveat for config search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,17 @@ Use the `/publicwww-search` skill to search website source code for CMP-specific
 
 Requires `PUBLICWWW_KEY` environment variable.
 
+## Checking for Existing Site Exceptions in `privacy-configuration`
+
+Some sites have autoconsent disabled entirely via the `duckduckgo/privacy-configuration` repo. Before investigating a reported popup, check whether an exception already exists for the domain in:
+
+- `features/autoconsent.json`
+- `overrides/{android,ios,macos,windows,extension}-override.json` and any files under `overrides/browsers/`
+
+**Do NOT rely on `gh search code` for this lookup.** GitHub's code search index has a per-file size limit and `features/autoconsent.json` is excluded — searches for the domain there silently return zero hits even when an exception exists.
+
+Instead, fetch the file directly and grep locally, and/or list PRs by title.
+
 ## Verification
 
 After creating or modifying a rule:


### PR DESCRIPTION
Task/Issue URL:

## Description:


## Steps to test this PR:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent guidance with no runtime or security impact.
> 
> **Overview**
> Adds a **Checking for Existing Site Exceptions in `privacy-configuration`** section to `AGENTS.md` so agents verify whether a domain already has autoconsent disabled in `duckduckgo/privacy-configuration` before debugging a popup.
> 
> It points reviewers at `features/autoconsent.json` and platform override files, and documents a **GitHub code search pitfall**: `gh search code` can miss entries in large or excluded files (including `features/autoconsent.json`), so lookups should use direct file fetch + local grep and/or PR title search instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64f0db4842a198181f61f27b3066997f58070407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->