### PR TITLE
Dismiss Pornhub minimized cookie banner

### DIFF
--- a/rules/autoconsent/pornhub-compact-cookie-banner.json
+++ b/rules/autoconsent/pornhub-compact-cookie-banner.json
@@ -1,0 +1,28 @@
+{
+    "name": "pornhub-compact-cookie-banner",
+    "runContext": {
+        "urlPattern": "^https://(www\\.)?pornhub\\.com/"
+    },
+    "cosmetic": false,
+    "prehideSelectors": ["#cookieBanner.cbShort"],
+    "detectCmp": [
+        {
+            "exists": "#cookieBanner.cbShort .cbCloseButton"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#cookieBanner.cbShort .cbCloseButton"
+        }
+    ],
+    "optIn": [
+        {
+            "click": "#cookieBanner.cbShort .cbCloseButton"
+        }
+    ],
+    "optOut": [
+        {
+            "click": "#cookieBanner.cbShort .cbCloseButton"
+        }
+    ]
+}

--- a/rules/autoconsent/pornhub.json
+++ b/rules/autoconsent/pornhub.json
@@ -12,7 +12,8 @@
     ],
     "detectPopup": [
         {
-            "visible": "#cookieBanner #cookieBannerContent, #globalCookieBanner, #cookieBanner .cbCloseButton"
+            "visible": "#cookieBanner #cookieBannerContent, #globalCookieBanner, #cookieBanner .cbCloseButton",
+            "check": "any"
         }
     ],
     "optIn": [

--- a/rules/autoconsent/pornhub.json
+++ b/rules/autoconsent/pornhub.json
@@ -4,15 +4,15 @@
         "urlPattern": "^https://(www\\.)?pornhub\\.com/"
     },
     "cosmetic": false,
-    "prehideSelectors": ["#cookieBanner #cookieBannerContent"],
+    "prehideSelectors": ["#cookieBanner #cookieBannerContent", "#cookieBanner.cbShort"],
     "detectCmp": [
         {
-            "exists": "#cookieBanner #cookieBannerContent, #globalCookieBanner"
+            "exists": "#cookieBanner #cookieBannerContent, #globalCookieBanner, #cookieBanner .cbCloseButton"
         }
     ],
     "detectPopup": [
         {
-            "visible": "#cookieBanner #cookieBannerContent, #globalCookieBanner"
+            "visible": "#cookieBanner #cookieBannerContent, #globalCookieBanner, #cookieBanner .cbCloseButton"
         }
     ],
     "optIn": [
@@ -22,34 +22,39 @@
     ],
     "optOut": [
         {
-            "if": {
-                "exists": "#globalCookieBanner .js-customizeGlobalCookies"
-            },
+            "if": { "exists": "#cookieBanner .cbCloseButton" },
             "then": [
                 {
-                    "waitForThenClick": "#globalCookieBanner .js-customizeGlobalCookies"
-                }
-            ]
-        },
-        {
-            "if": {
-                "exists": "#cookieBanner [data-label=accept_essential]"
-            },
-            "then": [
-                {
-                    "click": "#cookieBanner [data-label=accept_essential]"
+                    "click": "#cookieBanner .cbCloseButton"
                 }
             ],
             "else": [
                 {
-                    "waitForThenClick": "#cookieBanner button.cbSecondaryCTA"
+                    "if": {
+                        "exists": "#globalCookieBanner .js-customizeGlobalCookies"
+                    },
+                    "then": [
+                        {
+                            "waitForThenClick": "#globalCookieBanner .js-customizeGlobalCookies"
+                        }
+                    ]
+                },
+                {
+                    "if": {
+                        "exists": "#cookieBanner [data-label=accept_essential]"
+                    },
+                    "then": [
+                        {
+                            "click": "#cookieBanner [data-label=accept_essential]"
+                        }
+                    ],
+                    "else": [
+                        {
+                            "waitForThenClick": "#cookieBanner button.cbSecondaryCTA"
+                        }
+                    ]
                 }
             ]
-        },
-        {
-            "waitForThenClick": "#cookieBanner .cbCloseButton",
-            "comment": "dismiss the minimized banner shown after accepting essential cookies",
-            "optional": true
         }
     ]
 }

--- a/rules/autoconsent/pornhub.json
+++ b/rules/autoconsent/pornhub.json
@@ -45,6 +45,11 @@
                     "waitForThenClick": "#cookieBanner button.cbSecondaryCTA"
                 }
             ]
