### PR TITLE
Change heuristicMode parameter to a string and update handling.

### DIFF
--- a/addon/popup.html
+++ b/addon/popup.html
@@ -187,8 +187,12 @@
                 <div class="rule-list-status" id="consentomatic-rules-status"></div>
                 <div class="rule-list" id="consentomatic-rules-list"></div>
             </details>
+        </fieldset>
 
-            <div class="rule-section">
+        <fieldset>
+            <legend>Handle unknown popups (heuristic rule)</legend>
+
+            <div>
                 <input type="radio" id="heuristic-off" name="heuristic-mode" value="off" checked />
                 <label for="heuristic-off">Off</label>
             </div>

--- a/addon/popup.html
+++ b/addon/popup.html
@@ -189,8 +189,23 @@
             </details>
 
             <div class="rule-section">
-                <input type="checkbox" id="heuristic-action" name="heuristic-action" />
-                <label for="heuristic-action">Handle unknown popups (heuristic rule)</label>
+                <input type="radio" id="heuristic-off" name="heuristic-mode" value="off" checked />
+                <label for="heuristic-off">Off</label>
+            </div>
+
+            <div>
+                <input type="radio" id="heuristic-reject" name="heuristic-mode" value="reject" />
+                <label for="heuristic-reject">Reject when possible</label>
+            </div>
+
+            <div>
+                <input type="radio" id="heuristic-tier1" name="heuristic-mode" value="tier1" />
+                <label for="heuristic-tier1">Acknowledge if no reject (tier 1)</label>
+            </div>
+
+            <div>
+                <input type="radio" id="heuristic-tier2" name="heuristic-mode" value="tier2" />
+                <label for="heuristic-tier2">Accept if no reject or acknowledge (tier 2)</label>
             </div>
         </fieldset>
 

