### PR TITLE
Add independer.nl rule for custom cookie banner

### DIFF
--- a/rules/generated/auto_NL_independer.nl_ind.json
+++ b/rules/generated/auto_NL_independer.nl_ind.json
@@ -1,0 +1,40 @@
+{
+    "name": "auto_NL_independer.nl_ind",
+    "cosmetic": false,
+    "_metadata": {
+        "vendorUrl": "https://www.independer.nl/"
+    },
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?independer\\.nl/"
+    },
+    "prehideSelectors": [".ind-cbar[data-testid=\"ind-cbar\"]"],
+    "detectCmp": [
+        {
+            "exists": ".ind-cbar[data-testid=\"ind-cbar\"] button[save-cookie][data-value=\"0\"]"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": ".ind-cbar[data-testid=\"ind-cbar\"] button[save-cookie][data-value=\"0\"]"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": ".ind-cbar[data-testid=\"ind-cbar\"] button[save-cookie][data-value=\"1\"]"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": ".ind-cbar[data-testid=\"ind-cbar\"] button[save-cookie][data-value=\"0\"]"
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": ".ind-cbar[data-testid=\"ind-cbar\"]",
+            "check": "none",
+            "timeout": 2000
+        }
+    ]
+}

--- a/tests/generated/auto_NL_independer.nl_ind.spec.ts
+++ b/tests/generated/auto_NL_independer.nl_ind.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../../playwright/runner';
+generateCMPTests('auto_NL_independer.nl_ind', ['https://www.independer.nl/mijnindepender/inloggen'], {
+    testOptIn: false,
+    testSelfTest: true,
+    onlyRegions: ['NL'],
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1215358641230241?focus=true

## Description:

independer.nl uses a custom, site-specific cookie banner (`.ind-cbar`) whose reject button text is "Liever niet" — a phrasing not covered by the heuristic Dutch reject patterns, so the popup was being ignored by autoconsent.

Add a dedicated JSON rule that detects the banner and clicks the reject button, properly persisting the user's choice via the site's `Independer.Cookies.CookieUserAuthorisation` cookie.

## Steps to test this PR:

1. `npm run prepublish`
2. `REGION=NL npx playwright test tests/generated/auto_NL_independer.nl_ind.spec.ts --project chrome`
3. Load the extension in a browser and visit https://www.independer.nl/mijnindepender/inloggen — banner should be dismissed automatically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated new CMP rule and test with no changes to shared consent or auth logic.
> 
> **Overview**
> Adds a **Netherlands-only** autoconsent rule for **independer.nl** so the custom `.ind-cbar` banner is handled when generic Dutch reject heuristics miss the **"Liever niet"** reject control.
> 
> The rule **prehides** the bar, **detects** it via the reject button (`button[save-cookie][data-value="0"]`), and **clicks** that button on opt-out (or `data-value="1"` on opt-in). A generated Playwright spec runs against the login URL with **opt-out/self-test** coverage and **`onlyRegions: ['NL']`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3703ed1bad7302ee7cd2fa9f6a43d5ac39fef1fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->