### PR TITLE
Add vivenu rule for the cookie banner used on vivenu-powered shops

### DIFF
--- a/rules/autoconsent/vivenu.json
+++ b/rules/autoconsent/vivenu.json
@@ -1,0 +1,31 @@
+{
+    "name": "vivenu",
+    "vendorUrl": "https://vivenu.com",
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "[data-slot=\"dialog-content\"] a[href*=\"vivenu.com/dataprivacy\"]"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "[data-slot=\"dialog-content\"] a[href*=\"vivenu.com/dataprivacy\"]"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "[data-slot=\"dialog-content\"]:has(a[href*=\"vivenu.com/dataprivacy\"]) button:nth-of-type(1)"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "[data-slot=\"dialog-content\"]:has(a[href*=\"vivenu.com/dataprivacy\"]) button:nth-of-type(2)"
+        }
+    ],
+    "test": [
+        {
+            "visible": "[data-slot=\"dialog-content\"] a[href*=\"vivenu.com/dataprivacy\"]",
+            "check": "none"
+        }
+    ]
+}

--- a/tests/vivenu.spec.ts
+++ b/tests/vivenu.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('vivenu', ['https://tickets.schalke04.de/events/monster-jam-rj197m', 'https://tickets.worldofvalue.ch/'], {
+    skipRegions: ['US'],
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1215467551372209?focus=true

## Description:


## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new CMP rule and tests only; no changes to shared consent or auth logic.
> 
> **Overview**
> Adds **autoconsent support for vivenu** cookie dialogs on vivenu-powered ticket shops.
> 
> A new rule **`vivenu`** detects the consent dialog via a `[data-slot="dialog-content"]` link to `vivenu.com/dataprivacy`, then maps **opt-in** to the first button and **opt-out** to the second. Playwright coverage runs against Schalke 04 and World of Value ticket URLs with **`skipRegions: ['US']`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6646750f62ee453ea4c43030909993f6e2b889e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->