### PR TITLE
Update Dependabot config: ignore major version and set cooldown for safety

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
       groups:
           dev-dependencies:
               dependency-type: 'development'
+      ignore:
+          - dependency-name: '*'
+            update-types: ['version-update:semver-major']
+      cooldown:
+          default-days: 5


### PR DESCRIPTION
Task/Issue URL: 
PR from dependabot https://github.com/duckduckgo/autoconsent/pull/1442

I found the dependabot PR failed, It most likely due to major version upgrade, expected to happen in semserver.

## Description:

I added 2 changes, feel free to correct me if this is no DDG approach.

**Ignore major version.**
In Semserver, major version expected to have breaking changes.
Only updates the minor & patch version, and update major version manually.

**Set cooldown period**
I added cooldown ([docs](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-)) period for package updates to 5 days. This will allow the package to be scanned by other 3rd party providers in case it has chain vulnerability. Based from my previous experience, even the latest package could have vulnerability.


## Steps to test this PR:

None, if build green, that's mean package successfully built.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/supply-chain config only; no runtime or application code changes.
> 
> **Overview**
> **Dependabot** for npm is tightened so automated PRs skip **semver-major** upgrades (`ignore` on `version-update:semver-major` for all dependencies) and wait **5 days** after a release before proposing updates (`cooldown.default-days: 5`).
> 
> Major bumps stay manual; minor/patch and grouped dev-dependencies behavior is unchanged aside from the cooldown delay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3709459c1700e099c4bddff9632f793c39f73736. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->