### PR TITLE
Add Playwright integration test for bundled MV3 extension

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -28,4 +28,7 @@ jobs:
                   node-version: lts/*
                   cache: 'npm'
             - run: npm ci
+            - run: npx playwright install chromium
+            - run: npm run prepublish
             - run: npm run test:lib
+            - run: npm run test:webext

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,6 +29,5 @@ jobs:
                   cache: 'npm'
             - run: npm ci
             - run: npx playwright install chromium
-            - run: npm run prepublish
             - run: npm run test:lib
             - run: npm run test:webext

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,7 +59,7 @@ const c = tseslint.config(
     },
 
     {
-        files: ['tests/**/*', 'tests-wtr/**/*'],
+        files: ['tests/**/*', 'tests-wtr/**/*', 'tests-webext/**/*'],
         languageOptions: {
             globals: {
                 ...globals.jasmine,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:webkit": "playwright test --project webkit",
     "test:firefox": "playwright test --project firefox",
     "test:chrome": "playwright test --project chrome",
+    "test:webext": "playwright test --config tests-webext/playwright.config.ts",
     "test:lib": "web-test-runner",
     "test:sample": "playwright test tests/_sample-test.spec.ts --project webkit",
     "build-rules": "ts-node rules/build.ts",

--- a/tests-webext/autoconsent.spec.ts
+++ b/tests-webext/autoconsent.spec.ts
@@ -1,8 +1,10 @@
 import type { Page } from '@playwright/test';
 import { test, expect } from './fixtures';
+import { expectBannerHidden, expectBannerVisible, openPopup } from './helpers';
 
 const TESTCMP_URL = 'https://privacy-test-pages.site/features/autoconsent/index.html';
 const HEURISTIC_URL = 'https://privacy-test-pages.site/features/autoconsent/heuristic.html';
+const COSMETIC_BANNER_URL = 'https://privacy-test-pages.site/features/autoconsent/banner.html';
 
 async function expectRejectClicked(page: Page) {
     await expect
@@ -39,5 +41,23 @@ test.describe('MV3 extension', () => {
         await expect(page.locator('#privacy-test-page-cmp-test-heuristic')).toBeVisible();
 
         await expectRejectClicked(page);
+    });
+
+    test('hides cosmetic banner and stops hiding when disabled in popup', async ({ context }) => {
+        const page = await context.newPage();
+
+        await page.goto(COSMETIC_BANNER_URL, { waitUntil: 'domcontentloaded' });
+
+        await expect(page.locator('#privacy-test-page-cmp-test-banner')).toBeVisible();
+
+        await expectBannerHidden(page);
+
+        const popup = await openPopup(context);
+        await popup.locator('#cosmetic-off').check();
+        await popup.close();
+
+        await page.reload({ waitUntil: 'domcontentloaded' });
+
+        await expectBannerVisible(page);
     });
 });

--- a/tests-webext/autoconsent.spec.ts
+++ b/tests-webext/autoconsent.spec.ts
@@ -48,8 +48,6 @@ test.describe('MV3 extension', () => {
 
         await page.goto(COSMETIC_BANNER_URL, { waitUntil: 'domcontentloaded' });
 
-        await expect(page.locator('#privacy-test-page-cmp-test-banner')).toBeVisible();
-
         await expectBannerHidden(page);
 
         const popup = await openPopup(context);

--- a/tests-webext/autoconsent.spec.ts
+++ b/tests-webext/autoconsent.spec.ts
@@ -1,27 +1,43 @@
+import type { Page } from '@playwright/test';
 import { test, expect } from './fixtures';
 
-const TEST_URL = 'https://privacy-test-pages.site/features/autoconsent/index.html';
+const TESTCMP_URL = 'https://privacy-test-pages.site/features/autoconsent/index.html';
+const HEURISTIC_URL = 'https://privacy-test-pages.site/features/autoconsent/heuristic.html';
+
+async function expectRejectClicked(page: Page) {
+    await expect
+        .poll(
+            async () =>
+                page.evaluate(() => {
+                    const results = (window as unknown as { results?: { results?: string[] } }).results;
+                    return results?.results?.[0] === 'button_clicked';
+                }),
+            {
+                message: 'extension should click the reject button',
+                timeout: 60_000,
+            },
+        )
+        .toBe(true);
+}
 
 test.describe('MV3 extension', () => {
     test('clicks reject on the privacy test page', async ({ context }) => {
         const page = await context.newPage();
 
-        await page.goto(TEST_URL, { waitUntil: 'domcontentloaded' });
+        await page.goto(TESTCMP_URL, { waitUntil: 'domcontentloaded' });
 
         await expect(page.locator('#privacy-test-page-cmp-test')).toBeVisible();
 
-        await expect
-            .poll(
-                async () =>
-                    page.evaluate(() => {
-                        const results = (window as unknown as { results?: { results?: string[] } }).results;
-                        return results?.results?.[0] === 'button_clicked';
-                    }),
-                {
-                    message: 'extension should click the reject button',
-                    timeout: 60_000,
-                },
-            )
-            .toBe(true);
+        await expectRejectClicked(page);
+    });
+
+    test('clicks reject on the heuristic test page', async ({ context }) => {
+        const page = await context.newPage();
+
+        await page.goto(HEURISTIC_URL, { waitUntil: 'domcontentloaded' });
+
+        await expect(page.locator('#privacy-test-page-cmp-test-heuristic')).toBeVisible();
+
+        await expectRejectClicked(page);
     });
 });

--- a/tests-webext/autoconsent.spec.ts
+++ b/tests-webext/autoconsent.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from './fixtures';
+
+const TEST_URL = 'https://privacy-test-pages.site/features/autoconsent/index.html';
+
+test.describe('MV3 extension', () => {
+    test('clicks reject on the privacy test page', async ({ context }) => {
+        const page = await context.newPage();
+
+        await page.goto(TEST_URL, { waitUntil: 'domcontentloaded' });
+
+        await expect(page.locator('#privacy-test-page-cmp-test')).toBeVisible();
+
+        await expect
+            .poll(
+                async () =>
+                    page.evaluate(() => {
+                        const results = (window as unknown as { results?: { results?: string[] } }).results;
+                        return results?.results?.[0] === 'button_clicked';
+                    }),
+                {
+                    message: 'extension should click the reject button',
+                    timeout: 60_000,
+                },
+            )
+            .toBe(true);
+    });
+});

--- a/tests-webext/fixtures.ts
+++ b/tests-webext/fixtures.ts
@@ -1,0 +1,41 @@
+import { test as base, chromium, type BrowserContext } from '@playwright/test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const pathToExtension = path.join(__dirname, '../dist/addon-mv3');
+
+export const test = base.extend<{
+    context: BrowserContext;
+    extensionId: string;
+}>({
+    context: async (_fixtures, use) => {
+        if (!fs.existsSync(path.join(pathToExtension, 'manifest.json'))) {
+            throw new Error('Bundled MV3 extension not found. Run `npm run prepublish` before webext tests.');
+        }
+
+        const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pw-webext-'));
+        const context = await chromium.launchPersistentContext(userDataDir, {
+            channel: 'chromium',
+            headless: !!process.env.CI,
+            args: [
+                ...(process.env.CI ? ['--headless=new'] : []),
+                `--disable-extensions-except=${pathToExtension}`,
+                `--load-extension=${pathToExtension}`,
+            ],
+        });
+
+        await use(context);
+        await context.close();
+    },
+    extensionId: async ({ context }, use) => {
+        let [serviceWorker] = context.serviceWorkers();
+        if (!serviceWorker) {
+            serviceWorker = await context.waitForEvent('serviceworker');
+        }
+        const extensionId = serviceWorker.url().split('/')[2];
+        await use(extensionId);
+    },
+});
+
+export { expect } from '@playwright/test';

--- a/tests-webext/fixtures.ts
+++ b/tests-webext/fixtures.ts
@@ -9,7 +9,9 @@ export const test = base.extend<{
     context: BrowserContext;
     extensionId: string;
 }>({
-    context: async (_fixtures, use) => {
+    // Playwright requires an object destructuring pattern for fixture dependencies.
+    // eslint-disable-next-line no-empty-pattern
+    context: async ({}, use) => {
         if (!fs.existsSync(path.join(pathToExtension, 'manifest.json'))) {
             throw new Error('Bundled MV3 extension not found. Run `npm run prepublish` before webext tests.');
         }

--- a/tests-webext/fixtures.ts
+++ b/tests-webext/fixtures.ts
@@ -2,6 +2,7 @@ import { test as base, chromium, type BrowserContext } from '@playwright/test';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { getExtensionId } from './helpers';
 
 const pathToExtension = path.join(__dirname, '../dist/addon-mv3');
 
@@ -31,11 +32,7 @@ export const test = base.extend<{
         await context.close();
     },
     extensionId: async ({ context }, use) => {
-        let [serviceWorker] = context.serviceWorkers();
-        if (!serviceWorker) {
-            serviceWorker = await context.waitForEvent('serviceworker');
-        }
-        const extensionId = serviceWorker.url().split('/')[2];
+        const extensionId = await getExtensionId(context);
         await use(extensionId);
     },
 });

--- a/tests-webext/helpers.ts
+++ b/tests-webext/helpers.ts
@@ -1,0 +1,64 @@
+import { expect, type BrowserContext, type Page } from '@playwright/test';
+
+export async function getExtensionId(context: BrowserContext): Promise<string> {
+    const deadline = Date.now() + 30_000;
+    while (Date.now() < deadline) {
+        const [serviceWorker] = context.serviceWorkers();
+        if (serviceWorker) {
+            return serviceWorker.url().split('/')[2];
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    const serviceWorker = await context.waitForEvent('serviceworker', { timeout: 30_000 });
+    return serviceWorker.url().split('/')[2];
+}
+
+export async function openPopup(context: BrowserContext, extensionId?: string): Promise<Page> {
+    const id = extensionId ?? (await getExtensionId(context));
+    const popup = await context.newPage();
+    await popup.goto(`chrome-extension://${id}/popup.html`);
+    await popup.waitForLoadState('domcontentloaded');
+    return popup;
+}
+
+type TestPageResults = {
+    results?: { results?: string[] };
+};
+
+export async function expectBannerHidden(page: Page) {
+    await expect
+        .poll(
+            async () => {
+                const results = await page.evaluate(() => {
+                    const windowResults = (window as unknown as TestPageResults).results;
+                    return windowResults?.results ?? [];
+                });
+                if (results.includes('banner_hidden')) {
+                    return true;
+                }
+
+                return page.evaluate(() => {
+                    const banner = document.getElementById('privacy-test-page-cmp-test-banner');
+                    return !!banner && window.getComputedStyle(banner).display === 'none';
+                });
+            },
+            {
+                message: 'cosmetic rule should hide the banner',
+                timeout: 60_000,
+            },
+        )
+        .toBe(true);
+}
+
+export async function expectBannerVisible(page: Page) {
+    await page.waitForTimeout(600);
+
+    await expect(page.locator('#privacy-test-page-cmp-test-banner')).toBeVisible();
+
+    const results = await page.evaluate(() => {
+        const windowResults = (window as unknown as TestPageResults).results;
+        return windowResults?.results ?? [];
+    });
+    expect(results).not.toContain('banner_hidden');
+}

--- a/tests-webext/playwright.config.ts
+++ b/tests-webext/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from '@playwright/test';
+
+const config = defineConfig({
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 2 : 0,
+    testDir: '.',
+    use: {
+        trace: 'off',
+    },
+    projects: [
+        {
+            name: 'chrome-extension',
+        },
+    ],
+});
+
+export default config;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds Playwright integration tests that load the bundled Chrome MV3 extension (`dist/addon-mv3`) and verify autoconsent behavior on privacy test pages.

### Changes
- New `tests-webext/` folder with:
  - `fixtures.ts` — launches Chromium with the MV3 extension via `launchPersistentContext`
  - `helpers.ts` — popup navigation and banner visibility helpers
  - `autoconsent.spec.ts` — tests:
    - `index.html` — declarative CMP rule clicks reject
    - `heuristic.html` — heuristic detection clicks reject
    - `banner.html` — cosmetic rule hides banner; disabling "Apply cosmetic rules" in popup keeps banner visible after reload
  - `playwright.config.ts` — dedicated config for extension tests
- `npm run test:webext` script
- CI workflow runs webext tests after `npm ci` (which builds the extension via `prepublish`)

### How it works
Tests load the bundled extension in Chrome and assert against `window.results` signals from the privacy test pages. The cosmetic test opens the extension popup at `chrome-extension://<id>/popup.html`, toggles `#cosmetic-off`, reloads the page, and verifies the banner is no longer hidden.

## Steps to test this PR:

```bash
npm ci
npx playwright install chromium
npm run test:webext
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c85553aa-63ba-41d0-9c3b-f8b801c85eb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c85553aa-63ba-41d0-9c3b-f8b801c85eb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

