### PR TITLE
Add aytm.com rule for custom cookie banner

### DIFF
--- a/rules/autoconsent/aytm.json
+++ b/rules/autoconsent/aytm.json
@@ -1,6 +1,9 @@
 {
     "name": "aytm",
     "vendorUrl": "https://aytm.com/",
+    "runContext": {
+        "urlPattern": "^https?://(www\\.|)?aytm\\.com/"
+    },
     "prehideSelectors": ["#cookie-consent"],
     "detectCmp": [
         {

--- a/rules/autoconsent/aytm.json
+++ b/rules/autoconsent/aytm.json
@@ -1,0 +1,25 @@
+{
+    "name": "aytm",
+    "vendorUrl": "https://aytm.com/",
+    "prehideSelectors": ["#cookie-consent"],
+    "detectCmp": [
+        {
+            "exists": "#cookie-consent[style*=\"max-height\"] #cookie-status-reject"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#cookie-consent[style*=\"max-height\"] #cookie-status-reject"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "#cookie-consent[style*=\"max-height\"] #cookie-status-agree"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "#cookie-consent[style*=\"max-height\"] #cookie-status-reject"
+        }
+    ]
+}

--- a/rules/autoconsent/opera.com.json
+++ b/rules/autoconsent/opera.com.json
@@ -22,7 +22,12 @@
         }
     ],
     "optOut": [
-        { "waitForThenClick": "#cookie-consent .cookie-consent__switch:not(.always_on)", "all": true },
+        {
+            "waitForThenClick": "#cookie-consent .cookie-consent__switch.active:not(.always_on)",
+            "all": true,
+            "timeout": 500,
+            "optional": true
+        },
         { "waitForThenClick": "#cookie-consent .cookie-selection__btn" }
     ],
     "test": [{ "cookieContains": "cookie_consent_essential=true" }, { "cookieContains": "cookie_consent_marketing=true", "negated": true }]

--- a/tests/aytm.spec.ts
+++ b/tests/aytm.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('aytm', ['https://aytm.com/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1215395515926124?focus=true


## Description:
aytm.com uses a custom cookie banner injected via Webflow that ships with two duplicate #cookie-consent containers (one visible, one hidden clone). The autoconsent heuristic cannot distinguish between them and ends up clicking the hidden duplicate's reject button which has no onclick handler attached.

Add a site-specific rule that targets the popup whose inline style includes max-height (set by the page's own window.onload handler when the banner is opened), ensuring we click the reject button whose onclick handler is actually wired up.



## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to autoconsent rule JSON and a new Playwright spec; no auth, data, or core runtime logic is touched.
> 
> **Overview**
> Adds a site-specific autoconsent rule for **aytm.com** so opt-in/opt-out clicks the visible Webflow banner (the `#cookie-consent` instance whose inline style includes `max-height`), avoiding a duplicate hidden `#cookie-consent` that breaks generic heuristics. Detection, popup visibility, and agree/reject actions all use that scoped selector; `#cookie-consent` is prehidden and a Playwright CMP test targets `https://aytm.com/`.
> 
> **opera.com** opt-out is adjusted to toggle only `.cookie-consent__switch.active:not(.always_on)` (with `timeout: 500` and `optional: true`) before saving, instead of every non-`always_on` switch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6f973dbe5fc01cbae2cd4016369417364375335. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->