### PR TITLE
Test extension improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ test-results/
 rules/rules.*
 rules/consentomatic.json
 rules/compact-rules.json
+rules/rule-index.json
 lib/**/*.js
 addon/*.js
 .vscode/

--- a/addon/popup.html
+++ b/addon/popup.html
@@ -23,6 +23,52 @@
                 cursor: pointer;
                 border-radius: 2px;
             }
+
+            .rule-section {
+                margin: 0.5em 0;
+            }
+
+            .rule-search {
+                box-sizing: border-box;
+                margin: 0.5em 0;
+                width: 100%;
+            }
+
+            .rule-actions {
+                display: flex;
+                gap: 0.5em;
+                margin: 0.5em 0;
+            }
+
+            .rule-actions button {
+                flex: 1;
+            }
+
+            .rule-list {
+                border: 1px solid #ddd;
+                max-height: 12em;
+                overflow-y: auto;
+                padding: 0.25em;
+            }
+
+            .rule-row {
+                display: block;
+                overflow: hidden;
+                padding: 0.15em 0;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+
+            .rule-list-status {
+                color: #666;
+                font-size: 0.9em;
+                margin: 0.25em 0;
+            }
+
+            .rule-count-disabled {
+                color: #b00020;
+                font-weight: bold;
+            }
         </style>
     </head>
 
@@ -96,16 +142,55 @@
         </fieldset>
 
         <fieldset>
-            <legend>Handle unknown popups (beta)</legend>
+            <legend>Rules</legend>
 
-            <div>
-                <input type="radio" id="heuristic-action-on" name="heuristic-action" value="true" />
-                <label for="heuristic-action-on">On</label>
-            </div>
+            <details class="rule-section" id="generated-rules-section">
+                <summary>Generated rules <span id="generated-rules-count"></span></summary>
+                <input class="rule-search" type="search" id="generated-rules-search" placeholder="Search generated rules" />
+                <div class="rule-actions">
+                    <button id="generated-rules-enable-all">Enable all</button>
+                    <button id="generated-rules-disable-all">Disable all</button>
+                </div>
+                <div class="rule-list-status" id="generated-rules-status"></div>
+                <div class="rule-list" id="generated-rules-list"></div>
+            </details>
 
-            <div>
-                <input type="radio" id="heuristic-action-off" name="heuristic-action" value="false" checked />
-                <label for="heuristic-action-off">Off</label>
+            <details class="rule-section" id="generic-rules-section">
+                <summary>Generic rules <span id="generic-rules-count"></span></summary>
+                <input class="rule-search" type="search" id="generic-rules-search" placeholder="Search generic rules" />
+                <div class="rule-actions">
+                    <button id="generic-rules-enable-all">Enable all</button>
+                    <button id="generic-rules-disable-all">Disable all</button>
+                </div>
+                <div class="rule-list-status" id="generic-rules-status"></div>
+                <div class="rule-list" id="generic-rules-list"></div>
+            </details>
+
+            <details class="rule-section" id="code-rules-section">
+                <summary>Code-based rules <span id="code-rules-count"></span></summary>
+                <input class="rule-search" type="search" id="code-rules-search" placeholder="Search code-based rules" />
+                <div class="rule-actions">
+                    <button id="code-rules-enable-all">Enable all</button>
+                    <button id="code-rules-disable-all">Disable all</button>
+                </div>
+                <div class="rule-list-status" id="code-rules-status"></div>
+                <div class="rule-list" id="code-rules-list"></div>
+            </details>
+
+            <details class="rule-section" id="consentomatic-rules-section">
+                <summary>Consent-O-Matic rules <span id="consentomatic-rules-count"></span></summary>
+                <input class="rule-search" type="search" id="consentomatic-rules-search" placeholder="Search Consent-O-Matic rules" />
+                <div class="rule-actions">
+                    <button id="consentomatic-rules-enable-all">Enable all</button>
+                    <button id="consentomatic-rules-disable-all">Disable all</button>
+                </div>
+                <div class="rule-list-status" id="consentomatic-rules-status"></div>
+                <div class="rule-list" id="consentomatic-rules-list"></div>
+            </details>
+
+            <div class="rule-section">
+                <input type="checkbox" id="heuristic-action" name="heuristic-action" />
+                <label for="heuristic-action">Handle unknown popups (heuristic rule)</label>
             </div>
         </fieldset>
 

--- a/addon/popup.ts
+++ b/addon/popup.ts
@@ -1,7 +1,24 @@
+/// <reference types="chrome" />
+
 import { BackgroundMessage } from '../lib/messages';
 import { Config } from '../lib/types';
+import type { RuleIndexEntry, RuleIndexSection } from '../rules/rule-index-builder';
 import { storageGet, storageRemove, storageSet } from './mv-compat';
 import { initConfig, isEnabledForDomain, setIsEnabledForDomain, showOptOutStatus } from './utils';
+
+type RuleSection = RuleIndexSection;
+
+type RuleSectionControls = {
+    details: HTMLDetailsElement;
+    count: HTMLSpanElement;
+    search: HTMLInputElement;
+    enableAll: HTMLButtonElement;
+    disableAll: HTMLButtonElement;
+    status: HTMLDivElement;
+    list: HTMLDivElement;
+};
+
+const maxRenderedRules = 100;
 
 async function init() {
     const autoconsentConfig: Config = await storageGet('config');
@@ -16,8 +33,7 @@ async function init() {
     const cosmeticOffRadio = document.querySelector('input#cosmetic-off') as HTMLInputElement;
     const generatedOnRadio = document.querySelector('input#generated-on') as HTMLInputElement;
     const generatedOffRadio = document.querySelector('input#generated-off') as HTMLInputElement;
-    const heuristicActionOnRadio = document.querySelector('input#heuristic-action-on') as HTMLInputElement;
-    const heuristicActionOffRadio = document.querySelector('input#heuristic-action-off') as HTMLInputElement;
+    const heuristicActionCheckbox = document.querySelector('input#heuristic-action') as HTMLInputElement;
     const visualTestOnRadio = document.querySelector('input#visual-test-on') as HTMLInputElement;
     const visualTestOffRadio = document.querySelector('input#visual-test-off') as HTMLInputElement;
     const popupMutationOnRadio = document.querySelector('input#popup-mutation-on') as HTMLInputElement;
@@ -32,6 +48,48 @@ async function init() {
     const logsMessagesCheckbox = document.querySelector('input#logs-messages') as HTMLInputElement;
     const ruleReloadButton = document.querySelector('#reload') as HTMLButtonElement;
     const resetButton = document.querySelector('#reset') as HTMLButtonElement;
+    const ruleSectionControls: Record<RuleSection, RuleSectionControls> = {
+        generated: {
+            details: document.querySelector('#generated-rules-section') as HTMLDetailsElement,
+            count: document.querySelector('#generated-rules-count') as HTMLSpanElement,
+            search: document.querySelector('#generated-rules-search') as HTMLInputElement,
+            enableAll: document.querySelector('#generated-rules-enable-all') as HTMLButtonElement,
+            disableAll: document.querySelector('#generated-rules-disable-all') as HTMLButtonElement,
+            status: document.querySelector('#generated-rules-status') as HTMLDivElement,
+            list: document.querySelector('#generated-rules-list') as HTMLDivElement,
+        },
+        generic: {
+            details: document.querySelector('#generic-rules-section') as HTMLDetailsElement,
+            count: document.querySelector('#generic-rules-count') as HTMLSpanElement,
+            search: document.querySelector('#generic-rules-search') as HTMLInputElement,
+            enableAll: document.querySelector('#generic-rules-enable-all') as HTMLButtonElement,
+            disableAll: document.querySelector('#generic-rules-disable-all') as HTMLButtonElement,
+            status: document.querySelector('#generic-rules-status') as HTMLDivElement,
+            list: document.querySelector('#generic-rules-list') as HTMLDivElement,
+        },
+        code: {
+            details: document.querySelector('#code-rules-section') as HTMLDetailsElement,
+            count: document.querySelector('#code-rules-count') as HTMLSpanElement,
+            search: document.querySelector('#code-rules-search') as HTMLInputElement,
+            enableAll: document.querySelector('#code-rules-enable-all') as HTMLButtonElement,
+            disableAll: document.querySelector('#code-rules-disable-all') as HTMLButtonElement,
+            status: document.querySelector('#code-rules-status') as HTMLDivElement,
+            list: document.querySelector('#code-rules-list') as HTMLDivElement,
+        },
+        consentomatic: {
+            details: document.querySelector('#consentomatic-rules-section') as HTMLDetailsElement,
+            count: document.querySelector('#consentomatic-rules-count') as HTMLSpanElement,
+            search: document.querySelector('#consentomatic-rules-search') as HTMLInputElement,
+            enableAll: document.querySelector('#consentomatic-rules-enable-all') as HTMLButtonElement,
+            disableAll: document.querySelector('#consentomatic-rules-disable-all') as HTMLButtonElement,
+            status: document.querySelector('#consentomatic-rules-status') as HTMLDivElement,
+            list: document.querySelector('#consentomatic-rules-list') as HTMLDivElement,
+        },
+    };
+    let ruleIndexPromise: Promise<RuleIndexEntry[]> | null = null;
+    let ruleIndex: RuleIndexEntry[] | null = null;
+
+    autoconsentConfig.disabledCmps = autoconsentConfig.disabledCmps || [];
 
     // enable proceed button when necessary
 
@@ -106,11 +164,7 @@ async function init() {
         generatedOffRadio.checked = true;
     }
 
-    if (autoconsentConfig.enableHeuristicAction) {
-        heuristicActionOnRadio.checked = true;
-    } else {
-        heuristicActionOffRadio.checked = true;
-    }
+    heuristicActionCheckbox.checked = autoconsentConfig.enableHeuristicAction;
 
     if (autoconsentConfig.visualTest) {
         visualTestOnRadio.checked = true;
@@ -171,11 +225,10 @@ async function init() {
     generatedOffRadio.addEventListener('change', generatedChange);
 
     function heuristicActionChange() {
-        autoconsentConfig.enableHeuristicAction = heuristicActionOnRadio.checked;
+        autoconsentConfig.enableHeuristicAction = heuristicActionCheckbox.checked;
         storageSet({ config: autoconsentConfig });
     }
-    heuristicActionOnRadio.addEventListener('change', heuristicActionChange);
-    heuristicActionOffRadio.addEventListener('change', heuristicActionChange);
+    heuristicActionCheckbox.addEventListener('change', heuristicActionChange);
 
     function visualTestChange() {
         autoconsentConfig.visualTest = visualTestOnRadio.checked;
@@ -226,10 +279,156 @@ async function init() {
         updateLogsConfig();
     });
 
+    async function loadRuleIndex() {
+        if (!ruleIndexPromise) {
+            ruleIndexPromise = fetch('./rule-index.json').then(async (res) => (await res.json()) as RuleIndexEntry[]);
+        }
+        ruleIndex = await ruleIndexPromise;
+        updateRuleCounts();
+        return ruleIndex;
+    }
+
+    function updateRuleCounts() {
+        if (!ruleIndex) {
+            return;
+        }
+        const disabledCmps = autoconsentConfig.disabledCmps || [];
+        (Object.keys(ruleSectionControls) as RuleSection[]).forEach((section) => {
+            const sectionRules = ruleIndex?.filter((rule) => rule.section === section) || [];
+            const disabledInSection = sectionRules.filter((rule) => disabledCmps.includes(rule.name)).length;
+            const count = ruleSectionControls[section].count;
+            count.textContent = `(${disabledInSection}/${sectionRules.length} disabled)`;
+            count.classList.toggle('rule-count-disabled', disabledInSection > 0);
+        });
+    }
+
+    function setRuleEnabled(ruleName: string, enabled: boolean) {
+        const disabledCmps = new Set(autoconsentConfig.disabledCmps || []);
+        if (enabled) {
+            disabledCmps.delete(ruleName);
+        } else {
+            disabledCmps.add(ruleName);
+        }
+        autoconsentConfig.disabledCmps = Array.from(disabledCmps).sort();
+        storageSet({ config: autoconsentConfig });
+        updateRuleCounts();
+    }
+
+    function renderOpenRuleSections() {
+        (Object.keys(ruleSectionControls) as RuleSection[]).forEach((section) => {
+            if (ruleSectionControls[section].details.open) {
+                renderRuleSection(section);
+            }
+        });
+    }
+
+    function setRuleSectionEnabled(section: RuleSection, enabled: boolean) {
+        if (!ruleIndex) {
+            return;
+        }
+
+        const disabledCmps = new Set(autoconsentConfig.disabledCmps || []);
+        ruleIndex
+            .filter((rule) => rule.section === section)
+            .forEach((rule) => {
+                if (enabled) {
+                    disabledCmps.delete(rule.name);
+                } else {
+                    disabledCmps.add(rule.name);
+                }
+            });
+        autoconsentConfig.disabledCmps = Array.from(disabledCmps).sort();
+        storageSet({ config: autoconsentConfig });
+        updateRuleCounts();
+        renderOpenRuleSections();
+    }
+
+    function renderRuleSection(section: RuleSection) {
+        const controls = ruleSectionControls[section];
+        if (!ruleIndex) {
+            controls.status.textContent = 'Rules are not loaded yet.';
+            return;
+        }
+
+        const disabledCmps = autoconsentConfig.disabledCmps || [];
+        const searchQuery = controls.search.value.trim().toLowerCase();
+        const sectionRules = ruleIndex.filter((rule) => rule.section === section);
+        const matchingRules = sectionRules.filter((rule) => {
+            if (!searchQuery) {
+                return disabledCmps.includes(rule.name);
+            }
+            return rule.name.toLowerCase().includes(searchQuery) || !!rule.urlPattern?.toLowerCase().includes(searchQuery);
+        });
+        const renderedRules = matchingRules.slice(0, maxRenderedRules);
+        const disabledInSection = sectionRules.filter((rule) => disabledCmps.includes(rule.name)).length;
+        controls.status.textContent = searchQuery
+            ? `Showing ${renderedRules.length} of ${matchingRules.length} matches. ${disabledInSection} disabled.`
+            : `Showing ${renderedRules.length} of ${disabledInSection} disabled rules. Search to find enabled rules.`;
+        controls.list.replaceChildren(
+            ...renderedRules.map((rule) => {
+                const checkbox = document.createElement('input');
+                checkbox.type = 'checkbox';
+                checkbox.checked = !disabledCmps.includes(rule.name);
+                checkbox.addEventListener('change', () => {
+                    setRuleEnabled(rule.name, checkbox.checked);
+                    renderRuleSection(section);
+                });
+
+                const label = document.createElement('label');
+                label.className = 'rule-row';
+                label.title = rule.urlPattern ? `${rule.name}\n${rule.urlPattern}` : rule.name;
+                label.append(checkbox, document.createTextNode(` ${rule.name}${rule.cosmetic ? ' (cosmetic)' : ''}`));
+                return label;
+            }),
+        );
+    }
+
+    async function loadAndRenderRuleSection(section: RuleSection) {
+        ruleSectionControls[section].status.textContent = 'Loading rules...';
+        try {
+            await loadRuleIndex();
+            renderRuleSection(section);
+        } catch (e) {
+            console.error('Failed to load rule index', e);
+            ruleSectionControls[section].status.textContent = 'Failed to load rules.';
+        }
+    }
+
+    (Object.keys(ruleSectionControls) as RuleSection[]).forEach((section) => {
+        const controls = ruleSectionControls[section];
+        controls.details.addEventListener('toggle', () => {
+            if (controls.details.open) {
+                loadAndRenderRuleSection(section);
+            }
+        });
+        controls.search.addEventListener('input', () => renderRuleSection(section));
+        controls.enableAll.addEventListener('click', async () => {
+            await loadRuleIndex();
+            setRuleSectionEnabled(section, true);
+        });
+        controls.disableAll.addEventListener('click', async () => {
+            await loadRuleIndex();
+            setRuleSectionEnabled(section, false);
+        });
+    });
+
+    loadRuleIndex().catch((e) => {
+        console.error('Failed to load rule index', e);
+    });
+
     ruleReloadButton.addEventListener('click', async () => {
-        const res = await fetch('./rules.json');
-        storageSet({
-            rules: await res.json(),
+        const [compactRulesRes, fullRulesRes] = await Promise.all([fetch('./compact-rules.json'), fetch('./rules.json')]);
+        const fullRules = (await fullRulesRes.json()) as { autoconsent: unknown };
+        await storageSet({
+            rules: await compactRulesRes.json(),
+            fullRules: fullRules.autoconsent,
+        });
+        ruleIndexPromise = null;
+        ruleIndex = null;
+        (Object.keys(ruleSectionControls) as RuleSection[]).forEach((section) => {
+            if (ruleSectionControls[section].details.open) {
+                loadAndRenderRuleSection(section);
+            }
         });
     });
 

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ set -ex
 ESBUILD="node_modules/.bin/esbuild --bundle"
 
 $ESBUILD --format=iife --target=es2021 playwright/content.ts --outfile=dist/autoconsent.playwright.js
+$ESBUILD --format=iife --target=es2021 standalone/content.ts --outfile=dist/autoconsent.standalone.js
 $ESBUILD --format=esm --target=es2021 lib/web-extra.ts --outfile=dist/autoconsent.extra.esm.js
 $ESBUILD --format=cjs --target=es2021 --platform=node lib/web-extra.ts --outfile=dist/autoconsent.extra.cjs.js
 $ESBUILD --format=esm --target=es2021 lib/web.ts --outfile=dist/autoconsent.esm.js

--- a/build.sh
+++ b/build.sh
@@ -26,8 +26,10 @@ cp -r addon/icons dist/addon-mv3/
 cp -r addon/icons dist/addon-firefox/
 cp rules/rules.json dist/addon-mv3/
 cp rules/compact-rules.json dist/addon-mv3/
+cp rules/rule-index.json dist/addon-mv3/
 cp rules/rules.json dist/addon-firefox/
 cp rules/compact-rules.json dist/addon-firefox/
+cp rules/rule-index.json dist/addon-firefox/
 cp addon/popup.html dist/addon-mv3/
 cp addon/popup.html dist/addon-firefox/
 cp -r addon/devtools dist/addon-mv3/

--- a/lib/cmps/conversant.ts
+++ b/lib/cmps/conversant.ts
@@ -41,12 +41,15 @@ export default class Conversant extends AutoConsentCMPBase {
             (<HTMLElement>item.querySelector('.cmp-accordion-item-title')).click();
             await waitFor(() => !!item.querySelector('.cmp-accordion-item-content.cmp-active'), 10, 50);
             const content = item.querySelector('.cmp-accordion-item-content.cmp-active');
+            if (!content) {
+                return false;
+            }
             content
-                .querySelectorAll('.cmp-toggle-actions .cmp-toggle-deny:not(.cmp-toggle-deny--active)')
-                .forEach((e: HTMLElement) => e.click());
+                .querySelectorAll<HTMLElement>('.cmp-toggle-actions .cmp-toggle-deny:not(.cmp-toggle-deny--active)')
+                .forEach((e) => e.click());
             content
-                .querySelectorAll('.cmp-toggle-actions .cmp-toggle-checkbox:not(.cmp-toggle-checkbox--active)')
-                .forEach((e: HTMLElement) => e.click());
+                .querySelectorAll<HTMLElement>('.cmp-toggle-actions .cmp-toggle-checkbox:not(.cmp-toggle-checkbox--active)')
+                .forEach((e) => e.click());
             // await waitFor(() => !item.querySelector('.cmp-toggle-deny--active,.cmp-toggle-checkbox--active'), 5, 50); // this may take a long time
         }
         await this.click('.cmp-main-button:not(.cmp-main-button--primary)');

--- a/lib/cmps/trustarc-top.ts
+++ b/lib/cmps/trustarc-top.ts
@@ -18,7 +18,7 @@ export default class TrustArcTop extends AutoConsentCMPBase {
         frame: false,
     };
 
-    _shortcutButton: HTMLElement;
+    _shortcutButton: HTMLElement | null;
     _optInDone: boolean;
 
     constructor(autoconsentInstance: AutoConsent) {

--- a/lib/cmps/uniconsent.ts
+++ b/lib/cmps/uniconsent.ts
@@ -29,8 +29,8 @@ export default class Uniconsent extends AutoConsentCMPBase {
 
     async optOut() {
         await this.waitForElement('.unic button', 1000);
-        document.querySelectorAll('.unic button').forEach((button: HTMLButtonElement) => {
-            const text = button.textContent;
+        document.querySelectorAll<HTMLButtonElement>('.unic button').forEach((button) => {
+            const text = button.textContent || '';
             if (text.includes('Manage Options') || text.includes('Optionen verwalten')) {
                 button.click();
             }
@@ -39,14 +39,14 @@ export default class Uniconsent extends AutoConsentCMPBase {
         if (await this.waitForElement('.unic input[type=checkbox]', 1000)) {
             await this.waitForElement('.unic button', 1000);
 
-            document.querySelectorAll('.unic input[type=checkbox]').forEach((c: HTMLInputElement) => {
+            document.querySelectorAll<HTMLInputElement>('.unic input[type=checkbox]').forEach((c) => {
                 if (c.checked) {
                     c.click();
                 }
             });
 
             for (const b of <NodeListOf<HTMLButtonElement>>document.querySelectorAll('.unic button')) {
-                const text = b.textContent;
+                const text = b.textContent || '';
                 for (const pattern of ['Confirm Choices', 'Save Choices', 'Auswahl speichern']) {
                     if (text.includes(pattern)) {
                         b.click();

--- a/lib/eval-handler.ts
+++ b/lib/eval-handler.ts
@@ -5,8 +5,8 @@ import { getRandomID } from './random';
 class Deferred<T> {
     id: string;
     promise: Promise<T>;
-    resolve: (value?: T) => void;
-    reject: (reason?: any) => void;
+    resolve!: (value: T) => void;
+    reject!: (reason?: unknown) => void;
     timer: number;
 
     constructor(id: string, timeout = 1000) {
@@ -23,7 +23,7 @@ class Deferred<T> {
 
 type EvalState = {
     pending: Map<string, Deferred<boolean>>;
-    sendContentMessage: (message: ContentScriptMessage) => void;
+    sendContentMessage: ((message: ContentScriptMessage) => void) | null;
 };
 
 export const evalState: EvalState = {
@@ -32,6 +32,9 @@ export const evalState: EvalState = {
 };
 
 export function requestEval(code: string, snippetId?: keyof typeof snippets): Promise<boolean> {
+    if (!evalState.sendContentMessage) {
+        return Promise.reject(new Error('AutoConsent is not initialized yet'));
+    }
     const id = getRandomID();
     evalState.sendContentMessage({
         type: 'eval',

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -114,13 +114,18 @@ export function scheduleWhenIdle(callback: () => void, timeout = 500) {
     }
 }
 
+type HighlightedHTMLElement = HTMLElement & {
+    __oldStyles?: string;
+};
+
 export function highlightNode(node: HTMLElement) {
+    const highlightedNode = node as HighlightedHTMLElement;
     if (!node.style) return;
-    if (node.__oldStyles !== undefined) {
+    if (highlightedNode.__oldStyles !== undefined) {
         return; // already highlighted
     }
     if (node.hasAttribute('style')) {
-        node.__oldStyles = node.style.cssText;
+        highlightedNode.__oldStyles = node.style.cssText;
     }
     node.style.animation = 'pulsate .5s infinite';
     node.style.outline = 'solid red';
@@ -151,10 +156,11 @@ export function highlightNode(node: HTMLElement) {
 }
 
 export function unhighlightNode(node: HTMLElement) {
+    const highlightedNode = node as HighlightedHTMLElement;
     if (!node.style || !node.hasAttribute('style')) return;
-    if (node.__oldStyles !== undefined) {
-        node.style.cssText = node.__oldStyles;
-        delete node.__oldStyles;
+    if (highlightedNode.__oldStyles !== undefined) {
+        node.style.cssText = highlightedNode.__oldStyles;
+        delete highlightedNode.__oldStyles;
     } else {
         node.removeAttribute('style');
     }

--- a/rules/build.ts
+++ b/rules/build.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import https from 'https';
 import { encodeRules, deduplicateRules } from '../lib/encoding';
 import { AutoConsentCMPRule } from '../lib/rules';
+import { buildRuleIndex } from './rule-index-builder';
 
 export const rulesDir = __dirname;
 
@@ -61,6 +62,9 @@ export async function buildConsentOMaticRules() {
 
     fs.writeFile(path.join(rulesDir, 'rules.json'), stringify({ autoconsent }), () => console.log('Written rules.json'));
     fs.writeFile(path.join(rulesDir, 'consentomatic.json'), stringify({ consentomatic }), () => console.log('Written consentomatic.json'));
+    fs.writeFile(path.join(rulesDir, 'rule-index.json'), stringify(buildRuleIndex(autoconsent, consentomatic)), () =>
+        console.log('Written rule-index.json'),
+    );
     fs.writeFile(compactRulesPath, stringify(encodeRules(autoconsent, existingCompactRules)), () =>
         console.log('Written compact-rules.json'),
     );

--- a/rules/rule-index-builder.ts
+++ b/rules/rule-index-builder.ts
@@ -1,0 +1,63 @@
+import { dynamicCMPs } from '../lib/cmps/all';
+import { AutoConsentCMPRule } from '../lib/rules';
+import AutoConsent from '../lib/web';
+
+export type RuleIndexSection = 'generated' | 'generic' | 'code' | 'consentomatic';
+
+// Lightweight popup manifest entry. This is only for listing/toggling rules;
+// execution still uses rules.json, compact-rules.json, code CMPs, and Consent-O-Matic bundles.
+export type RuleIndexEntry = {
+    // Matches AutoCMP.name at runtime, so toggles can reuse Config.disabledCmps.
+    name: string;
+    // Popup-only grouping; runtime rule loading still uses the existing rule bundles.
+    section: RuleIndexSection;
+    // Included for site-specific search/tooltip context without loading full rules.json.
+    urlPattern?: string;
+    // Lets the popup flag cosmetic rules while keeping the index small.
+    cosmetic?: boolean;
+};
+
+type DynamicCMPMetadata = {
+    name: string;
+};
+
+function buildCodeBasedRuleMetadata(): DynamicCMPMetadata[] {
+    const autoconsent = null as unknown as AutoConsent;
+    return dynamicCMPs.map((Cmp) => ({
+        name: new Cmp(autoconsent).name,
+    }));
+}
+
+export function buildRuleIndex(rules: AutoConsentCMPRule[], consentomatic: Record<string, object>): RuleIndexEntry[] {
+    const codeBasedRules: RuleIndexEntry[] = buildCodeBasedRuleMetadata().map((rule) => ({
+        name: rule.name,
+        section: 'code',
+    }));
+    const consentomaticRules: RuleIndexEntry[] = Object.keys(consentomatic).map((name) => ({
+        name: `com_${name}`,
+        section: 'consentomatic',
+    }));
+
+    return [
+        ...codeBasedRules,
+        ...consentomaticRules,
+        ...rules.map((rule) => {
+            const entry: RuleIndexEntry = {
+                name: rule.name,
+                section: rule.name.startsWith('auto_') ? 'generated' : 'generic',
+            };
+            if (rule.runContext?.urlPattern) {
+                entry.urlPattern = rule.runContext.urlPattern;
+            }
+            if (rule.cosmetic !== undefined) {
+                entry.cosmetic = rule.cosmetic;
+            }
+            return entry;
+        }),
+    ].sort((a, b) => {
+        if (a.section !== b.section) {
+            return a.section.localeCompare(b.section);
+        }
+        return a.name.localeCompare(b.name);
+    });
+}

--- a/standalone/content.ts
+++ b/standalone/content.ts
@@ -1,0 +1,103 @@
+import AutoConsent from '../lib/web';
+import { filterCompactRules, type IndexedCMPRuleset } from '../lib/encoding';
+import { BackgroundMessage, ContentScriptMessage } from '../lib/messages';
+import { Config, RuleBundle } from '../lib/types';
+import compactRules from '../rules/compact-rules.json';
+import { consentomatic } from '../rules/consentomatic.json';
+
+declare global {
+    interface Window {
+        autoconsentReceiveMessage: (message: BackgroundMessage) => Promise<void>;
+        autoconsentStandalone?: {
+            instance: AutoConsent;
+            messages: ContentScriptMessage[];
+        };
+    }
+}
+
+function isMainFrame() {
+    return window.top === window;
+}
+
+function buildRules(): RuleBundle {
+    return {
+        autoconsent: [],
+        consentomatic,
+        compact: filterCompactRules(compactRules as IndexedCMPRuleset, {
+            url: window.location.href,
+            mainFrame: isMainFrame(),
+        }),
+    };
+}
+
+function logMessage(message: ContentScriptMessage) {
+    switch (message.type) {
+        case 'cmpDetected':
+            console.log(`autoconsent detected CMP: ${message.cmp}`);
+            break;
+        case 'popupFound':
+            console.log(`autoconsent found popup: ${message.cmp}`);
+            break;
+        case 'optOutResult':
+            console.log(`autoconsent opt-out result: ${message.cmp}`, message.result);
+            break;
+        case 'autoconsentDone':
+            console.log(`autoconsent done: ${message.cmp}`, {
+                duration: message.duration,
+                totalClicks: message.totalClicks,
+            });
+            break;
+        case 'autoconsentError':
+            console.warn('autoconsent error', message.details);
+            break;
+    }
+}
+
+if (!window.autoconsentReceiveMessage) {
+    const config: Partial<Config> = {
+        isMainWorld: true,
+        enableHeuristicDetection: true,
+        enableHeuristicAction: true,
+        enablePopupMutationObserver: false,
+        logs: {
+            lifecycle: true,
+            rulesteps: true,
+            detectionsteps: false,
+            evals: false,
+            errors: true,
+            messages: false,
+            waits: true,
+        },
+    };
+    const rules = buildRules();
+    const messages: ContentScriptMessage[] = [];
+    const consentRef: { current?: AutoConsent } = {};
+
+    window.autoconsentReceiveMessage = async (message: BackgroundMessage) => {
+        if (!consentRef.current) {
+            throw new Error('autoconsent is not initialized yet');
+        }
+        await consentRef.current.receiveMessageCallback(message);
+    };
+
+    const sendMessage = async (message: ContentScriptMessage) => {
+        messages.push(message);
+        logMessage(message);
+    };
+
+    const consent = new AutoConsent(sendMessage);
+    consentRef.current = consent;
+    window.autoconsentStandalone = {
+        instance: consent,
+        messages,
+    };
+    consent.initialize(config, rules);
+
+    console.log('autoconsent standalone initialized', {
+        instanceId: consent.id,
+        rules: rules.compact?.r.length ?? 0,
+        url: window.location.href,
+    });
+} else {
+    console.warn('autoconsent already initialized', window.autoconsentReceiveMessage);
+}


### PR DESCRIPTION
Task/Issue URL:

## Description:
Add a standalone bundle and rule filtering in the addon

## Steps to test this PR:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Popup and reload paths change how rules are loaded and how disabledCmps is edited at scale; mistakes could skip CMPs on sites, but execution still uses existing bundles and filtering logic.
> 
> **Overview**
> Adds a **standalone** `autoconsent.standalone.js` bundle that initializes AutoConsent in the page with **URL-filtered compact rules** and console logging, for testing without the extension background.
> 
> The extension **popup** gains a **Rules** section: collapsible lists for generated, generic, code-based, and Consent-O-Matic rules backed by a new **`rule-index.json`** (built in `rules/build.ts` via `buildRuleIndex`). Users can search, toggle individual rules, and enable/disable whole sections by updating **`config.disabledCmps`** (same mechanism the runtime already uses). **Reload rules** now stores both **compact** and **full** rule payloads. Heuristic handling moves from on/off radios to a single checkbox under Rules.
> 
> **Build/packaging** copies `rule-index.json` into MV3 and Firefox addon dists and ignores it in git. Small **TypeScript** hardening in a few CMP handlers, `eval-handler`, and debug highlight helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58b8a567521404f737832aee04cf95a491ddd0a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->