+        },
+        {
+            "waitForThenClick": "#cookieBanner .cbCloseButton",
+            "comment": "dismiss the minimized banner shown after accepting essential cookies",
+            "optional": true
         }
     ]
 }

--- a/rules/autoconsent/pornhub.json
+++ b/rules/autoconsent/pornhub.json
@@ -4,16 +4,15 @@
         "urlPattern": "^https://(www\\.)?pornhub\\.com/"
     },
     "cosmetic": false,
-    "prehideSelectors": ["#cookieBanner #cookieBannerContent", "#cookieBanner.cbShort"],
+    "prehideSelectors": ["#cookieBanner #cookieBannerContent"],
     "detectCmp": [
         {
-            "exists": "#cookieBanner #cookieBannerContent, #globalCookieBanner, #cookieBanner .cbCloseButton"
+            "exists": "#cookieBanner #cookieBannerContent, #globalCookieBanner"
         }
     ],
     "detectPopup": [
         {
-            "visible": "#cookieBanner #cookieBannerContent, #globalCookieBanner, #cookieBanner .cbCloseButton",
-            "check": "any"
+            "visible": "#cookieBanner #cookieBannerContent, #globalCookieBanner"
         }
     ],
     "optIn": [
@@ -23,37 +22,27 @@
     ],
     "optOut": [
         {
-            "if": { "exists": "#cookieBanner .cbCloseButton" },
+            "if": {
+                "exists": "#globalCookieBanner .js-customizeGlobalCookies"
+            },
             "then": [
                 {
-                    "click": "#cookieBanner .cbCloseButton"
+                    "waitForThenClick": "#globalCookieBanner .js-customizeGlobalCookies"
+                }
+            ]
+        },
+        {
+            "if": {
+                "exists": "#cookieBanner [data-label=accept_essential]"
+            },
+            "then": [
+                {
+                    "click": "#cookieBanner [data-label=accept_essential]"
                 }
             ],
             "else": [
                 {
-                    "if": {
-                        "exists": "#globalCookieBanner .js-customizeGlobalCookies"
-                    },
-                    "then": [
-                        {
-                            "waitForThenClick": "#globalCookieBanner .js-customizeGlobalCookies"
-                        }
-                    ]
-                },
-                {
-                    "if": {
-                        "exists": "#cookieBanner [data-label=accept_essential]"
-                    },
-                    "then": [
-                        {
-                            "click": "#cookieBanner [data-label=accept_essential]"
-                        }
-                    ],
-                    "else": [
-                        {
-                            "waitForThenClick": "#cookieBanner button.cbSecondaryCTA"
-                        }
-                    ]
+                    "waitForThenClick": "#cookieBanner button.cbSecondaryCTA"
                 }
             ]
         }

--- a/tests/pornhub.spec.ts
+++ b/tests/pornhub.spec.ts
@@ -2,4 +2,5 @@ import generateCMPTests from '../playwright/runner';
 
 generateCMPTests('pornhub.com', ['https://pornhub.com/'], {
     onlyRegions: ['US'],
+    expectedRuns: 2,
 });

--- a/tests/pornhub.spec.ts
+++ b/tests/pornhub.spec.ts
@@ -1,6 +1,5 @@
 import generateCMPTests from '../playwright/runner';
 
 generateCMPTests('pornhub.com', ['https://pornhub.com/'], {
-    onlyRegions: ['US'],
     expectedRuns: 2,
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL:

## Description:

Adds a focused companion rule for Pornhub's compact cookie banner (`#cookieBanner.cbShort`) that appears after accepting essential cookies. The existing Pornhub rule continues to handle the primary cookie banner, while the new rule handles the follow-up cookie notice as a distinct popup to avoid reload-loop false positives in the test harness.

The Pornhub spec now runs across configured regions instead of being limited to US, matching the regional verification results.

The age-verification modal is intentionally not automated because it requires a user age attestation.

## Steps to test this PR:

- [x] `npm run build-rules`
- [x] `npm run rule-syntax-check`
- [x] `npx playwright test tests/pornhub.spec.ts --project chrome`
- [x] `npm run prepublish`
- [x] Regional proxy verification for `us`, `gb`, `au`, `ca`, `de`, `fr`, `nl`, `ch`, `no`, `it`, `es`, `pl`, `se`, `dk`, `jp`
- [x] Inspected final screenshots from regional proxy verification; cookie UI is cleared. Some regions continue to show the age-verification gate, which is intentionally left for the user.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a83f067-240f-40d1-b445-dba291609b92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a83f067-240f-40d1-b445-dba291609b92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

