### PR TITLE
add performance measuremenet button to devtools

### DIFF
--- a/addon/devtools/panel.html
+++ b/addon/devtools/panel.html
@@ -32,6 +32,9 @@
                     <button class="button" id="reload">Reload</button>
                 </div>
                 <div class="level-item">
+                    <button class="button" id="measure-performance">Measure Performance</button>
+                </div>
+                <div class="level-item">
                     <label class="checkbox">
                         <input type="checkbox" id="clear-storage" />
                         Clear site storage on reload
@@ -65,6 +68,7 @@
                     <th>Detection attempts</th>
                     <th>CMP Detected</th>
                     <th>Popup open</th>
+                    <th>Performance</th>
                 </tr>
             </thead>
             <tbody></tbody>
@@ -73,6 +77,7 @@
             <tr>
                 <td></td>
                 <td class="url"></td>
+                <td></td>
                 <td></td>
                 <td></td>
                 <td></td>

--- a/addon/devtools/panel.ts
+++ b/addon/devtools/panel.ts
@@ -1,4 +1,4 @@
-import { BackgroundDevtoolsMessage, DevtoolsMessage } from '../../lib/messages';
+import { BackgroundDevtoolsMessage, BackgroundMessage, DevtoolsMessage } from '../../lib/messages';
 import { Config } from '../../lib/types';
 import { storageGet, storageSet } from '../mv-compat';
 
@@ -25,6 +25,16 @@ function getRowForInstance(instanceId: string) {
     }
 }
 
+function formatPerformance(performance?: Record<string, number[]>) {
+    if (!performance) {
+        return '';
+    }
+    return Object.entries(performance)
+        .filter(([, values]) => values.length > 0)
+        .map(([name, values]) => `${name}: ${values.map((value) => `${value}ms`).join(', ')}`)
+        .join('\n');
+}
+
 function reconnect(): chrome.runtime.Port {
     backgroundPageConnection = chrome.runtime.connect({
         name: 'devtools-panel',
@@ -44,6 +54,7 @@ function reconnect(): chrome.runtime.Port {
             td[4].innerText = `${message.state.findCmpAttempts}`;
             td[5].innerText = message.state.detectedCmps.join(', ');
             td[6].innerText = message.state.detectedPopups.join(', ');
+            td[7].innerText = formatPerformance(message.state.performance);
         } else if (message.type === 'instanceTerminated') {
             document.getElementById(`instance-${message.instanceId}`)?.classList.add('dead');
         }
@@ -83,6 +94,12 @@ document.getElementById('reload').addEventListener('click', async () => {
     }
     clearPanel();
     chrome.devtools.inspectedWindow.reload({});
+});
+
+document.getElementById('measure-performance').addEventListener('click', () => {
+    chrome.tabs.sendMessage(chrome.devtools.inspectedWindow.tabId, {
+        type: 'measurePerformance',
+    } as BackgroundMessage);
 });
 
 document.getElementById('mode').addEventListener('change', async () => {


### PR DESCRIPTION
Task/Issue URL:

## Description:

<!--
Don't forget to label the PR.

Version labels use the `version:` prefix, for example `version: patch`.
Category labels use the `category:` prefix, for example `category: rules`.
Details: https://github.com/duckduckgo/autoconsent/blob/main/docs/release-notes.md
-->

## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to devtools UI wiring and display; no production consent or detection logic is modified in this diff.
> 
> **Overview**
> Adds **Measure Performance** to the Autoconsent devtools panel so you can trigger timing collection on the inspected tab and see results per frame instance.
> 
> Clicking the button sends a `measurePerformance` tab message (same path as opt-in/opt-out). Report rows gain a **Performance** column that renders `state.performance` as labeled millisecond lists via a new `formatPerformance` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19bc38219b06430a3d045c0291c9ca8fc197bcb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->