### PR TITLE
Add native OIL consent rule

### DIFF
--- a/rules/autoconsent/com_oil.json
+++ b/rules/autoconsent/com_oil.json
@@ -1,0 +1,23 @@
+{
+    "name": "com_oil",
+    "_metadata": {
+        "vendorUrl": "https://github.com/as-ideas/oil"
+    },
+    "prehideSelectors": [".as-oil-content-overlay"],
+    "detectCmp": [{ "exists": ".as-oil-content-overlay" }],
+    "detectPopup": [{ "visible": ".as-oil-content-overlay" }],
+    "optIn": [{ "waitForThenClick": ".as-js-optin" }],
+    "optOut": [
+        {
+            "if": { "exists": ".as-js-only-essentials" },
+            "then": [{ "waitForThenClick": ".as-js-only-essentials" }],
+            "else": [
+                { "waitForThenClick": ".as-js-advanced-settings" },
+                { "waitFor": ".as-oil-cpc__category-container, .as-oil-cpc__purpose-container" },
+                { "click": ".as-js-btn-deactivate-all", "optional": true },
+                { "waitForThenClick": ".as-js-optin" }
+            ]
+        }
+    ],
+    "test": [{ "cookieContains": "oil_data=" }]
+}

--- a/tests/oil.spec.ts
+++ b/tests/oil.spec.ts
@@ -2,12 +2,7 @@ import generateCMPTests from '../playwright/runner';
 
 generateCMPTests(
     'com_oil',
-    [
-        'https://www.elektro4000.de/',
-        'http://www.metallparadies.de/',
-        'http://www.ersatzteil-fee.de/',
-        'http://edelholzverkauf.de/',
-    ],
+    ['https://www.elektro4000.de/', 'http://www.metallparadies.de/', 'http://www.ersatzteil-fee.de/', 'http://edelholzverkauf.de/'],
     {
         skipRegions: ['GB'],
         testOptIn: false,

--- a/tests/oil.spec.ts
+++ b/tests/oil.spec.ts
@@ -1,7 +1,16 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('com_oil', ['https://www.farbtoner.com/', 'https://www.elektro4000.de/', 'http://edelholzverkauf.de/'], {
-    skipRegions: ['GB'],
-    testOptIn: false,
-    testSelfTest: false,
-});
+generateCMPTests(
+    'com_oil',
+    [
+        'https://www.elektro4000.de/',
+        'http://www.metallparadies.de/',
+        'http://www.ersatzteil-fee.de/',
+        'http://edelholzverkauf.de/',
+    ],
+    {
+        skipRegions: ['GB'],
+        testOptIn: false,
+        testSelfTest: false,
+    },
+);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL:

## Description:

Adds a native JSON autoconsent rule for the former Consent-O-Matic `com_oil` coverage. The rule detects OIL overlays, uses the direct only-essential action when available, and falls back to opening settings, deactivating optional purposes, and saving.

Updates the OIL Playwright spec to cover representative sites from `coverage.json` and a settings-only fallback site.

## Steps to test this PR:

- `npm run lint` ✅
- `npm run build-rules` ✅
- `npm run rule-syntax-check` ✅
- `npx playwright test tests/oil.spec.ts` ✅ (12 passed, 4 mobile skips)
- `npm run prepublish` ✅
- Manual screenshot/reload checks on `www.elektro4000.de` and `www.edelholzverkauf.de` ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1eaf903-a8b5-497d-9875-0d733b284aa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1eaf903-a8b5-497d-9875-0d733b284aa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

