### PR TITLE
Fix AWS Shortbread opt-out by using the new Decline button

### DIFF
--- a/rules/autoconsent/aws-amazon.json
+++ b/rules/autoconsent/aws-amazon.json
@@ -3,21 +3,31 @@
     "prehideSelectors": ["#awsccc-cb-content", "#awsccc-cs-container", "#awsccc-cs-modalOverlay", "#awsccc-cs-container-inner"],
     "detectCmp": [{ "exists": "#awsccc-cb-content" }],
     "detectPopup": [{ "visible": "#awsccc-cb-content" }],
-    "optIn": [{ "click": "button[data-id=awsccc-cb-btn-accept" }],
+    "optIn": [{ "click": "button[data-id=awsccc-cb-btn-accept]" }],
     "optOut": [
         {
-            "click": "button[data-id=awsccc-cb-btn-customize]"
-        },
-        {
-            "waitFor": "input[aria-checked]"
-        },
-        {
-            "click": "input[aria-checked=true]",
-            "all": true,
-            "optional": true
-        },
-        {
-            "click": "button[data-id=awsccc-cs-btn-save]"
+            "if": { "exists": "button[data-id=awsccc-cb-btn-decline]" },
+            "then": [
+                {
+                    "click": "button[data-id=awsccc-cb-btn-decline]"
+                }
+            ],
+            "else": [
+                {
+                    "click": "button[data-id=awsccc-cb-btn-customize]"
+                },
+                {
+                    "waitFor": "input[aria-checked]"
+                },
+                {
+                    "click": "input[aria-checked=true]",
+                    "all": true,
+                    "optional": true
+                },
+                {
+                    "click": "button[data-id=awsccc-cs-btn-save]"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1215659123360017?focus=true

## Description:
The aws.amazon.com rule's Customize-based opt-out flow no longer completes on the current Shortbread banner because the customize panel inputs no longer carry the aria-checked attribute that the 'waitFor' step relies on, causing the rule to fail before saving.

The current banner exposes a direct Decline button (button[data-id=awsccc-cb-btn-decline]), so prefer clicking it and fall back to the existing Customize-then-Save flow for older deployments. Also fix the optIn selector which was missing a closing bracket.

## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-site autoconsent JSON rule change with no auth, data, or core app impact.
> 
> **Overview**
> Updates the **aws.amazon.com** autoconsent rule so opt-out works with the current AWS Shortbread banner and accept still clicks reliably.
> 
> **optIn** fixes a broken selector by adding the missing `]` on `button[data-id=awsccc-cb-btn-accept]`.
> 
> **optOut** is now conditional: when `button[data-id=awsccc-cb-btn-decline]` exists, it clicks **Decline**; otherwise it keeps the previous **Customize → wait for `input[aria-checked]` → toggle checked inputs → Save** path for older banners that no longer expose `aria-checked` on the customize panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f3f0a94719778387c63df6661d970388352e176. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->