### PR TITLE
Bail out of detection if the page is too big

### DIFF
--- a/addon/popup.html
+++ b/addon/popup.html
@@ -268,6 +268,10 @@
                 <input type="number" id="retries" name="retries" value="20" />
                 <label for="retries">Detection attempts</label>
             </div>
+            <div>
+                <input type="number" id="max-document-elements" name="max-document-elements" value="100000" min="0" step="1000" />
+                <label for="max-document-elements">Max document elements (0 disables)</label>
+            </div>
             <button id="reload">Reload rules</button>
             <button id="reset">Reset settings</button>
         </fieldset>

--- a/addon/popup.ts
+++ b/addon/popup.ts
@@ -42,6 +42,7 @@ async function init() {
     const popupMutationOnRadio = document.querySelector('input#popup-mutation-on') as HTMLInputElement;
     const popupMutationOffRadio = document.querySelector('input#popup-mutation-off') as HTMLInputElement;
     const retriesInput = document.querySelector('input#retries') as HTMLInputElement;
+    const maxDocumentElementsInput = document.querySelector('input#max-document-elements') as HTMLInputElement;
     const logsLifecycleCheckbox = document.querySelector('input#logs-lifecycle') as HTMLInputElement;
     const logsRulestepsCheckbox = document.querySelector('input#logs-rulesteps') as HTMLInputElement;
     const logsDetectionstepsCheckbox = document.querySelector('input#logs-detectionsteps') as HTMLInputElement;
@@ -132,6 +133,7 @@ async function init() {
     logsErrorsCheckbox.checked = autoconsentConfig.logs.errors;
     logsMessagesCheckbox.checked = autoconsentConfig.logs.messages;
     retriesInput.value = autoconsentConfig.detectRetries.toString();
+    maxDocumentElementsInput.value = autoconsentConfig.maxDocumentElements.toString();
     if (autoconsentConfig.autoAction === 'optIn') {
         optInRadio.checked = true;
     } else if (autoconsentConfig.autoAction === 'optOut') {
@@ -188,6 +190,11 @@ async function init() {
 
     retriesInput.addEventListener('change', () => {
         autoconsentConfig.detectRetries = parseInt(retriesInput.value, 10);
+        storageSet({ config: autoconsentConfig });
+    });
+
+    maxDocumentElementsInput.addEventListener('change', () => {
+        autoconsentConfig.maxDocumentElements = parseInt(maxDocumentElementsInput.value, 10);
         storageSet({ config: autoconsentConfig });
     });
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -75,6 +75,7 @@ export type Config = {
     performanceLoggingEnabled: boolean;
     heuristicPopupSearchTimeout: number;
     heuristicMode: HeuristicLevel; // controls the behavior of the heuristic popup detection.
+    maxDocumentElements: number; // skip non-site-specific detection when the document is larger than this, 0 disables the check.
 };
 
 export type LifecycleState =

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -94,6 +94,7 @@ export function normalizeConfig(providedConfig: any): Config {
         performanceLoggingEnabled: false,
         heuristicPopupSearchTimeout: 100,
         heuristicMode: 'off', // heuristic disabled by default
+        maxDocumentElements: 100000,
     };
     const updatedConfig: Config = copyObject(defaultConfig);
     // filter out any unknown entries

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -301,10 +301,21 @@ export default class AutoConsent {
             }
         };
 
-        const mutationObserver = this.domActions.waitForMutation('html');
-        mutationObserver.catch(() => {}); // ensure promise rejection is caught
+        let mutationObserver: Promise<boolean> | null = null;
+        let skipBroadDetection = false;
 
         for (const [stageName, ruleGroup] of rulesPriorityStages) {
+            if (stageName !== 'site-specific') {
+                if (this.shouldSkipBroadDetection()) {
+                    skipBroadDetection = true;
+                    break;
+                }
+                if (!mutationObserver) {
+                    mutationObserver = this.domActions.waitForMutation('html');
+                    mutationObserver.catch(() => {}); // ensure promise rejection is caught
+                }
+            }
+
             logsConfig.lifecycle &&
                 ruleGroup.length > 0 &&
                 console.log(
@@ -324,13 +335,16 @@ export default class AutoConsent {
         }
 
         this.detectHeuristics(); // run heuristics after trying rules
+        if (skipBroadDetection) {
+            return foundCMPs;
+        }
 
         if (foundCMPs.length === 0 && retries > 0) {
             // if we didn't find a CMP, try again
             // We wait 500ms, and also for some kind of dom mutation to happen before
             // rerunning the findCmp check
             const waitFor: Promise<boolean>[] = [this.domActions.wait(500)];
-            if (this.state.findCmpAttempts > 1) {
+            if (this.state.findCmpAttempts > 1 && mutationObserver) {
                 waitFor.push(mutationObserver);
             }
             try {
@@ -344,6 +358,34 @@ export default class AutoConsent {
         }
 
         return foundCMPs;
+    }
+
+    shouldSkipBroadDetection(): boolean {
+        const limit = this.config.maxDocumentElements;
+        this.config.performanceLoggingEnabled && performance.mark('documentSizeCheckStart');
+        const documentTooLarge = limit > 0 && document.getElementsByTagName('*').length > limit;
+        this.config.performanceLoggingEnabled && performance.mark('documentSizeCheckEnd');
+        this.config.performanceLoggingEnabled && performance.measure('documentSizeCheck', 'documentSizeCheckStart', 'documentSizeCheckEnd');
+
+        if (documentTooLarge) {
+            const errorDetails = {
+                msg: `Document too large: ${limit}`,
+                reason: 'documentTooLarge',
+                limit,
+                url: location.href,
+            };
+            this.config.logs.lifecycle &&
+                console.log(errorDetails.msg, {
+                    limit,
+                    url: location.href,
+                });
+            this.sendContentMessage({
+                type: 'autoconsentError',
+                details: errorDetails,
+            });
+        }
+
+        return documentTooLarge;
     }
 
     detectHeuristics() {
@@ -652,6 +694,7 @@ export default class AutoConsent {
             findCmpGeneric: getRoundedPerformanceEntries('findCmp_generic'),
             findCmpHeuristic: getRoundedPerformanceEntries('findCmp_heuristic'),
             parseDeclarativeRules: getRoundedPerformanceEntries('parseDeclarativeRules'),
+            documentSizeCheck: getRoundedPerformanceEntries('documentSizeCheck'),
         };
     }
 }

--- a/lib/web.ts
+++ b/lib/web.ts
@@ -363,13 +363,14 @@ export default class AutoConsent {
     shouldSkipBroadDetection(): boolean {
         const limit = this.config.maxDocumentElements;
         this.config.performanceLoggingEnabled && performance.mark('documentSizeCheckStart');
-        const documentTooLarge = limit > 0 && document.getElementsByTagName('*').length > limit;
+        const documentElementCount = document.getElementsByTagName('*').length;
+        const documentTooLarge = limit > 0 && documentElementCount > limit;
         this.config.performanceLoggingEnabled && performance.mark('documentSizeCheckEnd');
         this.config.performanceLoggingEnabled && performance.measure('documentSizeCheck', 'documentSizeCheckStart', 'documentSizeCheckEnd');
 
         if (documentTooLarge) {
             const errorDetails = {
-                msg: `Document too large: ${limit}`,
+                msg: `Document too large: ${documentElementCount} > ${limit}`,
                 reason: 'documentTooLarge',
                 limit,
                 url: location.href,

--- a/tests-wtr/lifecycle/find-cmp.ts
+++ b/tests-wtr/lifecycle/find-cmp.ts
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import Autoconsent from '../../lib/web';
 import Onetrust from '../../lib/cmps/onetrust';
+import { ContentScriptMessage } from '../../lib/messages';
 
 describe('Autoconsent.findCmp', () => {
     let autoconsent: Autoconsent;
@@ -133,6 +134,114 @@ describe('Autoconsent.findCmp', () => {
             expect(found).to.have.length(1);
             expect(found[0].name).to.equal('runContextRule');
         });
+
+        it('skips generic detection when the document exceeds the element limit', async () => {
+            const messages: ContentScriptMessage[] = [];
+            autoconsent = new Autoconsent(
+                (msg) => {
+                    messages.push(msg);
+                    return Promise.resolve();
+                },
+                {
+                    enabled: false,
+                    autoAction: null,
+                    heuristicMode: 'off',
+                    maxDocumentElements: 1,
+                },
+            );
+            autoconsent.addDeclarativeCMP({
+                name: 'genericRule',
+                detectCmp: [{ exists: '#privacy-test-page-cmp-test' }],
+                detectPopup: [],
+                optIn: [],
+                optOut: [],
+            });
+
+            const found = await autoconsent.findCmp(0);
+            const error = messages.find((message) => message.type === 'autoconsentError');
+
+            expect(found).to.have.length(0);
+            expect(error?.details.reason).to.equal('documentTooLarge');
+        });
+
+        it('still runs heuristic text detection when the document exceeds the element limit', async () => {
+            autoconsent = new Autoconsent((msg) => Promise.resolve(), {
+                enabled: false,
+                autoAction: null,
+                enableHeuristicDetection: true,
+                heuristicMode: 'off',
+                maxDocumentElements: 1,
+            });
+
+            const found = await autoconsent.findCmp(0);
+
+            expect(found).to.have.length(0);
+            expect(autoconsent.state.heuristicPatterns).not.to.have.length(0);
+        });
+
+        it('still runs matching site-specific rules when the document exceeds the element limit', async () => {
+            autoconsent = new Autoconsent((msg) => Promise.resolve(), {
+                enabled: false,
+                autoAction: null,
+                heuristicMode: 'off',
+                maxDocumentElements: 1,
+            });
+            autoconsent.addDeclarativeCMP({
+                name: 'siteSpecificRule',
+                runContext: { urlPattern: '^http://localhost' },
+                detectCmp: [{ exists: '#privacy-test-page-cmp-test' }],
+                detectPopup: [],
+                optIn: [],
+                optOut: [],
+            });
+
+            const found = await autoconsent.findCmp(0);
+
+            expect(found).to.have.length(1);
+            expect(found[0].name).to.equal('siteSpecificRule');
+        });
+
+        it('runs generic detection when the document is below the element limit', async () => {
+            autoconsent = new Autoconsent((msg) => Promise.resolve(), {
+                enabled: false,
+                autoAction: null,
+                heuristicMode: 'off',
+                maxDocumentElements: document.getElementsByTagName('*').length + 1,
+            });
+            autoconsent.addDeclarativeCMP({
+                name: 'genericRule',
+                detectCmp: [{ exists: '#privacy-test-page-cmp-test' }],
+                detectPopup: [],
+                optIn: [],
+                optOut: [],
+            });
+
+            const found = await autoconsent.findCmp(0);
+
+            expect(found).to.have.length(1);
+            expect(found[0].name).to.equal('genericRule');
+        });
+
+        it('runs generic detection when the element limit is disabled', async () => {
+            autoconsent = new Autoconsent((msg) => Promise.resolve(), {
+                enabled: false,
+                autoAction: null,
+                heuristicMode: 'off',
+                maxDocumentElements: 0,
+            });
+            autoconsent.addDeclarativeCMP({
+                name: 'genericRule',
+                detectCmp: [{ exists: '#privacy-test-page-cmp-test' }],
+                detectPopup: [],
+                optIn: [],
+                optOut: [],
+            });
+
+            const found = await autoconsent.findCmp(0);
+
+            expect(found).to.have.length(1);
+            expect(found[0].name).to.equal('genericRule');
+        });
     });
 
     describe('heuristicMode = reject', () => {
@@ -167,6 +276,30 @@ describe('Autoconsent.findCmp', () => {
 
             expect(found).to.have.length(1);
             expect(found[0].name).to.equal('HEURISTIC-REJECT');
+        });
+
+        it('skips heuristic detection when the document exceeds the element limit', async () => {
+            const messages: ContentScriptMessage[] = [];
+            autoconsent = new Autoconsent(
+                (msg) => {
+                    messages.push(msg);
+                    return Promise.resolve();
+                },
+                {
+                    enabled: false,
+                    autoAction: null,
+                    heuristicMode: 'reject',
+                    maxDocumentElements: 1,
+                },
+            );
+            // force findCmpAttempts to 1 so heuristic CMP would be run on the first attempt
+            autoconsent.state.findCmpAttempts = 1;
+
+            const found = await autoconsent.findCmp(1);
+            const error = messages.find((message) => message.type === 'autoconsentError');
+
+            expect(found).to.have.length(0);
+            expect(error?.details.reason).to.equal('documentTooLarge');
         });
 
         it('prefers declarative rules over heuristic CMP', async () => {

--- a/tests-wtr/web/do-opt-in.test.ts
+++ b/tests-wtr/web/do-opt-in.test.ts
@@ -19,7 +19,11 @@ function createTestConfig(overrides: Partial<Config> = {}): Config {
         isMainWorld: false,
         prehideTimeout: 2000,
         enableHeuristicDetection: false,
+        enablePopupMutationObserver: false,
+        performanceLoggingEnabled: false,
+        heuristicPopupSearchTimeout: 100,
         heuristicMode: 'off',
+        maxDocumentElements: 100000,
         visualTest: false,
         logs: {
             lifecycle: false,

--- a/tests-wtr/web/do-opt-out.test.ts
+++ b/tests-wtr/web/do-opt-out.test.ts
@@ -19,7 +19,11 @@ function createTestConfig(overrides: Partial<Config> = {}): Config {
         isMainWorld: false,
         prehideTimeout: 2000,
         enableHeuristicDetection: false,
+        enablePopupMutationObserver: false,
+        performanceLoggingEnabled: false,
+        heuristicPopupSearchTimeout: 100,
         heuristicMode: 'off',
+        maxDocumentElements: 100000,
         visualTest: false,
         logs: {
             lifecycle: false,

--- a/tests-wtr/web/do-self-test.test.ts
+++ b/tests-wtr/web/do-self-test.test.ts
@@ -19,7 +19,11 @@ function createTestConfig(overrides: Partial<Config> = {}): Config {
         isMainWorld: false,
         prehideTimeout: 2000,
         enableHeuristicDetection: false,
+        enablePopupMutationObserver: false,
+        performanceLoggingEnabled: false,
+        heuristicPopupSearchTimeout: 100,
         heuristicMode: 'off',
+        maxDocumentElements: 100000,
         visualTest: false,
         logs: {
             lifecycle: false,

--- a/tests-wtr/web/filter-cmps.test.ts
+++ b/tests-wtr/web/filter-cmps.test.ts
@@ -41,7 +41,11 @@ function createTestConfig(overrides: Partial<Config> = {}): Config {
         isMainWorld: false,
         prehideTimeout: 2000,
         enableHeuristicDetection: false,
+        enablePopupMutationObserver: false,
+        performanceLoggingEnabled: false,
+        heuristicPopupSearchTimeout: 100,
         heuristicMode: 'off',
+        maxDocumentElements: 100000,
         visualTest: false,
         logs: {
             lifecycle: false,

--- a/tests-wtr/web/receive-message-callback.test.ts
+++ b/tests-wtr/web/receive-message-callback.test.ts
@@ -18,7 +18,11 @@ function createTestConfig(overrides: Partial<Config> = {}): Config {
         isMainWorld: false,
         prehideTimeout: 2000,
         enableHeuristicDetection: false,
+        enablePopupMutationObserver: false,
+        performanceLoggingEnabled: false,
+        heuristicPopupSearchTimeout: 100,
         heuristicMode: 'off',
+        maxDocumentElements: 100000,
         visualTest: false,
         logs: {
             lifecycle: false,

--- a/tests-wtr/web/update-state.test.ts
+++ b/tests-wtr/web/update-state.test.ts
@@ -18,7 +18,11 @@ function createTestConfig(overrides: Partial<Config> = {}): Config {
         isMainWorld: false,
         prehideTimeout: 2000,
         enableHeuristicDetection: false,
+        enablePopupMutationObserver: false,
+        performanceLoggingEnabled: false,
+        heuristicPopupSearchTimeout: 100,
         heuristicMode: 'off',
+        maxDocumentElements: 100000,
         visualTest: false,
         logs: {
             lifecycle: false,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201844467387842/task/1216168716226662?focus=true

## Description:

<!--
Don't forget to label the PR.

Version labels use the `version:` prefix, for example `version: patch`.
Category labels use the `category:` prefix, for example `category: rules`.
Details: https://github.com/duckduckgo/autoconsent/blob/main/docs/release-notes.md
-->

## Steps to test this PR:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core detection path on large pages, so CMPs only reachable via generic/heuristic rules may be missed unless a site-specific rule matches.
> 
> **Overview**
> Adds a **`maxDocumentElements`** setting (default **100000**, **0** to disable) so autoconsent can bail out of expensive **generic** and **heuristic CMP** detection when the DOM is too large.
> 
> In **`findCmp`**, site-specific rules still run first; before generic/heuristic stages, **`shouldSkipBroadDetection()`** counts elements via `document.getElementsByTagName('*')`, logs/sends **`autoconsentError`** with reason **`documentTooLarge`**, and stops broad detection (including retries tied to mutation waiting). Optional **heuristic text** scanning via **`detectHeuristics()`** still runs when enabled. The extension popup exposes the limit under **Other**, and performance reporting includes **`documentSizeCheck`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98e791d5637331f04b9fc506c73466564c4ccec5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->