### PR TITLE
Improve heuristic detection performance

### DIFF
--- a/lib/cmps/base.ts
+++ b/lib/cmps/base.ts
@@ -441,7 +441,9 @@ export class AutoConsentHeuristicCMP extends AutoConsentCMPBase {
         return false;
     }
 
-    detectCmp(): Promise<boolean> {
+    async detectCmp(): Promise<boolean> {
+        // wait for one tick to deprioritize heavy DOM operations
+        await new Promise((resolve) => setTimeout(resolve, 0));
         this.autoconsent.config.performanceLoggingEnabled && performance.mark('heuristicDetectorStart');
         this.popups = getActionablePopups();
         this.autoconsent.config.performanceLoggingEnabled && performance.mark('heuristicDetectorEnd');

--- a/lib/cmps/base.ts
+++ b/lib/cmps/base.ts
@@ -445,7 +445,7 @@ export class AutoConsentHeuristicCMP extends AutoConsentCMPBase {
         // wait for one tick to deprioritize heavy DOM operations
         await new Promise((resolve) => setTimeout(resolve, 0));
         this.autoconsent.config.performanceLoggingEnabled && performance.mark('heuristicDetectorStart');
-        this.popups = getActionablePopups();
+        this.popups = getActionablePopups(this.autoconsent.config.heuristicPopupSearchTimeout);
         this.autoconsent.config.performanceLoggingEnabled && performance.mark('heuristicDetectorEnd');
         this.autoconsent.config.performanceLoggingEnabled &&
             performance.measure('heuristicDetector', 'heuristicDetectorStart', 'heuristicDetectorEnd');

--- a/lib/heuristics.ts
+++ b/lib/heuristics.ts
@@ -162,10 +162,15 @@ function getPopupLikeElements(): HTMLElement[] {
             },
         },
     );
-
+    const startTime = performance.now();
     const found = [];
     for (let node = walker.nextNode(); node; node = walker.nextNode()) {
         found.push(node as HTMLElement);
+        // exit after 10ms to avoid blocking the main thread
+        if (performance.now() - startTime > 10) {
+            console.log('heuristic timeout');
+            break;
+        }
     }
     return excludeContainers(found);
 }

--- a/lib/heuristics.ts
+++ b/lib/heuristics.ts
@@ -21,8 +21,8 @@ export function checkHeuristicPatterns(allText: string, detectPatterns = DETECT_
     return { patterns, snippets };
 }
 
