### PR TITLE
Disable per-rule performance measurement

### DIFF
--- a/lib/web.ts
+++ b/lib/web.ts
@@ -304,11 +304,7 @@ export default class AutoConsent {
         ];
         const runDetectCmp = async (cmp: AutoCMP) => {
             try {
-                this.config.performanceLoggingEnabled && performance.mark(`detectCmp_${cmp.name}`);
                 const result = await cmp.detectCmp();
-                this.config.performanceLoggingEnabled && performance.mark(`detectCmpEnd_${cmp.name}`);
-                this.config.performanceLoggingEnabled &&
-                    performance.measure(`detectCmp_${cmp.name}`, `detectCmp_${cmp.name}`, `detectCmpEnd_${cmp.name}`);
                 if (result) {
                     logsConfig.lifecycle && console.log(`Found CMP: ${cmp.name} ${window.location.href}`);
                     this.sendContentMessage({
@@ -700,20 +696,5 @@ export default class AutoConsent {
             findCmpHeuristic: getRoundedPerformanceEntries('findCmp_heuristic'),
             parseDeclarativeRules: getRoundedPerformanceEntries('parseDeclarativeRules'),
         };
-    }
-
-    measureDetailedRulePerformance() {
-        const cmpPerformance: Record<string, number> = performance
-            .getEntriesByType('measure')
-            .filter((m) => m.name.startsWith('detectCmp_'))
-            .reduce((acc, m) => {
-                const k = m.name.slice(10);
-                if (!acc[k]) {
-                    acc[k] = 0;
-                }
-                acc[k] += m.duration;
-                return acc;
-            }, Object.create(null));
-        return cmpPerformance;
     }
 }


### PR DESCRIPTION
Task/Issue URL:

## Description:


## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change with no impact on CMP detection or consent handling logic.
> 
> **Overview**
> **Disables per-rule CMP detection timing** when performance logging is on, so `detectCmp` no longer records `performance.mark` / `measure` entries for each rule name.
> 
> **Removes** the unused `measureDetailedRulePerformance()` helper that aggregated those per-CMP measures. **Stage-level** metrics in `measurePerformance()` (site-specific / generic / heuristic `findCmp_*`, heuristics, declarative parsing) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82b100db06d9e21b9d9319e793d0247d294bf9e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->