--- a/addon/popup.ts
+++ b/addon/popup.ts
@@ -33,7 +33,10 @@ async function init() {
     const cosmeticOffRadio = document.querySelector('input#cosmetic-off') as HTMLInputElement;
     const generatedOnRadio = document.querySelector('input#generated-on') as HTMLInputElement;
     const generatedOffRadio = document.querySelector('input#generated-off') as HTMLInputElement;
-    const heuristicActionCheckbox = document.querySelector('input#heuristic-action') as HTMLInputElement;
+    const heuristicOffRadio = document.querySelector('input#heuristic-off') as HTMLInputElement;
+    const heuristicRejectRadio = document.querySelector('input#heuristic-reject') as HTMLInputElement;
+    const heuristicTier1Radio = document.querySelector('input#heuristic-tier1') as HTMLInputElement;
+    const heuristicTier2Radio = document.querySelector('input#heuristic-tier2') as HTMLInputElement;
     const visualTestOnRadio = document.querySelector('input#visual-test-on') as HTMLInputElement;
     const visualTestOffRadio = document.querySelector('input#visual-test-off') as HTMLInputElement;
     const popupMutationOnRadio = document.querySelector('input#popup-mutation-on') as HTMLInputElement;
@@ -164,7 +167,15 @@ async function init() {
         generatedOffRadio.checked = true;
     }
 
-    heuristicActionCheckbox.checked = autoconsentConfig.enableHeuristicAction;
+    if (autoconsentConfig.heuristicMode === 'reject') {
+        heuristicRejectRadio.checked = true;
+    } else if (autoconsentConfig.heuristicMode === 'tier1') {
+        heuristicTier1Radio.checked = true;
+    } else if (autoconsentConfig.heuristicMode === 'tier2') {
+        heuristicTier2Radio.checked = true;
+    } else {
+        heuristicOffRadio.checked = true;
+    }
 
     if (autoconsentConfig.visualTest) {
         visualTestOnRadio.checked = true;
@@ -224,11 +235,22 @@ async function init() {
     generatedOnRadio.addEventListener('change', generatedChange);
     generatedOffRadio.addEventListener('change', generatedChange);
 
-    function heuristicActionChange() {
-        autoconsentConfig.enableHeuristicAction = heuristicActionCheckbox.checked;
+    function heuristicModeChange() {
+        if (heuristicRejectRadio.checked) {
+            autoconsentConfig.heuristicMode = 'reject';
+        } else if (heuristicTier1Radio.checked) {
+            autoconsentConfig.heuristicMode = 'tier1';
+        } else if (heuristicTier2Radio.checked) {
+            autoconsentConfig.heuristicMode = 'tier2';
+        } else {
+            autoconsentConfig.heuristicMode = 'off';
+        }
         storageSet({ config: autoconsentConfig });
     }
-    heuristicActionCheckbox.addEventListener('change', heuristicActionChange);
+    heuristicOffRadio.addEventListener('change', heuristicModeChange);
+    heuristicRejectRadio.addEventListener('change', heuristicModeChange);
+    heuristicTier1Radio.addEventListener('change', heuristicModeChange);
+    heuristicTier2Radio.addEventListener('change', heuristicModeChange);
 
     function visualTestChange() {
         autoconsentConfig.visualTest = visualTestOnRadio.checked;

--- a/addon/utils.ts
+++ b/addon/utils.ts
@@ -12,8 +12,8 @@ export function extensionDefaultConfig(storedConfig: Partial<Config> = {}): Conf
     if (storedConfig.enablePopupMutationObserver === undefined) {
         storedConfig.enablePopupMutationObserver = true;
     }
-    if (storedConfig.enableHeuristicAction === undefined) {
-        storedConfig.enableHeuristicAction = true;
+    if (storedConfig.heuristicMode === undefined) {
+        storedConfig.heuristicMode = 'tier1';
     }
     if (!storedConfig.logs) {
         storedConfig.logs = {

--- a/lib/cmps/base.ts
+++ b/lib/cmps/base.ts
@@ -1,4 +1,4 @@
-import { AutoCMP, DomActionsProvider, PopupData, PopupHandlingMode, PopupHandlingModes } from '../types';
+import { AutoCMP, DomActionsProvider, HeuristicLevel, PopupData } from '../types';
 import { AutoConsentCMPRule, AutoConsentRuleStep, ElementSelector, HideMethod, RunContext, VisibilityCheck } from '../rules';
 import { requestEval } from '../eval-handler';
 import AutoConsent from '../web';
@@ -419,9 +419,9 @@ export class AutoConsentCMP extends AutoConsentCMPBase {
 
 export class AutoConsentHeuristicCMP extends AutoConsentCMPBase {
     popups: PopupData[] = [];
-    mode: PopupHandlingMode;
+    mode: HeuristicLevel;
 
-    constructor(autoconsentInstance: AutoConsent, mode: PopupHandlingMode = PopupHandlingModes.Reject) {
+    constructor(autoconsentInstance: AutoConsent, mode: HeuristicLevel = '1') {
         super(autoconsentInstance);
         this.name = 'HEURISTIC';
         this.runContext = {
@@ -453,7 +453,7 @@ export class AutoConsentHeuristicCMP extends AutoConsentCMPBase {
             performance.measure('heuristicDetector', 'heuristicDetectorStart', 'heuristicDetectorEnd');
 
         if (this.popups.length > 0) {
-            this.name = `HEURISTIC-TIER${this.popups[0].regexClassification}`;
+            this.name = `HEURISTIC-${this.popups[0].regexClassification?.toUpperCase()}`;
             return Promise.resolve(true);
         }
         return Promise.resolve(false);
@@ -473,8 +473,7 @@ export class AutoConsentHeuristicCMP extends AutoConsentCMPBase {
         const popup = this.popups[0];
         const level = popup.regexClassification;
         const buttons = popup.buttons;
-        const targetButtonType =
-            level === PopupHandlingModes.Reject ? 'reject' : level === PopupHandlingModes.Tier1 ? 'acknowledge' : 'accept';
+        const targetButtonType = level === 'reject' ? 'reject' : level === 'tier1' ? 'acknowledge' : 'accept';
         return buttons.find((button) => button.regexClassification === targetButtonType);
     }
 

--- a/lib/cmps/base.ts
+++ b/lib/cmps/base.ts
@@ -421,7 +421,7 @@ export class AutoConsentHeuristicCMP extends AutoConsentCMPBase {
     popups: PopupData[] = [];
     mode: HeuristicLevel;
 
-    constructor(autoconsentInstance: AutoConsent, mode: HeuristicLevel = '1') {
+    constructor(autoconsentInstance: AutoConsent, mode: HeuristicLevel = 'reject') {
         super(autoconsentInstance);
         this.name = 'HEURISTIC';
         this.runContext = {

--- a/lib/heuristics.ts
+++ b/lib/heuristics.ts
@@ -54,7 +54,6 @@ export function getActionablePopups(mode: HeuristicLevel = 'reject', timeout = P
         .filter(
             (popup) =>
                 popup.regexClassification !== undefined &&
-                popup.regexClassification !== 'none' &&
                 acceptedLevels.includes(popup.regexClassification),
         )
         .sort((a, b) => ((a.regexClassification ?? '') > (b.regexClassification ?? '') ? 1 : -1));

--- a/lib/heuristics.ts
+++ b/lib/heuristics.ts
@@ -6,7 +6,7 @@ import {
     REJECT_PATTERNS,
     SETTINGS_PATTERNS,
 } from './heuristic-patterns';
-import { ButtonData, ButtonRegexClassification, PopupData, PopupHandlingMode, PopupHandlingModes } from './types';
+import { ButtonData, ButtonRegexClassification, HeuristicLevel, PopupClassification, PopupData } from './types';
 import { isElementVisible, isTopFrame } from './utils';
 
 const BUTTON_LIKE_ELEMENT_SELECTOR = 'button, input[type="button"], input[type="submit"], a, [role="button"], [class*="button"]';
@@ -28,7 +28,12 @@ export function checkHeuristicPatterns(allText: string, detectPatterns = DETECT_
     return { patterns, snippets };
 }
 
-export function getActionablePopups(mode: PopupHandlingMode = PopupHandlingModes.Reject, timeout = POPUP_SEARCH_MAX_TIME): PopupData[] {
+export function getActionablePopups(mode: HeuristicLevel = '1', timeout = POPUP_SEARCH_MAX_TIME): PopupData[] {
+    const acceptedLevels: PopupClassification[] =
+        mode === 'tier2' ? ['reject', 'tier1', 'tier2'] : mode === 'tier1' ? ['reject', 'tier1'] : ['reject'];
+    if (acceptedLevels.length === 0) {
+        return [];
+    }
     const popups = getPotentialPopups(timeout);
     const result = popups.reduce((acc, popup) => {
         const popupText = popup.text?.trim();
@@ -49,10 +54,10 @@ export function getActionablePopups(mode: PopupHandlingMode = PopupHandlingModes
         .filter(
             (popup) =>
                 popup.regexClassification !== undefined &&
-                popup.regexClassification !== PopupHandlingModes.None &&
-                popup.regexClassification <= mode,
+                popup.regexClassification !== 'none' &&
+                acceptedLevels.includes(popup.regexClassification),
         )
-        .sort((a, b) => (a.regexClassification ?? 0) - (b.regexClassification ?? 0));
+        .sort((a, b) => ((a.regexClassification ?? '') > (b.regexClassification ?? '') ? 1 : -1));
 }
 
 export function classifyButtons(buttons: ButtonData[]) {
@@ -61,7 +66,7 @@ export function classifyButtons(buttons: ButtonData[]) {
     }
 }
 
-function classifyPopup(buttons: ButtonData[]): PopupHandlingMode {
+function classifyPopup(buttons: ButtonData[]): PopupClassification {
     const { reject, settings, accept, acknowledge } = buttons.reduce(
         (acc, button) => {
             if (button.regexClassification && button.regexClassification !== 'other') {
@@ -72,18 +77,18 @@ function classifyPopup(buttons: ButtonData[]): PopupHandlingMode {
         { reject: 0, settings: 0, accept: 0, acknowledge: 0 },
     );
     if (reject > 0) {
-        return PopupHandlingModes.Reject;
+        return 'reject';
     }
     if (settings > 0) {
-        return PopupHandlingModes.None;
+        return 'none';
     }
     if (acknowledge > 0) {
-        return PopupHandlingModes.Tier1;
+        return 'tier1';
     }
     if (accept > 0) {
-        return accept === 1 ? PopupHandlingModes.Tier2 : PopupHandlingModes.None;
+        return accept === 1 ? 'tier2' : 'none';
     }
-    return PopupHandlingModes.None;
+    return 'none';
 }
 
 /**

--- a/lib/heuristics.ts
+++ b/lib/heuristics.ts
@@ -28,7 +28,7 @@ export function checkHeuristicPatterns(allText: string, detectPatterns = DETECT_
     return { patterns, snippets };
 }
 
-export function getActionablePopups(mode: HeuristicLevel = '1', timeout = POPUP_SEARCH_MAX_TIME): PopupData[] {
+export function getActionablePopups(mode: HeuristicLevel = 'reject', timeout = POPUP_SEARCH_MAX_TIME): PopupData[] {
     const acceptedLevels: PopupClassification[] =
         mode === 'tier2' ? ['reject', 'tier1', 'tier2'] : mode === 'tier1' ? ['reject', 'tier1'] : ['reject'];
     if (acceptedLevels.length === 0) {

--- a/lib/heuristics.ts
+++ b/lib/heuristics.ts
@@ -51,11 +51,7 @@ export function getActionablePopups(mode: HeuristicLevel = 'reject', timeout = P
     }, [] as PopupData[]);
     // popups filtered by mode and sorted so a popup with reject will always win.
     return result
-        .filter(
-            (popup) =>
-                popup.regexClassification !== undefined &&
-                acceptedLevels.includes(popup.regexClassification),
-        )
+        .filter((popup) => popup.regexClassification !== undefined && acceptedLevels.includes(popup.regexClassification))
         .sort((a, b) => ((a.regexClassification ?? '') > (b.regexClassification ?? '') ? 1 : -1));
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -133,8 +133,8 @@ export interface PopupData {
  * The user setting for autoconsent and heuristic detection.
  *  - off: Heuristic detection is disabled.
  *  - reject: Heuristic detection is enabled, and will click the reject button on a popup if it exists.
- *  - tier1: Heuristic detection is enabled, and will click the acknowledge button on a popup if it exists, and no Reject button exists.
- *  - tier2: Heuristic detection is enabled, and will click the accept button on a popup if it exists, and no Reject or Acknowledge button exists.
+ *  - tier1: Heuristic detection is enabled, and will click the acknowledge button on a popup if it exists, and no Reject or Settings button exists.
+ *  - tier2: Heuristic detection is enabled, and will click the accept button on a popup if it exists, and no Reject, Acknowledge, or Settings button exists.
  */
 export type HeuristicLevel = 'off' | 'reject' | 'tier1' | 'tier2';
 export type PopupClassification = 'none' | 'reject' | 'tier1' | 'tier2';

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -64,7 +64,6 @@ export type Config = {
     prehideTimeout: number;
     enableFilterList: boolean;
     enableHeuristicDetection: boolean;
-    enableHeuristicAction: boolean;
     enablePopupMutationObserver: boolean;
     visualTest: boolean; // If true, the script will delay before every click action
     logs: {
@@ -78,7 +77,7 @@ export type Config = {
     };
     performanceLoggingEnabled: boolean;
     heuristicPopupSearchTimeout: number;
-    heuristicMode: PopupHandlingMode; // controls the behavior of the heuristic popup detection. Has no effect if enableHeuristicDetection is false.
+    heuristicMode: HeuristicLevel; // controls the behavior of the heuristic popup detection.
 };
 
 export type LifecycleState =
@@ -127,20 +126,16 @@ export interface PopupData {
     text: string;
     element: HTMLElement;
     buttons: ButtonData[];
-    regexClassification?: PopupHandlingMode;
+    regexClassification?: PopupClassification;
 }
 
 /**
- * Controls the behavior of the heuristic popup detection.
- *  - Reject: Will click the reject button on a popup if it exists.
- *  - Tier1: Will also click the acknowledge button on a popup if it exists, and no Reject button exists.
- *  - Tier2: Will also click the accept button on a popup if it exists, and no Reject or Acknowledge button exists.
- *  - None: Disabled
+ * The user setting for autoconsent and heuristic detection.
+ *  - off: Autoconsent is fully disabled.
+ *  - 0: Heuristic detection is disabled.
+ *  - 1: Heuristic detection is enabled, and will click the reject button on a popup if it exists.
+ *  - tier1: Heuristic detection is enabled, and will click the acknowledge button on a popup if it exists, and no Reject button exists.
+ *  - tier2: Heuristic detection is enabled, and will click the accept button on a popup if it exists, and no Reject or Acknowledge button exists.
  */
-export const PopupHandlingModes = {
-    None: -1,
-    Reject: 0,
-    Tier1: 1,
-    Tier2: 2,
-} as const;
-export type PopupHandlingMode = (typeof PopupHandlingModes)[keyof typeof PopupHandlingModes];
+export type HeuristicLevel = 'off' | '0' | '1' | 'tier1' | 'tier2';
+export type PopupClassification = 'none' | 'reject' | 'tier1' | 'tier2';

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -131,11 +131,10 @@ export interface PopupData {
 
 /**
  * The user setting for autoconsent and heuristic detection.
- *  - off: Autoconsent is fully disabled.
- *  - 0: Heuristic detection is disabled.
- *  - 1: Heuristic detection is enabled, and will click the reject button on a popup if it exists.
+ *  - off: Heuristic detection is disabled.
+ *  - reject: Heuristic detection is enabled, and will click the reject button on a popup if it exists.
  *  - tier1: Heuristic detection is enabled, and will click the acknowledge button on a popup if it exists, and no Reject button exists.
  *  - tier2: Heuristic detection is enabled, and will click the accept button on a popup if it exists, and no Reject or Acknowledge button exists.
  */
-export type HeuristicLevel = 'off' | '0' | '1' | 'tier1' | 'tier2';
+export type HeuristicLevel = 'off' | 'reject' | 'tier1' | 'tier2';
 export type PopupClassification = 'none' | 'reject' | 'tier1' | 'tier2';

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -94,7 +94,7 @@ export function normalizeConfig(providedConfig: any): Config {
         },
         performanceLoggingEnabled: false,
         heuristicPopupSearchTimeout: 100,
-        heuristicMode: '1', // heuristic enabled in reject-only mode
+        heuristicMode: '0', // heuristic disabled by default
     };
     const updatedConfig: Config = copyObject(defaultConfig);
     // filter out any unknown entries

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,5 @@
 import { HideMethod } from './rules';
-import { Config, PopupHandlingModes } from './types';
+import { Config } from './types';
 
 // get or create a style container for CSS overrides
 export function getStyleElement(styleOverrideElementId = 'autoconsent-css-rules'): HTMLStyleElement {
@@ -77,7 +77,6 @@ export function normalizeConfig(providedConfig: any): Config {
         enableCosmeticRules: true,
         enableGeneratedRules: true,
         enableHeuristicDetection: false,
-        enableHeuristicAction: false,
         enablePopupMutationObserver: false,
         detectRetries: 20,
         isMainWorld: false,
@@ -95,7 +94,7 @@ export function normalizeConfig(providedConfig: any): Config {
         },
         performanceLoggingEnabled: false,
         heuristicPopupSearchTimeout: 100,
-        heuristicMode: PopupHandlingModes.Reject,
+        heuristicMode: '1', // heuristic enabled in reject-only mode
     };
     const updatedConfig: Config = copyObject(defaultConfig);
     // filter out any unknown entries

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -94,7 +94,7 @@ export function normalizeConfig(providedConfig: any): Config {
         },
         performanceLoggingEnabled: false,
         heuristicPopupSearchTimeout: 100,
-        heuristicMode: '0', // heuristic disabled by default
+        heuristicMode: 'off', // heuristic disabled by default
     };
     const updatedConfig: Config = copyObject(defaultConfig);
     // filter out any unknown entries

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -296,7 +296,7 @@ export default class AutoConsent {
         });
         // heuristic CMP is only run in the top frame and only if heuristic action is enabled and retries is odd
         const heuristicRules =
-            isTop && this.config.heuristicMode !== '0' && this.state.findCmpAttempts % 2 === 0
+            isTop && !['0', 'off'].includes(this.config.heuristicMode) && this.state.findCmpAttempts % 2 === 0
                 ? [new AutoConsentHeuristicCMP(this, this.config.heuristicMode)]
                 : [];
 

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -296,7 +296,7 @@ export default class AutoConsent {
         });
         // heuristic CMP is only run in the top frame and only if heuristic action is enabled and retries is odd
         const heuristicRules =
-            isTop && this.config.enableHeuristicAction && this.state.findCmpAttempts % 2 === 0
+            isTop && this.config.heuristicMode !== '0' && this.state.findCmpAttempts % 2 === 0
                 ? [new AutoConsentHeuristicCMP(this, this.config.heuristicMode)]
                 : [];
 

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -296,7 +296,7 @@ export default class AutoConsent {
         });
         // heuristic CMP is only run in the top frame and only if heuristic action is enabled and retries is odd
         const heuristicRules =
-            isTop && !['0', 'off'].includes(this.config.heuristicMode) && this.state.findCmpAttempts % 2 === 0
+            isTop && this.config.heuristicMode !== 'off' && this.state.findCmpAttempts % 2 === 0
                 ? [new AutoConsentHeuristicCMP(this, this.config.heuristicMode)]
                 : [];
 

--- a/tests-wtr/heuristics/get-actionable-popups.ts
+++ b/tests-wtr/heuristics/get-actionable-popups.ts
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { getActionablePopups } from '../../lib/heuristics';
-import { ButtonData, PopupHandlingModes } from '../../lib/types';
+import { ButtonData } from '../../lib/types';
 
 function rejectButtons(buttons: ButtonData[]) {
     return buttons.filter((b) => b.regexClassification === 'reject');
@@ -46,7 +46,7 @@ describe('getActionablePopups', () => {
         it('ignores popup with accept and settings buttons', () => {
             showPopup('popup-no-reject');
 
-            const popups = getActionablePopups(PopupHandlingModes.Tier2);
+            const popups = getActionablePopups('tier2');
 
             expect(popups.length).to.equal(0);
         });
@@ -56,7 +56,7 @@ describe('getActionablePopups', () => {
         it('finds accept-only popup with no reject buttons', () => {
             showPopup('popup-accept-only');
 
-            const popups = getActionablePopups(PopupHandlingModes.Tier2);
+            const popups = getActionablePopups('tier2');
 
             expect(popups.length).to.equal(1);
             expect(rejectButtons(popups[0].buttons)).to.have.length(0);
@@ -66,7 +66,7 @@ describe('getActionablePopups', () => {
         it('finds acknowledge-only popup with no reject buttons', () => {
             showPopup('popup-acknowledge-only');
 
-            const popups = getActionablePopups(PopupHandlingModes.Tier2);
+            const popups = getActionablePopups('tier2');
 
             expect(popups.length).to.equal(1);
             expect(rejectButtons(popups[0].buttons)).to.have.length(0);
@@ -76,10 +76,10 @@ describe('getActionablePopups', () => {
         it('finds popup with multiple reject buttons', () => {
             showPopup('popup-multiple-reject');
 
-            const popups = getActionablePopups(PopupHandlingModes.Tier2);
+            const popups = getActionablePopups('tier2');
 
             expect(popups.length).to.equal(1);
-            expect(popups[0].regexClassification).to.equal(PopupHandlingModes.Reject);
+            expect(popups[0].regexClassification).to.equal('reject');
             expect(rejectButtons(popups[0].buttons)).to.have.length(2);
         });
     });
@@ -88,7 +88,7 @@ describe('getActionablePopups', () => {
         it('does not return accept-only popup when mode is Reject', () => {
             showPopup('popup-accept-only');
 
-            const popups = getActionablePopups(PopupHandlingModes.Reject);
+            const popups = getActionablePopups();
 
             expect(popups.length).to.equal(0);
         });
@@ -96,16 +96,16 @@ describe('getActionablePopups', () => {
         it('returns acknowledge-only popup when mode is Tier1', () => {
             showPopup('popup-acknowledge-only');
 
-            const popups = getActionablePopups(PopupHandlingModes.Tier1);
+            const popups = getActionablePopups('tier1');
 
             expect(popups.length).to.equal(1);
-            expect(popups[0].regexClassification).to.equal(PopupHandlingModes.Tier1);
+            expect(popups[0].regexClassification).to.equal('tier1');
         });
 
         it('does not return accept-only popup when mode is Tier1', () => {
             showPopup('popup-accept-only');
 
-            const popups = getActionablePopups(PopupHandlingModes.Tier1);
+            const popups = getActionablePopups('tier1');
 
             expect(popups.length).to.equal(0);
         });
@@ -114,11 +114,11 @@ describe('getActionablePopups', () => {
             showPopup('popup-reject-all');
             showPopup('popup-accept-only');
 
-            const popups = getActionablePopups(PopupHandlingModes.Tier2);
+            const popups = getActionablePopups('tier2');
 
             expect(popups.length).to.equal(2);
-            expect(popups[0].regexClassification).to.equal(PopupHandlingModes.Reject);
-            expect(popups[1].regexClassification).to.equal(PopupHandlingModes.Tier2);
+            expect(popups[0].regexClassification).to.equal('reject');
+            expect(popups[1].regexClassification).to.equal('tier2');
         });
     });
 

--- a/tests-wtr/heuristics/heuristic-cmp.ts
+++ b/tests-wtr/heuristics/heuristic-cmp.ts
@@ -1,15 +1,14 @@
 import { expect } from '@esm-bundle/chai';
 import Autoconsent from '../../lib/web';
 import { AutoConsentHeuristicCMP } from '../../lib/cmps/base';
-import { PopupHandlingMode, PopupHandlingModes } from '../../lib/types';
+import { HeuristicLevel } from '../../lib/types';
 
 // must be run from heuristic-cmp.html
 describe('AutoConsentHeuristicCMP', () => {
-    function createAutoconsent(heuristicMode: PopupHandlingMode) {
+    function createAutoconsent(heuristicMode: HeuristicLevel) {
         return new Autoconsent(() => Promise.resolve(), {
             enabled: false,
             autoAction: null,
-            enableHeuristicAction: true,
             heuristicMode,
         });
     }
@@ -30,20 +29,20 @@ describe('AutoConsentHeuristicCMP', () => {
     });
 
     describe('detectCmp', () => {
-        it('detects reject popup as HEURISTIC-TIER0', async () => {
-            const autoconsent = createAutoconsent(PopupHandlingModes.Tier2);
-            const cmp = new AutoConsentHeuristicCMP(autoconsent, PopupHandlingModes.Tier2);
+        it('detects reject popup as HEURISTIC-REJECT', async () => {
+            const autoconsent = createAutoconsent('tier2');
+            const cmp = new AutoConsentHeuristicCMP(autoconsent, 'tier2');
             showPopup('popup-reject');
 
             const detected = await cmp.detectCmp();
 
             expect(detected).to.be.true;
-            expect(cmp.name).to.equal('HEURISTIC-TIER0');
+            expect(cmp.name).to.equal('HEURISTIC-REJECT');
         });
 
         it('detects acknowledge-only popup as HEURISTIC-TIER1', async () => {
-            const autoconsent = createAutoconsent(PopupHandlingModes.Tier2);
-            const cmp = new AutoConsentHeuristicCMP(autoconsent, PopupHandlingModes.Tier2);
+            const autoconsent = createAutoconsent('tier2');
+            const cmp = new AutoConsentHeuristicCMP(autoconsent, 'tier2');
             showPopup('popup-acknowledge-only');
 
             const detected = await cmp.detectCmp();
@@ -53,8 +52,8 @@ describe('AutoConsentHeuristicCMP', () => {
         });
 
         it('detects accept-only popup as HEURISTIC-TIER2', async () => {
-            const autoconsent = createAutoconsent(PopupHandlingModes.Tier2);
-            const cmp = new AutoConsentHeuristicCMP(autoconsent, PopupHandlingModes.Tier2);
+            const autoconsent = createAutoconsent('tier2');
+            const cmp = new AutoConsentHeuristicCMP(autoconsent, 'tier2');
             showPopup('popup-accept-only');
 
             const detected = await cmp.detectCmp();
@@ -64,8 +63,8 @@ describe('AutoConsentHeuristicCMP', () => {
         });
 
         it('does not detect popup with accept and settings buttons', async () => {
-            const autoconsent = createAutoconsent(PopupHandlingModes.Tier2);
-            const cmp = new AutoConsentHeuristicCMP(autoconsent, PopupHandlingModes.Tier2);
+            const autoconsent = createAutoconsent('tier2');
+            const cmp = new AutoConsentHeuristicCMP(autoconsent, 'tier2');
             showPopup('popup-accept-settings');
 
             const detected = await cmp.detectCmp();
@@ -73,33 +72,33 @@ describe('AutoConsentHeuristicCMP', () => {
             expect(detected).to.be.false;
         });
 
-        it('detects popup with multiple reject buttons as HEURISTIC-TIER0', async () => {
-            const autoconsent = createAutoconsent(PopupHandlingModes.Tier2);
-            const cmp = new AutoConsentHeuristicCMP(autoconsent, PopupHandlingModes.Tier2);
+        it('detects popup with multiple reject buttons as HEURISTIC-REJECT', async () => {
+            const autoconsent = createAutoconsent('tier2');
+            const cmp = new AutoConsentHeuristicCMP(autoconsent, 'tier2');
             showPopup('popup-multiple-reject');
 
             const detected = await cmp.detectCmp();
 
             expect(detected).to.be.true;
-            expect(cmp.name).to.equal('HEURISTIC-TIER0');
+            expect(cmp.name).to.equal('HEURISTIC-REJECT');
         });
 
         it('prefers reject popup when reject and accept popups are visible', async () => {
-            const autoconsent = createAutoconsent(PopupHandlingModes.Tier2);
-            const cmp = new AutoConsentHeuristicCMP(autoconsent, PopupHandlingModes.Tier2);
+            const autoconsent = createAutoconsent('tier2');
+            const cmp = new AutoConsentHeuristicCMP(autoconsent, 'tier2');
             showPopup('popup-tier-preference-reject', 'popup-tier-preference-accept');
 
             const detected = await cmp.detectCmp();
 
             expect(detected).to.be.true;
-            expect(cmp.name).to.equal('HEURISTIC-TIER0');
+            expect(cmp.name).to.equal('HEURISTIC-REJECT');
         });
     });
 
     describe('heuristicMode cap', () => {
         it('does not detect accept-only popup when mode is Reject', async () => {
-            const autoconsent = createAutoconsent(PopupHandlingModes.Reject);
-            const cmp = new AutoConsentHeuristicCMP(autoconsent, PopupHandlingModes.Reject);
+            const autoconsent = createAutoconsent('1');
+            const cmp = new AutoConsentHeuristicCMP(autoconsent, '1');
             showPopup('popup-accept-only');
 
             const detected = await cmp.detectCmp();
@@ -108,8 +107,8 @@ describe('AutoConsentHeuristicCMP', () => {
         });
 
         it('detects acknowledge-only popup when mode is Tier1', async () => {
-            const autoconsent = createAutoconsent(PopupHandlingModes.Tier1);
-            const cmp = new AutoConsentHeuristicCMP(autoconsent, PopupHandlingModes.Tier1);
+            const autoconsent = createAutoconsent('tier1');
+            const cmp = new AutoConsentHeuristicCMP(autoconsent, 'tier1');
             showPopup('popup-acknowledge-only');
 
             const detected = await cmp.detectCmp();
@@ -119,8 +118,8 @@ describe('AutoConsentHeuristicCMP', () => {
         });
 
         it('does not detect accept-only popup when mode is Tier1', async () => {
-            const autoconsent = createAutoconsent(PopupHandlingModes.Tier1);
-            const cmp = new AutoConsentHeuristicCMP(autoconsent, PopupHandlingModes.Tier1);
+            const autoconsent = createAutoconsent('tier1');
+            const cmp = new AutoConsentHeuristicCMP(autoconsent, 'tier1');
             showPopup('popup-accept-only');
 
             const detected = await cmp.detectCmp();
@@ -130,9 +129,9 @@ describe('AutoConsentHeuristicCMP', () => {
     });
 
     describe('optOut', () => {
-        it('clicks the reject button for TIER0 popup', async () => {
-            const autoconsent = createAutoconsent(PopupHandlingModes.Tier2);
-            const cmp = new AutoConsentHeuristicCMP(autoconsent, PopupHandlingModes.Tier2);
+        it('clicks the reject button for REJECT popup', async () => {
+            const autoconsent = createAutoconsent('tier2');
+            const cmp = new AutoConsentHeuristicCMP(autoconsent, 'tier2');
             showPopup('popup-reject');
             await cmp.detectCmp();
 
@@ -146,8 +145,8 @@ describe('AutoConsentHeuristicCMP', () => {
         });
 
         it('clicks the acknowledge button for TIER1 popup', async () => {
-            const autoconsent = createAutoconsent(PopupHandlingModes.Tier2);
-            const cmp = new AutoConsentHeuristicCMP(autoconsent, PopupHandlingModes.Tier2);
+            const autoconsent = createAutoconsent('tier2');
+            const cmp = new AutoConsentHeuristicCMP(autoconsent, 'tier2');
             showPopup('popup-acknowledge-only');
             await cmp.detectCmp();
 
@@ -161,8 +160,8 @@ describe('AutoConsentHeuristicCMP', () => {
         });
 
         it('clicks the accept button for TIER2 popup', async () => {
-            const autoconsent = createAutoconsent(PopupHandlingModes.Tier2);
-            const cmp = new AutoConsentHeuristicCMP(autoconsent, PopupHandlingModes.Tier2);
+            const autoconsent = createAutoconsent('tier2');
+            const cmp = new AutoConsentHeuristicCMP(autoconsent, 'tier2');
             showPopup('popup-accept-only');
             await cmp.detectCmp();
 

--- a/tests-wtr/heuristics/heuristic-cmp.ts
+++ b/tests-wtr/heuristics/heuristic-cmp.ts
@@ -97,8 +97,8 @@ describe('AutoConsentHeuristicCMP', () => {
 
     describe('heuristicMode cap', () => {
         it('does not detect accept-only popup when mode is Reject', async () => {
-            const autoconsent = createAutoconsent('1');
-            const cmp = new AutoConsentHeuristicCMP(autoconsent, '1');
+            const autoconsent = createAutoconsent('reject');
+            const cmp = new AutoConsentHeuristicCMP(autoconsent, 'reject');
             showPopup('popup-accept-only');
 
             const detected = await cmp.detectCmp();

--- a/tests-wtr/lifecycle/find-cmp.ts
+++ b/tests-wtr/lifecycle/find-cmp.ts
@@ -10,7 +10,7 @@ describe('Autoconsent.findCmp', () => {
             autoconsent = new Autoconsent((msg) => Promise.resolve(), {
                 enabled: false, // bypass initialization
                 autoAction: null,
-                heuristicMode: '0',
+                heuristicMode: 'off',
             });
         });
 
@@ -140,7 +140,7 @@ describe('Autoconsent.findCmp', () => {
             autoconsent = new Autoconsent((msg) => Promise.resolve(), {
                 enabled: false,
                 autoAction: null,
-                heuristicMode: '1',
+                heuristicMode: 'reject',
             });
         });
 

--- a/tests-wtr/lifecycle/find-cmp.ts
+++ b/tests-wtr/lifecycle/find-cmp.ts
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import Autoconsent from '../../lib/web';
 import Onetrust from '../../lib/cmps/onetrust';
-import { PopupHandlingModes } from '../../lib/types';
 
 describe('Autoconsent.findCmp', () => {
     let autoconsent: Autoconsent;
@@ -11,7 +10,7 @@ describe('Autoconsent.findCmp', () => {
             autoconsent = new Autoconsent((msg) => Promise.resolve(), {
                 enabled: false, // bypass initialization
                 autoAction: null,
-                enableHeuristicAction: false,
+                heuristicMode: '0',
             });
         });
 
@@ -141,7 +140,7 @@ describe('Autoconsent.findCmp', () => {
             autoconsent = new Autoconsent((msg) => Promise.resolve(), {
                 enabled: false,
                 autoAction: null,
-                enableHeuristicAction: true,
+                heuristicMode: '1',
             });
         });
 
@@ -167,7 +166,7 @@ describe('Autoconsent.findCmp', () => {
             const found = await autoconsent.findCmp(1);
 
             expect(found).to.have.length(1);
-            expect(found[0].name).to.equal('HEURISTIC-TIER0');
+            expect(found[0].name).to.equal('HEURISTIC-REJECT');
         });
 
         it('prefers declarative rules over heuristic CMP', async () => {
@@ -192,8 +191,7 @@ describe('Autoconsent.findCmp', () => {
             autoconsent = new Autoconsent((msg) => Promise.resolve(), {
                 enabled: false,
                 autoAction: null,
-                enableHeuristicAction: true,
-                heuristicMode: PopupHandlingModes.Tier1,
+                heuristicMode: 'tier1',
             });
             autoconsent.state.findCmpAttempts = 1;
 
@@ -210,8 +208,7 @@ describe('Autoconsent.findCmp', () => {
             autoconsent = new Autoconsent((msg) => Promise.resolve(), {
                 enabled: false,
                 autoAction: null,
-                enableHeuristicAction: true,
-                heuristicMode: PopupHandlingModes.Tier2,
+                heuristicMode: 'tier2',
             });
             autoconsent.state.findCmpAttempts = 1;
 


### PR DESCRIPTION
Task/Issue URL:

## Description:
 - Remove `enableHeuristicAction` parameter. Use `heuristicMode` as the source of truth.
 - Change the type of `heuristicMode` to match the pixel type.

## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how unknown consent popups are detected and which buttons get clicked, including default-off library behavior vs extension defaults—behavior shifts for integrators still using the removed config flag.
> 
> **Overview**
> Replaces the separate **`enableHeuristicAction`** flag and numeric **`PopupHandlingMode`** with a single string **`heuristicMode`** (`off`, `reject`, `tier1`, `tier2`). Heuristic CMP registration now keys off **`heuristicMode !== 'off'`** instead of the old boolean.
> 
> Popup/button tier logic uses new string types **`HeuristicLevel`** (user config) and **`PopupClassification`** (detected popups). **`getActionablePopups`** filters by allowed classification strings and sorts them lexicographically; detected CMP names change from **`HEURISTIC-TIER0`** to labels like **`HEURISTIC-REJECT`**.
> 
> The test extension popup swaps the heuristic checkbox for a four-option radio fieldset wired to **`heuristicMode`**. Library **`normalizeConfig`** defaults **`heuristicMode`** to **`off`**; the extension default remains **`tier1`** when unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca795641b7b1497bff1cb84012e68bf414235b08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->