-export function getActionablePopups(): PopupData[] {
-    const popups = getPotentialPopups();
+export function getActionablePopups(timeout = POPUP_SEARCH_MAX_TIME): PopupData[] {
+    const popups = getPotentialPopups(timeout);
     const result = popups.reduce((acc, popup) => {
         const popupText = popup.text?.trim();
         if (popupText) {
@@ -89,20 +89,20 @@ export function cleanButtonText(buttonText: string): string {
     return result;
 }
 
-function getPotentialPopups() {
+function getPotentialPopups(timeout = POPUP_SEARCH_MAX_TIME) {
     const isFramed = !isTopFrame();
     // do not inspect frames that are more than one level deep
     if (isFramed && window.parent && window.parent !== window.top) {
         return [];
     }
 
-    return collectPotentialPopups(isFramed);
+    return collectPotentialPopups(isFramed, timeout);
 }
 
-function collectPotentialPopups(isFramed: boolean): PopupData[] {
+function collectPotentialPopups(isFramed: boolean, timeout = POPUP_SEARCH_MAX_TIME): PopupData[] {
     let elements = [];
     if (!isFramed) {
-        elements = getPopupLikeElements();
+        elements = getPopupLikeElements(timeout);
     } else {
         // for iframes, just take the whole document
         const doc = document.body || document.documentElement;
@@ -141,7 +141,7 @@ export function isDialogLikeElement(node: HTMLElement): boolean {
  * Heuristic to get all elements that look like "popups"
  * TODO: this heuristic is too strict, not all popups are actually sticky/fixed
  */
-function getPopupLikeElements(): HTMLElement[] {
+function getPopupLikeElements(timeout = POPUP_SEARCH_MAX_TIME): HTMLElement[] {
     const startTime = performance.now();
     const walker = document.createTreeWalker(
         document.documentElement,
@@ -161,7 +161,7 @@ function getPopupLikeElements(): HTMLElement[] {
                     }
                 }
                 // start rejecting after POPUP_SEARCH_MAX_TIME to avoid blocking the main thread
-                if (performance.now() - startTime > POPUP_SEARCH_MAX_TIME) {
+                if (performance.now() - startTime > timeout) {
                     return NodeFilter.FILTER_REJECT;
                 }
                 return NodeFilter.FILTER_SKIP;

--- a/lib/heuristics.ts
+++ b/lib/heuristics.ts
@@ -160,7 +160,7 @@ function getPopupLikeElements(): HTMLElement[] {
                         return NodeFilter.FILTER_ACCEPT;
                     }
                 }
-                // start rejecting after 5ms to avoid blocking the main thread
+                // start rejecting after POPUP_SEARCH_MAX_TIME to avoid blocking the main thread
                 if (performance.now() - startTime > POPUP_SEARCH_MAX_TIME) {
                     return NodeFilter.FILTER_REJECT;
                 }

--- a/lib/heuristics.ts
+++ b/lib/heuristics.ts
@@ -4,7 +4,7 @@ import { isElementVisible, isTopFrame } from './utils';
 
 const BUTTON_LIKE_ELEMENT_SELECTOR = 'button, input[type="button"], input[type="submit"], a, [role="button"], [class*="button"]';
 const TEXT_LIMIT = 100000;
-const POPUP_SEARCH_MAX_TIME = 10;
+const POPUP_SEARCH_MAX_TIME = 100;
 
 export function checkHeuristicPatterns(allText: string, detectPatterns = DETECT_PATTERNS) {
     allText = allText.slice(0, TEXT_LIMIT);

--- a/lib/heuristics.ts
+++ b/lib/heuristics.ts
@@ -4,6 +4,7 @@ import { isElementVisible, isTopFrame } from './utils';
 
 const BUTTON_LIKE_ELEMENT_SELECTOR = 'button, input[type="button"], input[type="submit"], a, [role="button"], [class*="button"]';
 const TEXT_LIMIT = 100000;
+const POPUP_SEARCH_MAX_TIME = 10;
 
 export function checkHeuristicPatterns(allText: string, detectPatterns = DETECT_PATTERNS) {
     allText = allText.slice(0, TEXT_LIMIT);
@@ -141,6 +142,7 @@ export function isDialogLikeElement(node: HTMLElement): boolean {
  * TODO: this heuristic is too strict, not all popups are actually sticky/fixed
  */
 function getPopupLikeElements(): HTMLElement[] {
+    const startTime = performance.now();
     const walker = document.createTreeWalker(
         document.documentElement,
         NodeFilter.SHOW_ELEMENT, // visit only element nodes
@@ -158,19 +160,17 @@ function getPopupLikeElements(): HTMLElement[] {
                         return NodeFilter.FILTER_ACCEPT;
                     }
                 }
+                // start rejecting after 5ms to avoid blocking the main thread
+                if (performance.now() - startTime > POPUP_SEARCH_MAX_TIME) {
+                    return NodeFilter.FILTER_REJECT;
+                }
                 return NodeFilter.FILTER_SKIP;
             },
         },
     );
-    const startTime = performance.now();
     const found = [];
     for (let node = walker.nextNode(); node; node = walker.nextNode()) {
         found.push(node as HTMLElement);
-        // exit after 10ms to avoid blocking the main thread
-        if (performance.now() - startTime > 10) {
-            console.log('heuristic timeout');
-            break;
-        }
     }
     return excludeContainers(found);
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -77,6 +77,7 @@ export type Config = {
         waits: boolean;
     };
     performanceLoggingEnabled: boolean;
+    heuristicPopupSearchTimeout: number;
 };
 
 export type LifecycleState =

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -94,6 +94,7 @@ export function normalizeConfig(providedConfig: any): Config {
             waits: false,
         },
         performanceLoggingEnabled: false,
+        heuristicPopupSearchTimeout: 100,
     };
     const updatedConfig: Config = copyObject(defaultConfig);
     // filter out any unknown entries

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -294,8 +294,8 @@ export default class AutoConsent {
                 }
             }
         });
-        // heuristic CMP is only run in the top frame and only if heuristic action is enabled
-        const heuristicRules = isTop && this.config.enableHeuristicAction ? [new AutoConsentHeuristicCMP(this)] : [];
+        // heuristic CMP is only run in the top frame and only if heuristic action is enabled and retries is odd
+        const heuristicRules = isTop && this.config.enableHeuristicAction && retries % 2 === 1 ? [new AutoConsentHeuristicCMP(this)] : [];
 
         const rulesPriorityStages: [string, AutoCMP[]][] = [
             ['site-specific', siteSpecificRules],

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -351,8 +351,12 @@ export default class AutoConsent {
             // if we didn't find a CMP, try again
             // We wait 500ms, and also for some kind of dom mutation to happen before
             // rerunning the findCmp check
+            const waitFor: Promise<boolean>[] = [this.domActions.wait(500)];
+            if (retries !== this.config.detectRetries) {
+                waitFor.push(mutationObserver);
+            }
             try {
-                await Promise.all([this.domActions.wait(500), mutationObserver]);
+                await Promise.all(waitFor);
             } catch (e) {
                 // timeout waiting for mutation - break out of detection
                 return [];

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -295,7 +295,8 @@ export default class AutoConsent {
             }
         });
         // heuristic CMP is only run in the top frame and only if heuristic action is enabled and retries is odd
-        const heuristicRules = isTop && this.config.enableHeuristicAction && retries % 2 === 1 ? [new AutoConsentHeuristicCMP(this)] : [];
+        const heuristicRules =
+            isTop && this.config.enableHeuristicAction && this.state.findCmpAttempts % 2 === 0 ? [new AutoConsentHeuristicCMP(this)] : [];
 
         const rulesPriorityStages: [string, AutoCMP[]][] = [
             ['site-specific', siteSpecificRules],
@@ -352,7 +353,7 @@ export default class AutoConsent {
             // We wait 500ms, and also for some kind of dom mutation to happen before
             // rerunning the findCmp check
             const waitFor: Promise<boolean>[] = [this.domActions.wait(500)];
-            if (retries !== this.config.detectRetries) {
+            if (this.state.findCmpAttempts > 1) {
                 waitFor.push(mutationObserver);
             }
             try {

--- a/tests-wtr/lifecycle/find-cmp.ts
+++ b/tests-wtr/lifecycle/find-cmp.ts
@@ -156,6 +156,8 @@ describe('Autoconsent.findCmp', () => {
                 optIn: [],
                 optOut: [],
             });
+            // force findCmpAttempts to 1 so heuristic CMP is run on the first attempt
+            autoconsent.state.findCmpAttempts = 1;
             const found = await autoconsent.findCmp(1);
 
             expect(found).to.have.length(1);

--- a/tests-wtr/lifecycle/find-cmp.ts
+++ b/tests-wtr/lifecycle/find-cmp.ts
@@ -156,7 +156,7 @@ describe('Autoconsent.findCmp', () => {
                 optIn: [],
                 optOut: [],
             });
-            const found = await autoconsent.findCmp(0);
+            const found = await autoconsent.findCmp(1);
 
             expect(found).to.have.length(1);
             expect(found[0].name).to.equal('HEURISTIC');


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1163321984198618/task/1215327929738869?focus=true

## Description:
The heuristic detector runs `getPopupLikeElements` which scans the DOM for fixed or sticky positioned elements. This is a synchronous operation that can block other page scripts, and affect performance on large pages.

This PR addresses performance issues by:
1. Only running the heuristic detection half as much (skipping the first detection iteration and every other iteration after that).
2. Bailing out of the tree walk if it takes longer than 10ms.
3. Ensure that the scan is at the end of the event queue, by running `setTimeout` at the start of detection.

## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Heuristic consent handling may run later or miss popups on very large/slow pages due to scan timeouts and running only on even findCmp attempts.
> 
> **Overview**
> Reduces main-thread impact from **heuristic consent popup detection** by scheduling work later, capping DOM scan time, and running the heuristic CMP less often during `findCmp` retries.
> 
> **Heuristic scan:** `getActionablePopups` / `getPopupLikeElements` now accept a configurable **`heuristicPopupSearchTimeout`** (default **100ms**). The tree walk starts returning `FILTER_REJECT` once elapsed time exceeds that budget so large pages cannot scan indefinitely. **`AutoConsentHeuristicCMP.detectCmp`** is **`async`** and **`await`s `setTimeout(0)`** before scanning so the heavy walk runs after the current event-queue work.
> 
> **`findCmp` scheduling:** The heuristic rule is included only when **`findCmpAttempts % 2 === 0`** (skips every other attempt, including the first). On retries, the code still waits **500ms**, but the **mutation observer** is only waited on when **`findCmpAttempts > 1`**, so the first retry does not block on DOM mutations.
> 
> Tests set **`findCmpAttempts = 1`** so heuristic detection still runs in the “no declarative match” case under the new even-attempt rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a6ab069630a66379f976efb36a54bb6ea09ffff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->