### PR TITLE
Preserve JSONC comments when bundling autoconsent config rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "esbuild": "^0.28.0",
         "eslint": "^10.0.3",
         "globals": "^17.4.0",
+        "jsonc-parser": "^3.3.1",
         "markdown-it": "^14.0.0",
         "mocha": "^11.0.1",
         "prettier": "3.8.3",
@@ -10021,6 +10022,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "esbuild": "^0.28.0",
     "eslint": "^10.0.3",
     "globals": "^17.4.0",
+    "jsonc-parser": "^3.3.1",
     "markdown-it": "^14.0.0",
     "mocha": "^11.0.1",
     "prettier": "3.8.3",

--- a/scripts/bundle-config-rules.ts
+++ b/scripts/bundle-config-rules.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import { encodeRules } from '../lib/encoding';
+import { applyEdits, modify, parse, type JSONPath } from 'jsonc-parser';
+import { encodeRules, type IndexedCMPRuleset } from '../lib/encoding';
 
 if (process.argv.length !== 3) {
     console.log('Usage: npm run bundle-config-rules path/to/privacy-configuration');
@@ -15,19 +16,24 @@ const bundleLocations = [path.join(privacyConfigPath, 'features', 'autoconsent.j
 const autoconsentRules = JSON.parse(fs.readFileSync(path.join(__dirname, '../rules/rules.json'), 'utf-8')).autoconsent;
 
 for (const location of bundleLocations) {
-    const config = JSON.parse(fs.readFileSync(location, 'utf-8'));
+    // privacy-configuration source files may contain comments (JSONC). Parse
+    // leniently and apply a targeted edit so comments and formatting survive.
+    const text = fs.readFileSync(location, 'utf-8');
+    const config = parse(text);
+    let rulePath: JSONPath;
+    let newCompactRuleList: IndexedCMPRuleset;
     if (location.endsWith('autoconsent.json')) {
         console.log(`Existing compact rule list: ${config.settings.compactRuleList.s.slice(0, 10)}`);
         // global config
-        config.settings.compactRuleList = encodeRules(autoconsentRules, config.settings.compactRuleList);
+        newCompactRuleList = encodeRules(autoconsentRules, config.settings.compactRuleList);
+        rulePath = ['settings', 'compactRuleList'];
     } else {
         // platform override
-        config.features.autoconsent.settings.compactRuleList = encodeRules(
-            autoconsentRules,
-            config.features.autoconsent.settings.compactRuleList,
-        );
+        newCompactRuleList = encodeRules(autoconsentRules, config.features.autoconsent.settings.compactRuleList);
+        rulePath = ['features', 'autoconsent', 'settings', 'compactRuleList'];
     }
-    // generate standard pretty-printed output
-    const outputData = JSON.stringify(config, undefined, 4);
-    fs.writeFileSync(location, outputData);
+    const edits = modify(text, rulePath, newCompactRuleList, {
+        formattingOptions: { tabSize: 4, insertSpaces: true },
+    });
+    fs.writeFileSync(location, applyEdits(text, edits));
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1199237043598868/task/1208768018422058?focus=true

## Description:

This makes sure that the rewriter of the config uses the JSONC formatting instead to ensure that the comments stay in place. I think it's a pretty low chance of this happening, but I just wanted to pass this over to you for validation.

> The release automation rewrote privacy-configuration's features/autoconsent.json with JSON.parse + JSON.stringify, which throws once the source file contains comments and strips every comment on write-back. Parse with jsonc-parser and apply a targeted modify/applyEdits to settings.compactRuleList so comments and formatting are preserved. Adds jsonc-parser as a devDependency.


## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to a dev/release script and a new devDependency; no runtime product or auth/data paths affected.
> 
> **Overview**
> **`bundle-config-rules`** no longer rewrites whole privacy-configuration files with `JSON.parse` + `JSON.stringify`. It now uses **`jsonc-parser`** to parse JSONC, update only **`compactRuleList`** via `modify` / `applyEdits`, and write back so **comments and surrounding formatting stay intact**.
> 
> Adds **`jsonc-parser`** as a devDependency. Behavior for rule encoding is unchanged; only how the autoconsent config file is updated on disk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a69619fab5016e81dd9aa16b540780c46cffcde5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->