### PR TITLE
Set up Cursor Cloud dev environment + AGENTS.md notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,3 +171,12 @@ After creating or modifying a rule:
 4. `npm run prepublish` — full build including extension bundle
 5. Validate that the rule stops matching after the popup is dismissed and the page is reloaded (unless it's a cosmetic rule).
 6. Check the rule works across all supported geographic regions using available regional testing tooling.
+
+## Cursor Cloud specific instructions
+
+Environment is already bootstrapped by the startup update script (`npm ci` + `npx playwright install`). Standard commands live in "Quick Start"/"Verification" above and in `package.json` scripts. Non-obvious caveats:
+
+- **Node version:** The VM's default `node` is v22.x (from `/exec-daemon`, early in `PATH`), not the v20.12.1 pinned in `.node-version`. v22 builds, lints, and tests fine — don't waste time forcing v20 via `nvm` (the `/exec-daemon` shim shadows it anyway).
+- **E2E tests hit live external sites**, so results depend on the VM's egress IP (effectively a US datacenter). Sites may show a different/no popup or block datacenter IPs, causing "no CMP detected" failures that are environmental, not rule bugs. For region-accurate runs, set `REGION=...` and route through a proxy (see the `proxy-testing` skill / `PROXY_SERVER`). A globally-reliable smoke test is `REGION=US npx playwright test tests/sourcepoint.spec.ts --project chrome -g theguardian`.
+- **Tests require a build first:** run `npm run prepublish` (or `npm run build-rules`) before Playwright/`test:lib`, since the harness reads `dist/` and `rules/rules.json`. `npm ci` already triggers a `prepublish` build.
+- E2E screenshots are written to `test-results/screenshots/` — check them to confirm a popup was actually handled (a passing report alone can be misleading).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for the autoconsent library in Cursor Cloud, and documents non-obvious cloud caveats in `AGENTS.md`.

No application/source code was changed — only `AGENTS.md` gained a `## Cursor Cloud specific instructions` section. The dependency-refresh steps are captured in the Cloud Agent startup **update script** (`npm ci` + `npx playwright install`), not in the repo.

## Environment verification

All commands run with the VM's default Node v22.14.0 (the pinned `.node-version` v20.12.1 is shadowed by an injected `/exec-daemon/node`; v22 works fine).

| Step | Command | Result |
|------|---------|--------|
| Install deps | `npm ci` | ✅ 1146 packages; auto-runs `prepublish` build |
| Browsers | `npx playwright install` | ✅ chromium/firefox/webkit |
| Build | `npm run prepublish` | ✅ builds `dist/` lib + mv3/firefox extension bundles |
| Lint | `npm run lint` | ✅ eslint + prettier + rule-syntax-check pass |
| Unit tests | `npm run test:lib` | ✅ 31 files, 837 passed, 0 failed |
| E2E (hello world) | `REGION=US npx playwright test tests/sourcepoint.spec.ts --project chrome -g theguardian` | ✅ 2 passed (optIn + optOut) |

## Hello-world demonstration

Ran the engine end-to-end against `theguardian.com`: it detected the Sourcepoint consent popup and automatically opted out/in (`optOutResult: true`, `autoconsentDone`, 1 click).

Before (popup shown) / after (popup dismissed):

[Guardian consent popup detected](https://cursor.com/agents/bc-5ffae724-eb4f-4948-be86-d2c76e4caddb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fguardian-popup-before.jpg)
[Guardian popup dismissed by autoconsent](https://cursor.com/agents/bc-5ffae724-eb4f-4948-be86-d2c76e4caddb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fguardian-popup-after.jpg)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ffae724-eb4f-4948-be86-d2c76e4caddb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ffae724-eb4f-4948-be86-d2c76e4caddb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

