### PR TITLE
Clean up some outdated config parameters

### DIFF
--- a/.agents/skills/proxy-testing/scripts/regional-proxy.mjs
+++ b/.agents/skills/proxy-testing/scripts/regional-proxy.mjs
@@ -55,6 +55,8 @@
  * @property {(url: string, region: string) => TestResult} collectResult
  */
 
+/** @typedef {import('../../../../lib/types').Config} Config */
+
 /**
  * Primitives the message handler uses to talk to a specific frame's content script.
  * `frameRef` is the isolated world's execution-context uniqueId the message arrived from;
@@ -140,6 +142,7 @@ export async function injectAutoconsent(page, options = {}) {
     const action = 'action' in options ? options.action : 'optOut';
     /** @type {any[]} */
     const received = [];
+    /** @type {Partial<Config>} */
     const config = {
         enabled: true,
         autoAction: action,
@@ -149,7 +152,7 @@ export async function injectAutoconsent(page, options = {}) {
         enableCosmeticRules: true,
         enableGeneratedRules: true,
         enableHeuristicDetection: true,
-        enableHeuristicAction: true,
+        heuristicMode: 'tier2',
         // The engine runs in the isolated world; eval snippets are forwarded to the main world.
         isMainWorld: false,
         logs: { lifecycle: true, rulesteps: true, detectionsteps: false, evals: false, errors: true },

--- a/docs/puppeteer.md
+++ b/docs/puppeteer.md
@@ -41,7 +41,7 @@ const autoconsentConfig = {
   isMainWorld: false,
   prehideTimeout: 2000,
   enableHeuristicDetection: true,
-  enableHeuristicAction: true,
+  heuristicMode: 'tier2',
   logs: {
     lifecycle: false,
     rulesteps: false,

--- a/standalone/content.ts
+++ b/standalone/content.ts
@@ -55,7 +55,7 @@ if (!window.autoconsentReceiveMessage) {
     const config: Partial<Config> = {
         isMainWorld: true,
         enableHeuristicDetection: true,
-        enableHeuristicAction: true,
+        heuristicMode: 'tier2',
         enablePopupMutationObserver: false,
         logs: {
             lifecycle: true,

--- a/tests-wtr/lifecycle/find-cmp.ts
+++ b/tests-wtr/lifecycle/find-cmp.ts
@@ -5,7 +5,7 @@ import Onetrust from '../../lib/cmps/onetrust';
 describe('Autoconsent.findCmp', () => {
     let autoconsent: Autoconsent;
 
-    describe('enableHeuristicAction = false', () => {
+    describe('heuristicMode = off', () => {
         beforeEach(() => {
             autoconsent = new Autoconsent((msg) => Promise.resolve(), {
                 enabled: false, // bypass initialization
@@ -135,7 +135,7 @@ describe('Autoconsent.findCmp', () => {
         });
     });
 
-    describe('enableHeuristicAction = true', () => {
+    describe('heuristicMode = reject', () => {
         beforeEach(() => {
             autoconsent = new Autoconsent((msg) => Promise.resolve(), {
                 enabled: false,

--- a/tests-wtr/web/do-opt-in.test.ts
+++ b/tests-wtr/web/do-opt-in.test.ts
@@ -19,7 +19,7 @@ function createTestConfig(overrides: Partial<Config> = {}): Config {
         isMainWorld: false,
         prehideTimeout: 2000,
         enableHeuristicDetection: false,
-        enableHeuristicAction: false,
+        heuristicMode: 'off',
         visualTest: false,
         logs: {
             lifecycle: false,

--- a/tests-wtr/web/do-opt-out.test.ts
+++ b/tests-wtr/web/do-opt-out.test.ts
@@ -19,7 +19,7 @@ function createTestConfig(overrides: Partial<Config> = {}): Config {
         isMainWorld: false,
         prehideTimeout: 2000,
         enableHeuristicDetection: false,
-        enableHeuristicAction: false,
+        heuristicMode: 'off',
         visualTest: false,
         logs: {
             lifecycle: false,

--- a/tests-wtr/web/do-self-test.test.ts
+++ b/tests-wtr/web/do-self-test.test.ts
@@ -19,7 +19,7 @@ function createTestConfig(overrides: Partial<Config> = {}): Config {
         isMainWorld: false,
         prehideTimeout: 2000,
         enableHeuristicDetection: false,
-        enableHeuristicAction: false,
+        heuristicMode: 'off',
         visualTest: false,
         logs: {
             lifecycle: false,

--- a/tests-wtr/web/filter-cmps.test.ts
+++ b/tests-wtr/web/filter-cmps.test.ts
@@ -41,7 +41,7 @@ function createTestConfig(overrides: Partial<Config> = {}): Config {
         isMainWorld: false,
         prehideTimeout: 2000,
         enableHeuristicDetection: false,
-        enableHeuristicAction: false,
+        heuristicMode: 'off',
         visualTest: false,
         logs: {
             lifecycle: false,

--- a/tests-wtr/web/receive-message-callback.test.ts
+++ b/tests-wtr/web/receive-message-callback.test.ts
@@ -18,7 +18,7 @@ function createTestConfig(overrides: Partial<Config> = {}): Config {
         isMainWorld: false,
         prehideTimeout: 2000,
         enableHeuristicDetection: false,
-        enableHeuristicAction: false,
+        heuristicMode: 'off',
         visualTest: false,
         logs: {
             lifecycle: false,

--- a/tests-wtr/web/update-state.test.ts
+++ b/tests-wtr/web/update-state.test.ts
@@ -18,7 +18,7 @@ function createTestConfig(overrides: Partial<Config> = {}): Config {
         isMainWorld: false,
         prehideTimeout: 2000,
         enableHeuristicDetection: false,
-        enableHeuristicAction: false,
+        heuristicMode: 'off',
         visualTest: false,
         logs: {
             lifecycle: false,


### PR DESCRIPTION
Task/Issue URL:

## Description:


## Steps to test this PR:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only call-site updates with no engine logic in the diff; behavior follows existing `heuristicMode` semantics if mappings match the old flag.
> 
> **Overview**
> Removes the deprecated **`enableHeuristicAction`** boolean from example configs, standalone defaults, and test fixtures, and uses **`heuristicMode`** instead (`'off'`, `'reject'`, `'tier2'`, etc.) to match the current `Config` type.
> 
> **Runtime defaults** for proxy testing, Puppeteer docs, and standalone content now set **`heuristicMode: 'tier2'`** where heuristic action was previously enabled. Tests that disabled heuristic action use **`heuristicMode: 'off'`**. **`find-cmp`** suite labels are updated from the old boolean wording to **`heuristicMode = off`** / **`heuristicMode = reject`**.
> 
> **`regional-proxy.mjs`** also types the injected config as **`Partial<Config>`** via a JSDoc import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b3ce22f314cf35aebf29639e1fef216e205b435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->