### PR TITLE
Dismiss The Guardian "consent or pay" wall in EU/UK via cosmetic rule

### DIFF
--- a/rules/autoconsent/theguardian.com.json
+++ b/rules/autoconsent/theguardian.com.json
@@ -1,0 +1,21 @@
+{
+    "name": "theguardian.com",
+    "vendorUrl": "https://www.theguardian.com/",
+    "comment": "Sourcepoint 'consent or pay' wall shown in the EU/EEA (message 1482251) and UK (message 1482252), where the only reject option requires a paid subscription. The container id embeds the Sourcepoint message id, so we target the pay-wall variants specifically to avoid clashing with the free-reject Sourcepoint popup used in other regions (handled by Sourcepoint-frame). Brittle: message ids may change if the campaign is reconfigured.",
+    "cosmetic": true,
+    "minimumRuleStepVersion": 2,
+    "runContext": {
+        "urlPattern": "^https?://(\\w+\\.)?theguardian\\.com/",
+        "main": true,
+        "frame": false
+    },
+    "prehideSelectors": ["div[id='sp_message_container_1482251'],div[id='sp_message_container_1482252']"],
+    "detectCmp": [{ "exists": "div[id='sp_message_container_1482251'],div[id='sp_message_container_1482252']" }],
+    "detectPopup": [{ "visible": "div[id='sp_message_container_1482251'],div[id='sp_message_container_1482252']" }],
+    "optIn": [],
+    "optOut": [
+        { "hide": "div[id='sp_message_container_1482251'],div[id='sp_message_container_1482252']" },
+        { "removeClass": "sp-message-open", "selector": "html", "optional": true }
+    ],
+    "test": [{ "visible": "div[id='sp_message_container_1482251'],div[id='sp_message_container_1482252']", "check": "none" }]
+}

--- a/tests/sourcepoint.spec.ts
+++ b/tests/sourcepoint.spec.ts
@@ -1,11 +1,12 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('Sourcepoint-frame', [
-    'https://www.theguardian.com/',
-    'https://news.sky.com/',
-    'https://www.economist.com/',
-    'https://www.carwow.co.uk/',
-]);
+generateCMPTests('Sourcepoint-frame', ['https://news.sky.com/', 'https://www.economist.com/', 'https://www.carwow.co.uk/']);
+
+// The Guardian serves a "consent or pay" wall in the EU/EEA and UK (handled by the
+// theguardian.com cosmetic rule); only the remaining regions get a free-reject popup.
+generateCMPTests('Sourcepoint-frame', ['https://www.theguardian.com/'], {
+    skipRegions: ['GB', 'DE', 'FR', 'IT', 'ES', 'NL', 'PL', 'SE', 'NO', 'DK', 'CH'],
+});
 
 generateCMPTests(
     'Sourcepoint-frame',

--- a/tests/theguardian.com.spec.ts
+++ b/tests/theguardian.com.spec.ts
@@ -1,0 +1,11 @@
+import generateCMPTests from '../playwright/runner';
+
+// The Guardian shows a Sourcepoint "consent or pay" wall in the EU/EEA and UK,
+// where the only reject option requires a paid subscription. A cosmetic rule
+// dismisses it by hiding the Sourcepoint container and removing the scroll lock.
+// Other regions keep a free-reject Sourcepoint popup handled by Sourcepoint-frame.
+generateCMPTests('theguardian.com', ['https://www.theguardian.com/'], {
+    onlyRegions: ['GB', 'DE', 'FR', 'IT', 'ES', 'NL', 'PL', 'SE', 'NO', 'DK', 'CH'],
+    testOptIn: false,
+    testSelfTest: false,
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The Guardian serves a Sourcepoint **"consent or pay"** modal in the EU/EEA and UK, where the only reject option is *"Reject all and subscribe to Guardian Ad-Lite for £5/€5 per month"* — there is no free reject. The generic `Sourcepoint-frame` rule correctly bails on this paywall (it clicks nothing), so the popup is left in place and blocks the page (scroll-locked).

This adds a **top-frame cosmetic rule** (`theguardian.com`) that dismisses the wall by:
1. hiding the Sourcepoint container (`div[id='sp_message_container_...']`), and
2. removing the `sp-message-open` scroll-lock class from `<html>`.

## Why this is scoped the way it is

The Sourcepoint UI lives in a cross-origin `sourcepoint.theguardian.com` iframe, so the top frame cannot inspect whether a free reject exists. Crucially, the EU/UK consent-or-pay modal is **identical to the standard free-reject Sourcepoint modal** used in some regions (e.g. CA, JP) at the top-frame level — same container, same `sp-message-open` class, same `/index.html` + `consent_origin=tcfv2`. The **only** distinguishing signal is the Sourcepoint `message_id`, which is embedded in the container element id:

| Regions | `message_id` | Reject option |
|---|---|---|
| EU/EEA (DE, FR, IT, ES, NL, PL, SE, NO, DK, CH) | `1482251` | consent-or-pay (paywall) |
| UK (GB) | `1482252` | consent-or-pay (paywall) |
| CA, JP | `1482255` | free reject (handled by `Sourcepoint-frame`) |
| US | `1498198` | usnat notice (handled by `Sourcepoint-frame`) |
| AU | `1418584` | global-cmp notice (handled by `Sourcepoint-frame`) |

The rule therefore targets **only** `sp_message_container_1482251` and `sp_message_container_1482252`, and runs on the top frame only (`frame: false`), so it never fires in the free-reject regions and does not conflict with `Sourcepoint-frame`.

> [!WARNING]
> This is intentionally **brittle**: the `message_id` values are Sourcepoint campaign IDs and will need updating if The Guardian reconfigures the campaign. This trade-off is documented in the rule `comment`.

## Tests

- New `tests/theguardian.com.spec.ts` covering the consent-or-pay regions.
- `tests/sourcepoint.spec.ts`: Guardian moved to a region-scoped group so `Sourcepoint-frame` is only asserted in the free-reject regions (US/CA/AU/…).

## Verification (regional proxies, opt-out + screenshots)

| Region | Acted CMP | optOut | Notes |
|---|---|---|---|
| GB, DE, FR, IT, ES, NL, PL, SE, NO, DK, CH | `theguardian.com` | ✅ | consent-or-pay dismissed; page scrollable (screenshots verified for GB/DE) |
| US, CA, JP | `Sourcepoint-frame` | ✅ | new rule did **not** fire; genuine opt-out preserved |
| AU | `Sourcepoint-frame` | ⚠️ flaky | pre-existing `Sourcepoint-frame` instability — reproduced **without** this change; new rule does not fire in AU |

Cross-frame check: in EU only the top-frame cosmetic rule emits `autoconsentDone` (the iframe `Sourcepoint-frame` detects the CMP but bails on the paywall), so there's no double-completion / reload-loop. Compact-rule filtering confirmed the rule is present on the `www.theguardian.com` frame and absent from the `sourcepoint.theguardian.com` iframe.

Local checks: `npm run build-rules`, `npm run rule-syntax-check`, `npm run lint`, `npm run prepublish` all pass.

## Note on policy

Per `AGENTS.md`, consent-or-pay is generally treated as a paywall that "does not need to be handled" (the usual remedy is a `privacy-configuration` exception). This PR implements the explicitly-requested cosmetic dismissal instead; reviewers may prefer the config-exception route.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9799bcc-822b-44dd-a762-bd219e28f8e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9799bcc-822b-44dd-a762-bd219e28f8e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

