### PR TITLE
Improve checkHeuristicPatterns performance.

### DIFF
--- a/lib/heuristics.ts
+++ b/lib/heuristics.ts
@@ -5,16 +5,25 @@ import { isElementVisible, isTopFrame } from './utils';
 const BUTTON_LIKE_ELEMENT_SELECTOR = 'button, input[type="button"], input[type="submit"], a, [role="button"], [class*="button"]';
 const TEXT_LIMIT = 100000;
 
-export function checkHeuristicPatterns(allText: string, detectPatterns = DETECT_PATTERNS) {
+export function checkHeuristicPatterns(
+    allText: string,
+    detectPatterns = DETECT_PATTERNS,
+    { includeSnippets = true, allMatches = true } = {},
+) {
     allText = allText.slice(0, TEXT_LIMIT);
     const patterns = [];
     const snippets = [];
 
     for (const p of detectPatterns) {
-        const matches = allText?.match(p);
+        const matches = includeSnippets ? allText?.match(p) : p.test(allText);
         if (matches) {
             patterns.push(p.toString());
-            snippets.push(...matches.map((m) => m.substring(0, 200)));
+            if (includeSnippets) {
+                snippets.push(...(matches as RegExpMatchArray).map((m) => m.substring(0, 200)));
+            }
+            if (!allMatches) {
+                break;
+            }
         }
     }
     return { patterns, snippets };
@@ -25,7 +34,7 @@ export function getActionablePopups(): PopupData[] {
     const result = popups.reduce((acc, popup) => {
         const popupText = popup.text?.trim();
         if (popupText) {
-            const { patterns } = checkHeuristicPatterns(popupText);
+            const { patterns } = checkHeuristicPatterns(popupText, DETECT_PATTERNS, { includeSnippets: false, allMatches: false });
             if (patterns.length > 0) {
                 const { rejectButtons, otherButtons } = classifyButtons(popup.buttons);
                 if (rejectButtons.length > 0) {

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -11,6 +11,7 @@ import { isTopFrame, normalizeConfig, scheduleWhenIdle } from './utils';
 import { FiltersEngine } from '@ghostery/adblocker';
 import { checkHeuristicPatterns } from './heuristics';
 import { decodeRules } from './encoding';
+import { DETECT_PATTERNS } from './heuristic-patterns';
 
 // Re-export types and functions for external use
 export { snippets as evalSnippets } from './eval-snippets';
@@ -352,7 +353,11 @@ export default class AutoConsent {
 
     detectHeuristics() {
         if (this.config.enableHeuristicDetection) {
-            const { patterns, snippets } = checkHeuristicPatterns(document.documentElement?.innerText || '');
+            // Unless extended logging is enabled, we don't need to include snippets and all matches
+            const { patterns, snippets } = checkHeuristicPatterns(document.documentElement?.innerText || '', DETECT_PATTERNS, {
+                includeSnippets: this.config.logs.lifecycle || false,
+                allMatches: this.config.logs.lifecycle || false,
+            });
             if (
                 patterns.length > 0 &&
                 (patterns.length !== this.state.heuristicPatterns.length || this.state.heuristicPatterns.some((p, i) => p !== patterns[i]))

--- a/tests-wtr/heuristics/heuristics-utils.test.ts
+++ b/tests-wtr/heuristics/heuristics-utils.test.ts
@@ -11,33 +11,52 @@ import {
 } from '../../lib/heuristics';
 
 describe('checkHeuristicPatterns', () => {
-    it('detects cookie-related text', () => {
-        const { patterns, snippets } = checkHeuristicPatterns('We use cookies here', [/we use cookies/gi]);
+    const optionPermutations = [
+        { includeSnippets: true, allMatches: true },
+        { includeSnippets: true, allMatches: false },
+        { includeSnippets: false, allMatches: true },
+        { includeSnippets: false, allMatches: false },
+    ] as const;
 
-        expect(patterns.length).to.be.greaterThan(0);
-        expect(snippets.length).to.be.greaterThan(0);
-    });
+    for (const options of optionPermutations) {
+        const label = `includeSnippets=${options.includeSnippets}, allMatches=${options.allMatches}`;
 
-    it('returns empty arrays for unrelated text', () => {
-        const { patterns, snippets } = checkHeuristicPatterns('Welcome to our website', [/we use cookies/gi]);
+        it(`detects cookie-related text (${label})`, () => {
+            const { patterns, snippets } = checkHeuristicPatterns('We use cookies here', [/we use cookies/gi], options);
 
-        expect(patterns).to.have.length(0);
-        expect(snippets).to.have.length(0);
-    });
+            expect(patterns.length).to.be.greaterThan(0);
+            if (options.includeSnippets) {
+                expect(snippets.length).to.be.greaterThan(0);
+            } else {
+                expect(snippets).to.have.length(0);
+            }
+        });
 
-    it('returns empty arrays for empty text', () => {
-        const { patterns, snippets } = checkHeuristicPatterns('', [/we use cookies/gi]);
+        it(`returns empty arrays for unrelated text (${label})`, () => {
+            const { patterns, snippets } = checkHeuristicPatterns('Welcome to our website', [/we use cookies/gi], options);
 
-        expect(patterns).to.have.length(0);
-        expect(snippets).to.have.length(0);
-    });
+            expect(patterns).to.have.length(0);
+            expect(snippets).to.have.length(0);
+        });
 
-    it('does not match after the text limit', () => {
-        const { patterns, snippets } = checkHeuristicPatterns('X'.repeat(100000) + 'We use cookies here', [/we use cookies/gi]);
+        it(`returns empty arrays for empty text (${label})`, () => {
+            const { patterns, snippets } = checkHeuristicPatterns('', [/we use cookies/gi], options);
 
-        expect(patterns).to.have.length(0);
-        expect(snippets).to.have.length(0);
-    });
+            expect(patterns).to.have.length(0);
+            expect(snippets).to.have.length(0);
+        });
+
+        it(`does not match after the text limit (${label})`, () => {
+            const { patterns, snippets } = checkHeuristicPatterns(
+                'X'.repeat(100000) + 'We use cookies here',
+                [/we use cookies/gi],
+                options,
+            );
+
+            expect(patterns).to.have.length(0);
+            expect(snippets).to.have.length(0);
+        });
+    }
 });
 
 describe('cleanButtonText', () => {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1163321984198618/task/1215327929738869?focus=true

## Description:
Improve performance of `checkHeuristicPatterns`. This function is called frequently on page load and, in the worst case, needs to check ~80 regexes on a 100k string. We can optimize it by always doing the minimal work:
 1. We only need all the matches when debugging the module, everywhere use we just check that `patterns > 0`. Therefore, except when logging flags are set, we can just exit as soon as the first regex matches.
 2. Likewise, we only need the actual matched text snippets when logging. When they're not needed we can switch to Regex `test` (instead of `match`) which is faster.

## Steps to test this PR:

