### PR TITLE
Add GPC signals to test extension

### DIFF
--- a/addon/gpc-rules.json
+++ b/addon/gpc-rules.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": 1,
+    "priority": 40000,
+    "action": {
+      "type": "modifyHeaders",
+      "requestHeaders": [
+        {
+          "header": "Sec-GPC",
+          "operation": "set",
+          "value": "1"
+        }
+      ]
+    },
+    "condition": {
+      "urlFilter": "*",
+      "resourceTypes": [
+        "main_frame",
+        "sub_frame",
+        "stylesheet",
+        "script",
+        "image",
+        "font",
+        "object",
+        "xmlhttprequest",
+        "ping",
+        "csp_report",
+        "media",
+        "websocket",
+        "webtransport",
+        "webbundle",
+        "other"
+      ]
+    }
+  }
+]

--- a/addon/gpc-rules.json
+++ b/addon/gpc-rules.json
@@ -1,36 +1,36 @@
 [
-  {
-    "id": 1,
-    "priority": 40000,
-    "action": {
-      "type": "modifyHeaders",
-      "requestHeaders": [
-        {
-          "header": "Sec-GPC",
-          "operation": "set",
-          "value": "1"
+    {
+        "id": 1,
+        "priority": 40000,
+        "action": {
+            "type": "modifyHeaders",
+            "requestHeaders": [
+                {
+                    "header": "Sec-GPC",
+                    "operation": "set",
+                    "value": "1"
+                }
+            ]
+        },
+        "condition": {
+            "urlFilter": "*",
+            "resourceTypes": [
+                "main_frame",
+                "sub_frame",
+                "stylesheet",
+                "script",
+                "image",
+                "font",
+                "object",
+                "xmlhttprequest",
+                "ping",
+                "csp_report",
+                "media",
+                "websocket",
+                "webtransport",
+                "webbundle",
+                "other"
+            ]
         }
-      ]
-    },
-    "condition": {
-      "urlFilter": "*",
-      "resourceTypes": [
-        "main_frame",
-        "sub_frame",
-        "stylesheet",
-        "script",
-        "image",
-        "font",
-        "object",
-        "xmlhttprequest",
-        "ping",
-        "csp_report",
-        "media",
-        "websocket",
-        "webtransport",
-        "webbundle",
-        "other"
-      ]
     }
-  }
 ]

--- a/addon/gpc.ts
+++ b/addon/gpc.ts
@@ -1,0 +1,13 @@
+try {
+    const gpcNavigator = navigator as Navigator & { globalPrivacyControl?: boolean };
+
+    if (!gpcNavigator.globalPrivacyControl) {
+        Object.defineProperty(Navigator.prototype, 'globalPrivacyControl', {
+            get: () => true,
+            configurable: true,
+            enumerable: true,
+        });
+    }
+} catch {
+    // Ignore conflicts with browsers or other extensions that define the signal.
+}

--- a/addon/manifest.firefox.json
+++ b/addon/manifest.firefox.json
@@ -13,6 +13,18 @@
         "*://*/*"
       ],
       "js": [
+        "gpc.bundle.js"
+      ],
+      "match_origin_as_fallback": true,
+      "run_at": "document_start",
+      "all_frames": true,
+      "world": "MAIN"
+    },
+    {
+      "matches": [
+        "*://*/*"
+      ],
+      "js": [
         "content.bundle.js"
       ],
       "match_origin_as_fallback": true,
@@ -26,11 +38,21 @@
   "permissions": [
     "cookies",
     "tabs",
+    "declarativeNetRequest",
     "scripting",
     "storage",
     "webNavigation",
     "browsingData"
   ],
+  "declarative_net_request": {
+    "rule_resources": [
+      {
+        "id": "gpc",
+        "enabled": true,
+        "path": "gpc-rules.json"
+      }
+    ]
+  },
   "action": {
     "default_title": "Autoconsent",
     "default_popup": "popup.html"

--- a/addon/manifest.mv3.json
+++ b/addon/manifest.mv3.json
@@ -11,6 +11,18 @@
         "*://*/*"
       ],
       "js": [
+        "gpc.bundle.js"
+      ],
+      "match_origin_as_fallback": true,
+      "run_at": "document_start",
+      "all_frames": true,
+      "world": "MAIN"
+    },
+    {
+      "matches": [
+        "*://*/*"
+      ],
+      "js": [
         "content.bundle.js"
       ],
       "match_origin_as_fallback": true,
@@ -24,11 +36,21 @@
   "permissions": [
     "cookies",
     "tabs",
+    "declarativeNetRequest",
     "scripting",
     "storage",
     "webNavigation",
     "browsingData"
   ],
+  "declarative_net_request": {
+    "rule_resources": [
+      {
+        "id": "gpc",
+        "enabled": true,
+        "path": "gpc-rules.json"
+      }
+    ]
+  },
   "action": {
     "browser_style": true,
     "default_title": "Autoconsent",

--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,7 @@ npx tsc -p tsconfig.build.json
 # Extension
 $ESBUILD addon/background.ts --outfile=dist/addon-mv3/background.bundle.js
 $ESBUILD addon/content.ts --outfile=dist/addon-mv3/content.bundle.js
+$ESBUILD addon/gpc.ts --outfile=dist/addon-mv3/gpc.bundle.js
 $ESBUILD addon/popup.ts --outfile=dist/addon-mv3/popup.bundle.js
 $ESBUILD addon/devtools/panel.ts --outfile=dist/addon-mv3/devtools/panel.js
 
@@ -27,6 +28,8 @@ cp rules/rules.json dist/addon-mv3/
 cp rules/compact-rules.json dist/addon-mv3/
 cp rules/rules.json dist/addon-firefox/
 cp rules/compact-rules.json dist/addon-firefox/
+cp addon/gpc-rules.json dist/addon-mv3/
+cp addon/gpc-rules.json dist/addon-firefox/
 cp addon/popup.html dist/addon-mv3/
 cp addon/popup.html dist/addon-firefox/
 cp -r addon/devtools dist/addon-mv3/


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL:

## Description:
- Add a static DNR ruleset that sets `Sec-GPC: 1` on extension requests.
- Add a main-world content script that exposes `navigator.globalPrivacyControl === true`.
- Include the new GPC assets in the extension build outputs.

## Steps to test this PR:
- `npm run bundle`
- `npm run lint`
- `npx web-ext lint -s dist/addon-firefox` (expected existing failure: `ADDON_ID_REQUIRED`; no errors for the new GPC manifest fields or ruleset)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-573d3a2b-8e57-4ccb-baa4-0dc02981fbaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-573d3a2b-8e57-4ccb-baa4-0dc02981fbaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

