### PR TITLE
Add Dotdash Meredith CMP rule

### DIFF
--- a/rules/autoconsent/dotdash-meredith.json
+++ b/rules/autoconsent/dotdash-meredith.json
@@ -1,0 +1,17 @@
+{
+    "name": "dotdash-meredith",
+    "vendorUrl": "https://www.dotdashmeredith.com/",
+    "prehideSelectors": ["#onetrust-banner-sdk", ".onetrust-pc-dark-filter"],
+    "runContext": {
+        "main": true,
+        "urlPattern": "^https?://([^/]+\\.)?(aboutespanol|agriculture|allrecipes|bhg|brides|byrdie|dailypaws|ew|foodandwine|health|instyle|investopedia|lifewire|liquor|liveabout|marthastewart|midwestliving|mydomaine|parents|people|realsimple|seriouseats|shape|simplyrecipes|southernliving|thespruce|thesprucecrafts|thespruceeats|thoughtco|travelandleisure|treehugger|tripsavvy|verywellfit|verywellhealth|verywellmind)\\.com/"
+    },
+    "detectCmp": [{ "exists": "#onetrust-banner-sdk.otFlat" }, { "exists": ".ot-pref-trigger" }],
+    "detectPopup": [{ "visible": "#onetrust-banner-sdk" }],
+    "optIn": [{ "waitForThenClick": "#onetrust-accept-btn-handler" }],
+    "optOut": [
+        { "waitForThenClick": ".onetrust-close-btn-handler" },
+        { "waitForVisible": "#onetrust-banner-sdk", "check": "none", "timeout": 10000 }
+    ],
+    "test": [{ "cookieContains": "OptanonAlertBoxClosed" }]
+}

--- a/tests/dotdash-meredith.spec.ts
+++ b/tests/dotdash-meredith.spec.ts
@@ -1,0 +1,23 @@
+import generateCMPTests from '../playwright/runner';
+
+// Dotdash Meredith network of sites. The OneTrust banner is server-side rendered
+// and the OneTrust SDK is only loaded on demand (via Mntl.CMP), so the generic
+// Onetrust rule cannot interact with it reliably.
+generateCMPTests(
+    'dotdash-meredith',
+    [
+        'https://people.com/jean-smart-best-roles-in-tv-shows-before-hacks-and-snl-photos-8720080',
+        'https://www.allrecipes.com/',
+        'https://www.investopedia.com/',
+        'https://www.byrdie.com/',
+        'https://www.simplyrecipes.com/',
+        'https://www.verywellhealth.com/',
+        'https://www.foodandwine.com/',
+        'https://www.realsimple.com/',
+    ],
+    {
+        // The banner is only visible to users in regions where consent is required (mostly EU/GDPR).
+        // From a US IP the banner stays hidden, so we skip these regions.
+        onlyRegions: ['DE', 'GB', 'FR'],
+    },
+);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1214959942625055?focus=true

## Description:
Dotdash Meredith network sites (people.com, allrecipes.com, investopedia.com, etc.) use a server-rendered OneTrust banner controlled by their own Mntl.CMP wrapper. The OneTrust SDK is only loaded on demand, so the generic Onetrust rule cannot open the preference center or save preferences and silently reports a fake success while leaving the banner on screen.

Add a site-specific rule that takes priority over the generic Onetrust rule on these domains and opts out by clicking the banner close button. In consent-required regions Mntl.CMP intercepts the click, loads the OneTrust SDK and replays it, which results in OptanonConsent with all non-essential groups disabled and OptanonAlertBoxClosed being set.

## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New consent rule and tests only; no changes to core app logic, auth, or data handling.
> 
> **Overview**
> Adds a **site-specific autoconsent rule** for Dotdash Meredith properties so consent handling wins over the generic OneTrust rule on those domains.
> 
> The new rule targets a broad set of `*.com` brands via `urlPattern`, pre-hides the OneTrust banner, detects the server-rendered flat banner, and **opts out by clicking the close handler** (then waits for the banner to disappear) instead of using the preference-center flow the generic rule relies on. Success is asserted with `OptanonAlertBoxClosed`.
> 
> Adds **Playwright CMP coverage** for eight sample URLs, restricted to **DE, GB, and FR** because the banner only appears in consent-required regions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaadb206d678b068e4f4e07ee511caadadc81039. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->