### PR TITLE
Prompt AI to test in all regions

### DIFF
--- a/.agents/skills/proxy-testing/SKILL.md
+++ b/.agents/skills/proxy-testing/SKILL.md
@@ -108,7 +108,7 @@ await browser.close();
 
 1. Run `npm run build-rules` after changing rule JSON.
 2. Smoke-test each regional proxy.
-3. Test relevant regions.
+3. Test in ALL supported regions.
 4. Inspect screenshots, not just API results.
 5. Reload after dismissal and confirm the rule does not keep matching, unless cosmetic-only.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ CMPs behave differently by region:
 
 Use `if`/`then`/`else` to handle regional variants within a single rule.
 
-**All rule changes MUST be tested across geographic regions** to catch regional popup variations. Test from real geographic locations using available regional testing tooling (e.g. `proxy-testing` skill).
+**All rule changes MUST be tested across ALL supported geographic regions** to catch regional popup variations. Test from real geographic locations using available regional testing tooling (e.g. `proxy-testing` skill).
 
 ### Generic vs Site-Specific Rules
 
@@ -170,4 +170,4 @@ After creating or modifying a rule:
 3. `npx playwright test tests/<name>.spec.ts` — run the E2E test
 4. `npm run prepublish` — full build including extension bundle
 5. Validate that the rule stops matching after the popup is dismissed and the page is reloaded (unless it's a cosmetic rule).
-6. Check the rule works across geographic regions using available regional testing tooling.
+6. Check the rule works across all supported geographic regions using available regional testing tooling.


### PR DESCRIPTION
Task/Issue URL:

## Description:


## Steps to test this PR:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes with no runtime or rule logic impact.
> 
> **Overview**
> Tightens agent guidance so regional rule verification is explicit: **all supported** geographic regions, not a subset of “relevant” ones.
> 
> **`AGENTS.md`** updates the regional-differences requirement and verification step 6 to say rules must be checked across **all supported** geographic regions via regional testing tooling (e.g. the `proxy-testing` skill).
> 
> **`.agents/skills/proxy-testing/SKILL.md`** changes rule check #3 from “Test relevant regions” to **“Test in ALL supported regions”**, aligning with `testRegions()` defaulting to every configured region.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39b5b53960933a3a233aeab99465d18ffba73fdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->