### PR TITLE
Update nhnieuws rule for redesigned consent popup

### DIFF
--- a/rules/autoconsent/nhnieuws.json
+++ b/rules/autoconsent/nhnieuws.json
@@ -7,26 +7,23 @@
     "prehideSelectors": ["[class*=ConsentManager]"],
     "detectCmp": [
         {
-            "exists": "[class*=ConsentManager]"
+            "exists": "[class*=ConsentManager_cookieBar]"
         }
     ],
     "detectPopup": [
         {
-            "visible": "[class*=ConsentManager]"
+            "visible": "[class*=ConsentManager_cookieBar]",
+            "check": "any"
         }
     ],
     "optIn": [
         {
-            "waitForThenClick": "[class*=ConsentManager_continue]"
+            "waitForThenClick": "xpath///button[contains(@class, \"ConsentManager_cookieBarButton\") and contains(., \"accepteren\")]"
         }
     ],
     "optOut": [
         {
-            "waitForThenClick": "[class*=ConsentManager_row] input[type=radio][id$=no]",
-            "all": true
-        },
-        {
-            "waitForThenClick": "[class*=ConsentManager_continue]"
+            "waitForThenClick": "xpath///button[contains(@class, \"ConsentManager_cookieBarButton\") and contains(., \"weigeren\")]"
         }
     ],
     "test": [


### PR DESCRIPTION
NH Nieuws redesigned their consent UI: the popup now exposes direct 'Alles accepteren' / 'Alles weigeren' buttons instead of the previous radio-group flow gated by a 'Continue' button. The existing optOut step targeted radio inputs that no longer exist, causing the action to fail while detection still matched.

Update the click selectors to target the new buttons by text content, and narrow detection to the visible cookie bar to avoid matching the hidden underlying <dialog> element.

Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1216088580721685?focus=true

## Description:

<!--
Don't forget to label the PR.

Impact: choose one of `major`, `minor`, or `patch`.
Category: choose one of `rules`, `bug`, `enhancement`, `performance`, `dependencies`, `ci`, `ai`, `documentation`, `tests`, `internal`, or `other`.
Details: https://github.com/duckduckgo/autoconsent/blob/main/docs/release-notes.md
-->

## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-site consent rule selector updates only; no shared engine or security-sensitive logic changes.
> 
> **Overview**
> Updates the **nhnieuws** autoconsent rule for NH Nieuws’s redesigned consent UI, which now uses direct **accepteren** / **weigeren** buttons instead of radios plus **Continue**.
> 
> **Detection** now targets `[class*=ConsentManager_cookieBar]` and uses a visible check with `"check": "any"` so a hidden underlying dialog is not mistaken for the popup.
> 
> **optIn** and **optOut** click those bar buttons via XPath (class `ConsentManager_cookieBarButton` and button text). The old **optOut** path that selected `no` radios and clicked continue is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84dcd2901cd7268f25eec00b6f6f701c100188c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->