### PR TITLE
Extend bbc.com rule to cover bbc.co.uk

### DIFF
--- a/rules/autoconsent/bbc.com.json
+++ b/rules/autoconsent/bbc.com.json
@@ -1,7 +1,7 @@
 {
     "name": "bbc.com",
     "runContext": {
-        "urlPattern": "^https://(www\\.)?bbc\\.com"
+        "urlPattern": "^https://(www\\.)?bbc\\.(com|co\\.uk)"
     },
     "prehideSelectors": ["*[aria-labelledby=\"consent-banner-title\"]"],
     "detectCmp": [

--- a/tests/bbc.com.spec.ts
+++ b/tests/bbc.com.spec.ts
@@ -1,3 +1,3 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('bbc.com', ['https://www.bbc.com/sport/formula1']);
+generateCMPTests('bbc.com', ['https://www.bbc.com/sport/formula1', 'https://www.bbc.co.uk/', 'https://www.bbc.co.uk/news']);


### PR DESCRIPTION
The BBC uses the same consent banner (#consent-banner-title with data-testid reject/accept buttons) on both bbc.com and bbc.co.uk, but the rule's urlPattern only matched bbc.com, so the dedicated rule never ran on bbc.co.uk and the popup was unhandled on Android.

Broadened the urlPattern to also match bbc.co.uk and added a couple of bbc.co.uk URLs to the test spec.

Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1215532237336424?focus=true

## Description:


## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small URL-pattern and test-list change only; no new consent logic or selectors.
> 
> **Overview**
> The **bbc.com** autoconsent rule previously only ran on `bbc.com`, so the same consent banner on **bbc.co.uk** was not handled (notably on Android). The `runContext.urlPattern` now matches both `bbc.com` and `bbc.co.uk`; selectors and opt-in/opt-out behavior are unchanged.
> 
> Playwright CMP tests for this rule now include `https://www.bbc.co.uk/` and `https://www.bbc.co.uk/news` alongside the existing bbc.com URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ccf88e3e6e3736a651ab2da3f7683a72f0a1339. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->