### PR TITLE
Tighten heuristic patterns

### DIFF
--- a/lib/heuristic-patterns.ts
+++ b/lib/heuristic-patterns.ts
@@ -7,7 +7,6 @@ export const DETECT_PATTERNS = [
     /only necessary cookies/gi, // "only necessary" is probably too broad
     /(?:by continuing.{0,100}cookie)|(?:cookie.{0,100}by continuing)/gi,
     /(?:by continuing.{0,100}privacy)|(?:privacy.{0,100}by continuing)/gi,
-    /by clicking.{0,100}(?:accept|agree|allow)/gi,
     /we (?:use|serve)(?: optional)? cookies/gi,
     /we are using cookies/gi,
     /use of cookies/gi,
@@ -95,7 +94,6 @@ export const DETECT_PATTERNS = [
     /\b(hacemos|hace) uso de cookies\b/i,
     /\busa cookies de google\b/i,
     /acepta.{0,80} uso de cookies/i,
-    /al hacer clic.{0,80}aceptar/i,
     /al utilizar nuestro sitio web.{0,80}cookie/i,
     /almacenar la información en un dispositivo y\/?o acceder a ella/i,
     /cookie.{0,30} utiliza/i,
@@ -105,7 +103,6 @@ export const DETECT_PATTERNS = [
     /navegando.{0,100}cookie/i,
     /nosotros y nuestros( \d+)? (socios|proveedores).{0,180} cookies/gi,
     /recopilamos y almacenamos datos de usted y de su dispositivo/gi,
-    /si haces? clic.{0,20}acept/i,
     /utilizamos tecnolog[ií]as como las cookies/i,
 
     // Polish (PL)

--- a/lib/heuristic-patterns.ts
+++ b/lib/heuristic-patterns.ts
@@ -26,12 +26,8 @@ export const DETECT_PATTERNS = [
 
     // FR
     /utilisons.{0,100}des.{0,100}cookies/gi,
-    /nous.{0,100}utilisons.{0,100}des/gi,
     /des.{0,100}cookies.{0,100}pour/gi,
-    /des.{0,100}informations.{0,100}sur/gi,
     /retirer.{0,100}votre.{0,100}consentement/gi,
-    /accéder.{0,100}à.{0,100}des/gi,
-    /à.{0,100}des.{0,100}informations/gi,
     /et.{0,100}nos.{0,100}partenaires/gi,
     /publicités.{0,100}et.{0,100}du.{0,100}contenu/gi,
     /utilise.{0,100}des.{0,100}cookies/gi,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201844467387842/task/1216314767919204?focus=true

## Description:
Remove some detection patterns causing too many false positives
<!--
Don't forget to label the PR.

Version labels use the `version:` prefix, for example `version: patch`.
Category labels use the `category:` prefix, for example `category: rules`.
Details: https://github.com/duckduckgo/autoconsent/blob/main/docs/release-notes.md
-->

## Steps to test this PR:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live heuristic detection behavior across all sites using heuristic mode; fewer false positives but possible missed unknown banners that only matched the removed patterns.
> 
> **Overview**
> Narrows **heuristic cookie-banner detection** by deleting eight `DETECT_PATTERNS` regexes in `heuristic-patterns.ts` that were matching non-consent UI too often.
> 
> Removed matches include English “by clicking … accept/agree/allow”, several overly broad French fragments (e.g. generic “nous … utilisons … des” and “des … informations … sur”), and Spanish click-to-accept phrasing. Heuristic mode should trigger less often on pages that are not real CMPs; some edge-case banners that relied only on those strings may no longer be detected until a site-specific rule applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 267da5d73b4f6999d2455c9b8a6de4f1afb79562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->