### PR TITLE
Extend twitch.tv rule to cover m.twitch.tv subdomain

### DIFF
--- a/rules/autoconsent/twitch.json
+++ b/rules/autoconsent/twitch.json
@@ -1,7 +1,7 @@
 {
     "name": "twitch.tv",
     "runContext": {
-        "urlPattern": "^https?://(www\\.)?twitch\\.tv"
+        "urlPattern": "^https?://([\\w-]+\\.)?twitch\\.tv"
     },
     "prehideSelectors": [
         "div:has(> .consent-banner .consent-banner__content--gdpr-v2),.ReactModalPortal:has([data-a-target=consent-modal-save])"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1215826716149212?focus=true

## Description:
The previous urlPattern only matched the apex domain and www., so the rule never ran on m.twitch.tv even though the consent banner uses the same selectors. Widen the pattern to any subdomain.

## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single regex change in one rule file; consent actions are unchanged and the change only broadens where the existing rule applies.
> 
> **Overview**
> **Widens the Twitch autoconsent rule’s `runContext.urlPattern`** so the rule runs on subdomains such as `m.twitch.tv`, not only apex and `www`.
> 
> The pattern changes from `(www\.)?` to `([\w-]+\.)?` before `twitch\.tv`, aligning with other rules that match optional subdomain labels. Detection, prehide, and opt-in/out steps are unchanged; only URL gating is updated so the same GDPR banner handling applies on mobile and other Twitch hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7abf5c4b3ffd91ea8a4cb95e644f38322e3e3cc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->