### PR TITLE
Add flag to enable measurement of detectCMP phase

### DIFF
--- a/addon/utils.ts
+++ b/addon/utils.ts
@@ -26,6 +26,9 @@ export function extensionDefaultConfig(storedConfig: Partial<Config> = {}): Conf
             waits: true,
         };
     }
+    if (storedConfig.performanceLoggingEnabled === undefined) {
+        storedConfig.performanceLoggingEnabled = true;
+    }
     return normalizeConfig(storedConfig);
 }
 

--- a/lib/cmps/base.ts
+++ b/lib/cmps/base.ts
@@ -445,7 +445,8 @@ export class AutoConsentHeuristicCMP extends AutoConsentCMPBase {
         this.autoconsent.config.performanceLoggingEnabled && performance.mark('heuristicDetectorStart');
         this.popups = getActionablePopups();
         this.autoconsent.config.performanceLoggingEnabled && performance.mark('heuristicDetectorEnd');
-        this.autoconsent.config.performanceLoggingEnabled && performance.measure('heuristicDetector', 'heuristicDetectorStart', 'heuristicDetectorEnd');
+        this.autoconsent.config.performanceLoggingEnabled &&
+            performance.measure('heuristicDetector', 'heuristicDetectorStart', 'heuristicDetectorEnd');
         if (this.popups.length > 0) {
             return Promise.resolve(true);
         }

--- a/lib/cmps/base.ts
+++ b/lib/cmps/base.ts
@@ -442,7 +442,10 @@ export class AutoConsentHeuristicCMP extends AutoConsentCMPBase {
     }
 
     detectCmp(): Promise<boolean> {
+        this.autoconsent.config.performanceLoggingEnabled && performance.mark('heuristicDetectorStart');
         this.popups = getActionablePopups();
+        this.autoconsent.config.performanceLoggingEnabled && performance.mark('heuristicDetectorEnd');
+        this.autoconsent.config.performanceLoggingEnabled && performance.measure('heuristicDetector', 'heuristicDetectorStart', 'heuristicDetectorEnd');
         if (this.popups.length > 0) {
             return Promise.resolve(true);
         }

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -1,7 +1,7 @@
 import { snippets } from './eval-snippets';
 import { Config, ConsentState, RuleBundle } from './types';
 
-export type BackgroundMessage = InitResponseMessage | EvalResponseMessage | OptOutMessage | OptInMessage | SelfTestMessage;
+export type BackgroundMessage = InitResponseMessage | EvalResponseMessage | OptOutMessage | OptInMessage | SelfTestMessage | MeasurePerformanceMessage;
 
 export type ContentScriptMessage =
     | InitMessage
@@ -129,4 +129,8 @@ export type InstanceTerminatedMessage = {
 export type DevtoolsInitMessage = {
     type: 'init';
     tabId: number;
+};
+
+export type MeasurePerformanceMessage = {
+    type: 'measurePerformance';
 };

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -1,7 +1,13 @@
 import { snippets } from './eval-snippets';
 import { Config, ConsentState, RuleBundle } from './types';
 
-export type BackgroundMessage = InitResponseMessage | EvalResponseMessage | OptOutMessage | OptInMessage | SelfTestMessage | MeasurePerformanceMessage;
+export type BackgroundMessage =
+    | InitResponseMessage
+    | EvalResponseMessage
+    | OptOutMessage
+    | OptInMessage
+    | SelfTestMessage
+    | MeasurePerformanceMessage;
 
 export type ContentScriptMessage =
     | InitMessage

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -110,6 +110,7 @@ export type ConsentState = {
     clicks: number; // Number of clicks the script has made.
     startTime: number; // The time the script started.
     endTime: number; // The time the script ended.
+    performance?: Record<string, number[]>;
 };
 
 export interface ButtonData {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -76,6 +76,7 @@ export type Config = {
         messages: boolean;
         waits: boolean;
     };
+    performanceLoggingEnabled: boolean;
 };
 
 export type LifecycleState =

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -93,6 +93,7 @@ export function normalizeConfig(providedConfig: any): Config {
             messages: false,
             waits: false,
         },
+        performanceLoggingEnabled: false,
     };
     const updatedConfig: Config = copyObject(defaultConfig);
     // filter out any unknown entries

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -242,6 +242,7 @@ export default class AutoConsent {
             const results = {
                 filterCMPs: performance.getEntriesByName('filterCMPs').map((m) => m.duration),
                 detectHeuristics: performance.getEntriesByName('detectHeuristics').map((m) => m.duration),
+                heuristicDetector: performance.getEntriesByName('heuristicDetector').map((m) => m.duration),
                 findCmpSiteSpecific: performance.getEntriesByName('findCmp_site-specific').map((m) => m.duration),
                 findCmpGeneric: performance.getEntriesByName('findCmp_generic').map((m) => m.duration),
                 findCmpHeuristic: performance.getEntriesByName('findCmp_heuristic').map((m) => m.duration),

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -168,7 +168,8 @@ export default class AutoConsent {
     }
 
     parseDeclarativeRules(declarativeRules: RuleBundle) {
-        this.config.performanceLoggingEnabled && performance.mark('parseDeclarativeRulesStart');
+        const perfEnabled = this.#config?.performanceLoggingEnabled;
+        perfEnabled && performance.mark('parseDeclarativeRulesStart');
         if (declarativeRules.consentomatic) {
             for (const [name, rule] of Object.entries(declarativeRules.consentomatic)) {
                 this.addConsentomaticCMP(name, rule);
@@ -186,12 +187,11 @@ export default class AutoConsent {
                 const rules = decodeRules(declarativeRules.compact);
                 rules.forEach(this.addDeclarativeCMP.bind(this));
             } catch (e) {
-                this.config.logs.errors && console.error(e);
+                this.#config?.logs.errors && console.error(e);
             }
         }
-        this.config.performanceLoggingEnabled && performance.mark('parseDeclarativeRulesEnd');
-        this.config.performanceLoggingEnabled &&
-            performance.measure('parseDeclarativeRules', 'parseDeclarativeRulesStart', 'parseDeclarativeRulesEnd');
+        perfEnabled && performance.mark('parseDeclarativeRulesEnd');
+        perfEnabled && performance.measure('parseDeclarativeRules', 'parseDeclarativeRulesStart', 'parseDeclarativeRulesEnd');
     }
 
     addDeclarativeCMP(ruleset: AutoConsentCMPRule) {

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -694,20 +694,6 @@ export default class AutoConsent {
     }
 
     measurePerformance() {
-        // const cmpPerformance: Record<string, number> = performance
-        //     .getEntriesByType('measure')
-        //     .filter((m) => m.name.startsWith('detectCmp_'))
-        //     .reduce((acc, m) => {
-        //         const k = m.name.slice(10);
-        //         if (!acc[k]) {
-        //             acc[k] = 0;
-        //         }
-        //         acc[k] += m.duration;
-        //         return acc;
-        //     }, Object.create(null));
-        // const slowestRules = Object.entries(cmpPerformance)
-        //     .sort((a, b) => b[1] - a[1])
-        //     .slice(0, 10);
         return {
             filterCMPs: performance.getEntriesByName('filterCMPs').map((m) => m.duration),
             detectHeuristics: performance.getEntriesByName('detectHeuristics').map((m) => m.duration),
@@ -715,7 +701,21 @@ export default class AutoConsent {
             findCmpSiteSpecific: performance.getEntriesByName('findCmp_site-specific').map((m) => m.duration),
             findCmpGeneric: performance.getEntriesByName('findCmp_generic').map((m) => m.duration),
             findCmpHeuristic: performance.getEntriesByName('findCmp_heuristic').map((m) => m.duration),
-            // slowestRules: slowestRules.map(([name, duration]) => ({ name, duration })),
         };
+    }
+
+    measureDetailedRulePerformance() {
+        const cmpPerformance: Record<string, number> = performance
+            .getEntriesByType('measure')
+            .filter((m) => m.name.startsWith('detectCmp_'))
+            .reduce((acc, m) => {
+                const k = m.name.slice(10);
+                if (!acc[k]) {
+                    acc[k] = 0;
+                }
+                acc[k] += m.duration;
+                return acc;
+            }, Object.create(null));
+        return cmpPerformance;
     }
 }

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -103,8 +103,10 @@ export default class AutoConsent {
         if (config.enableFilterList) {
             this.initializeFilterList();
         }
-
+        this.config.performanceLoggingEnabled && performance.mark('filterCMPsStart');
         this.rules = filterCMPs(this.rules, normalizedConfig);
+        this.config.performanceLoggingEnabled && performance.mark('filterCMPsEnd');
+        this.config.performanceLoggingEnabled && performance.measure('filterCMPs', 'filterCMPsStart', 'filterCMPsEnd');
 
         if (this.shouldPrehide) {
             if (document.documentElement) {
@@ -166,6 +168,7 @@ export default class AutoConsent {
     }
 
     parseDeclarativeRules(declarativeRules: RuleBundle) {
+        this.config.performanceLoggingEnabled && performance.mark('parseDeclarativeRulesStart');
         if (declarativeRules.consentomatic) {
             for (const [name, rule] of Object.entries(declarativeRules.consentomatic)) {
                 this.addConsentomaticCMP(name, rule);
@@ -186,6 +189,9 @@ export default class AutoConsent {
                 this.config.logs.errors && console.error(e);
             }
         }
+        this.config.performanceLoggingEnabled && performance.mark('parseDeclarativeRulesEnd');
+        this.config.performanceLoggingEnabled &&
+            performance.measure('parseDeclarativeRules', 'parseDeclarativeRulesStart', 'parseDeclarativeRulesEnd');
     }
 
     addDeclarativeCMP(ruleset: AutoConsentCMPRule) {
@@ -217,6 +223,31 @@ export default class AutoConsent {
             }
 
             return this.filterListFallback();
+        }
+        if (this.config.performanceLoggingEnabled) {
+            const cmpPerformance: Record<string, number> = performance
+                .getEntriesByType('measure')
+                .filter((m) => m.name.startsWith('detectCmp_'))
+                .reduce((acc, m) => {
+                    const k = m.name.slice(10);
+                    if (!acc[k]) {
+                        acc[k] = 0;
+                    }
+                    acc[k] += m.duration;
+                    return acc;
+                }, Object.create(null));
+            const slowestRules = Object.entries(cmpPerformance)
+                .sort((a, b) => b[1] - a[1])
+                .slice(0, 10);
+            const results = {
+                filterCMPs: performance.getEntriesByName('filterCMPs').map((m) => m.duration),
+                detectHeuristics: performance.getEntriesByName('detectHeuristics').map((m) => m.duration),
+                findCmpSiteSpecific: performance.getEntriesByName('findCmp_site-specific').map((m) => m.duration),
+                findCmpGeneric: performance.getEntriesByName('findCmp_generic').map((m) => m.duration),
+                findCmpHeuristic: performance.getEntriesByName('findCmp_heuristic').map((m) => m.duration),
+                slowestRules: slowestRules.map(([name, duration]) => ({ name, duration })),
+            };
+            console.log('[performance]', results);
         }
 
         this.updateState({ lifecycle: 'cmpDetected' });
@@ -298,7 +329,11 @@ export default class AutoConsent {
         ];
         const runDetectCmp = async (cmp: AutoCMP) => {
             try {
+                this.config.performanceLoggingEnabled && performance.mark(`detectCmp_${cmp.name}`);
                 const result = await cmp.detectCmp();
+                this.config.performanceLoggingEnabled && performance.mark(`detectCmpEnd_${cmp.name}`);
+                this.config.performanceLoggingEnabled &&
+                    performance.measure(`detectCmp_${cmp.name}`, `detectCmp_${cmp.name}`, `detectCmpEnd_${cmp.name}`);
                 if (result) {
                     logsConfig.lifecycle && console.log(`Found CMP: ${cmp.name} ${window.location.href}`);
                     this.sendContentMessage({
@@ -323,7 +358,11 @@ export default class AutoConsent {
                     `Trying ${stageName} rules`,
                     ruleGroup.map((r) => r.name),
                 );
+            this.config.performanceLoggingEnabled && performance.mark(`findCmpStage_${stageName}`);
             await Promise.all(ruleGroup.map(runDetectCmp));
+            this.config.performanceLoggingEnabled && performance.mark(`findCmpStageEnd_${stageName}`);
+            this.config.performanceLoggingEnabled &&
+                performance.measure(`findCmp_${stageName}`, `findCmpStage_${stageName}`, `findCmpStageEnd_${stageName}`);
 
             // exit early if we already found a CMP
             if (foundCMPs.length > 0) {
@@ -352,6 +391,7 @@ export default class AutoConsent {
 
     detectHeuristics() {
         if (this.config.enableHeuristicDetection) {
+            this.config.performanceLoggingEnabled && performance.mark('detectHeuristicsStart');
             const { patterns, snippets } = checkHeuristicPatterns(document.documentElement?.innerText || '');
             if (
                 patterns.length > 0 &&
@@ -360,6 +400,9 @@ export default class AutoConsent {
                 this.config.logs.lifecycle && console.log('Heuristic patterns found', patterns, snippets);
                 this.updateState({ heuristicPatterns: patterns, heuristicSnippets: snippets }); // we don't care about previously found patterns
             }
+            this.config.performanceLoggingEnabled && performance.mark('detectHeuristicsEnd');
+            this.config.performanceLoggingEnabled &&
+                performance.measure('detectHeuristics', 'detectHeuristicsStart', 'detectHeuristicsEnd');
         }
     }
 

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -225,30 +225,7 @@ export default class AutoConsent {
             return this.filterListFallback();
         }
         if (this.config.performanceLoggingEnabled) {
-            const cmpPerformance: Record<string, number> = performance
-                .getEntriesByType('measure')
-                .filter((m) => m.name.startsWith('detectCmp_'))
-                .reduce((acc, m) => {
-                    const k = m.name.slice(10);
-                    if (!acc[k]) {
-                        acc[k] = 0;
-                    }
-                    acc[k] += m.duration;
-                    return acc;
-                }, Object.create(null));
-            const slowestRules = Object.entries(cmpPerformance)
-                .sort((a, b) => b[1] - a[1])
-                .slice(0, 10);
-            const results = {
-                filterCMPs: performance.getEntriesByName('filterCMPs').map((m) => m.duration),
-                detectHeuristics: performance.getEntriesByName('detectHeuristics').map((m) => m.duration),
-                heuristicDetector: performance.getEntriesByName('heuristicDetector').map((m) => m.duration),
-                findCmpSiteSpecific: performance.getEntriesByName('findCmp_site-specific').map((m) => m.duration),
-                findCmpGeneric: performance.getEntriesByName('findCmp_generic').map((m) => m.duration),
-                findCmpHeuristic: performance.getEntriesByName('findCmp_heuristic').map((m) => m.duration),
-                slowestRules: slowestRules.map(([name, duration]) => ({ name, duration })),
-            };
-            console.log('[performance]', results);
+            this.updateState({ performance: this.measurePerformance() });
         }
 
         this.updateState({ lifecycle: 'cmpDetected' });
@@ -350,7 +327,7 @@ export default class AutoConsent {
         };
 
         const mutationObserver = this.domActions.waitForMutation('html');
-        mutationObserver.catch(() => {}); // ensure promise rejection is caught
+        mutationObserver.catch(() => { }); // ensure promise rejection is caught
 
         for (const [stageName, ruleGroup] of rulesPriorityStages) {
             logsConfig.lifecycle &&
@@ -439,7 +416,7 @@ export default class AutoConsent {
                 this.detectHeuristics();
                 onFirstPopupAppears(cmp);
             })
-            .catch(() => {});
+            .catch(() => { });
 
         const results = await Promise.allSettled(tasks);
         const popups: AutoCMP[] = [];
@@ -604,7 +581,7 @@ export default class AutoConsent {
         let mutationObserver: Promise<boolean> | null = null;
         if (this.config.enablePopupMutationObserver) {
             mutationObserver = this.domActions.waitForMutation('html', 10000);
-            mutationObserver.catch(() => {});
+            mutationObserver.catch(() => { });
         }
 
         const isOpen = await cmp.detectPopup().catch((e) => {
@@ -710,6 +687,35 @@ export default class AutoConsent {
             case 'evalResp':
                 resolveEval(message.id, message.result);
                 break;
+            case 'measurePerformance':
+                this.updateState({ performance: this.measurePerformance() });
+                break;
         }
+    }
+
+    measurePerformance() {
+        // const cmpPerformance: Record<string, number> = performance
+        //     .getEntriesByType('measure')
+        //     .filter((m) => m.name.startsWith('detectCmp_'))
+        //     .reduce((acc, m) => {
+        //         const k = m.name.slice(10);
+        //         if (!acc[k]) {
+        //             acc[k] = 0;
+        //         }
+        //         acc[k] += m.duration;
+        //         return acc;
+        //     }, Object.create(null));
+        // const slowestRules = Object.entries(cmpPerformance)
+        //     .sort((a, b) => b[1] - a[1])
+        //     .slice(0, 10);
+        return {
+            filterCMPs: performance.getEntriesByName('filterCMPs').map((m) => m.duration),
+            detectHeuristics: performance.getEntriesByName('detectHeuristics').map((m) => m.duration),
+            heuristicDetector: performance.getEntriesByName('heuristicDetector').map((m) => m.duration),
+            findCmpSiteSpecific: performance.getEntriesByName('findCmp_site-specific').map((m) => m.duration),
+            findCmpGeneric: performance.getEntriesByName('findCmp_generic').map((m) => m.duration),
+            findCmpHeuristic: performance.getEntriesByName('findCmp_heuristic').map((m) => m.duration),
+            // slowestRules: slowestRules.map(([name, duration]) => ({ name, duration })),
+        };
     }
 }

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -327,7 +327,7 @@ export default class AutoConsent {
         };
 
         const mutationObserver = this.domActions.waitForMutation('html');
-        mutationObserver.catch(() => { }); // ensure promise rejection is caught
+        mutationObserver.catch(() => {}); // ensure promise rejection is caught
 
         for (const [stageName, ruleGroup] of rulesPriorityStages) {
             logsConfig.lifecycle &&
@@ -416,7 +416,7 @@ export default class AutoConsent {
                 this.detectHeuristics();
                 onFirstPopupAppears(cmp);
             })
-            .catch(() => { });
+            .catch(() => {});
 
         const results = await Promise.allSettled(tasks);
         const popups: AutoCMP[] = [];
@@ -581,7 +581,7 @@ export default class AutoConsent {
         let mutationObserver: Promise<boolean> | null = null;
         if (this.config.enablePopupMutationObserver) {
             mutationObserver = this.domActions.waitForMutation('html', 10000);
-            mutationObserver.catch(() => { });
+            mutationObserver.catch(() => {});
         }
 
         const isOpen = await cmp.detectPopup().catch((e) => {

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -103,10 +103,7 @@ export default class AutoConsent {
         if (config.enableFilterList) {
             this.initializeFilterList();
         }
-        this.config.performanceLoggingEnabled && performance.mark('filterCMPsStart');
         this.rules = filterCMPs(this.rules, normalizedConfig);
-        this.config.performanceLoggingEnabled && performance.mark('filterCMPsEnd');
-        this.config.performanceLoggingEnabled && performance.measure('filterCMPs', 'filterCMPsStart', 'filterCMPsEnd');
 
         if (this.shouldPrehide) {
             if (document.documentElement) {
@@ -216,6 +213,9 @@ export default class AutoConsent {
         this.updateState({ lifecycle: 'started' });
         const foundCmps = await this.findCmp(this.config.detectRetries);
         this.updateState({ detectedCmps: foundCmps.map((c) => c.name) });
+        if (this.config.performanceLoggingEnabled) {
+            this.updateState({ performance: this.measurePerformance() });
+        }
         if (foundCmps.length === 0) {
             logsConfig.lifecycle && console.log('no CMP found', location.href);
             if (this.shouldPrehide) {
@@ -223,9 +223,6 @@ export default class AutoConsent {
             }
 
             return this.filterListFallback();
-        }
-        if (this.config.performanceLoggingEnabled) {
-            this.updateState({ performance: this.measurePerformance() });
         }
 
         this.updateState({ lifecycle: 'cmpDetected' });
@@ -695,12 +692,12 @@ export default class AutoConsent {
 
     measurePerformance() {
         return {
-            filterCMPs: performance.getEntriesByName('filterCMPs').map((m) => m.duration),
             detectHeuristics: performance.getEntriesByName('detectHeuristics').map((m) => m.duration),
             heuristicDetector: performance.getEntriesByName('heuristicDetector').map((m) => m.duration),
             findCmpSiteSpecific: performance.getEntriesByName('findCmp_site-specific').map((m) => m.duration),
             findCmpGeneric: performance.getEntriesByName('findCmp_generic').map((m) => m.duration),
             findCmpHeuristic: performance.getEntriesByName('findCmp_heuristic').map((m) => m.duration),
+            parseDeclarativeRules: performance.getEntriesByName('parseDeclarativeRules').map((m) => m.duration),
         };
     }
 

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -691,13 +691,14 @@ export default class AutoConsent {
     }
 
     measurePerformance() {
+        const getRoundedPerformanceEntries = (name: string) => performance.getEntriesByName(name).map((m) => Number(m.duration.toFixed(3)));
         return {
-            detectHeuristics: performance.getEntriesByName('detectHeuristics').map((m) => m.duration),
-            heuristicDetector: performance.getEntriesByName('heuristicDetector').map((m) => m.duration),
-            findCmpSiteSpecific: performance.getEntriesByName('findCmp_site-specific').map((m) => m.duration),
-            findCmpGeneric: performance.getEntriesByName('findCmp_generic').map((m) => m.duration),
-            findCmpHeuristic: performance.getEntriesByName('findCmp_heuristic').map((m) => m.duration),
-            parseDeclarativeRules: performance.getEntriesByName('parseDeclarativeRules').map((m) => m.duration),
+            detectHeuristics: getRoundedPerformanceEntries('detectHeuristics'),
+            heuristicDetector: getRoundedPerformanceEntries('heuristicDetector'),
+            findCmpSiteSpecific: getRoundedPerformanceEntries('findCmp_site-specific'),
+            findCmpGeneric: getRoundedPerformanceEntries('findCmp_generic'),
+            findCmpHeuristic: getRoundedPerformanceEntries('findCmp_heuristic'),
+            parseDeclarativeRules: getRoundedPerformanceEntries('parseDeclarativeRules'),
         };
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215357412614455

## Description:
Adds performance measurement of different parts of the `findCMP` path to allow us to measure how efficient this code is. The results are included in `report` messages so debugging tools can pick them up.

## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes gated behind a config flag; no change to consent detection or opt-out behavior when disabled.
> 
> **Overview**
> Adds a **`performanceLoggingEnabled`** config flag (off by default in the library, on for the test extension) that gates **`performance.mark` / `measure`** instrumentation along the CMP detection path.
> 
> When enabled, timings are collected for **declarative rule parsing**, **each `findCmp` stage** (site-specific, generic, heuristic), **per-rule `detectCmp`**, **heuristic pattern detection**, and the **heuristic popup detector**. Aggregated durations are stored on **`ConsentState.performance`** and flow out via existing **`report`** messages after detection completes; devtools can also trigger a refresh with a new **`measurePerformance`** background message. A helper **`measureDetailedRulePerformance`** sums per-CMP `detectCmp` measures for deeper analysis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59a572d0acfb84a5785cde93dea12e2370300f11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->