### PR TITLE
Rule update: Admiral

### DIFF
--- a/lib/cmps/admiral.ts
+++ b/lib/cmps/admiral.ts
@@ -3,6 +3,39 @@ import AutoConsentCMPBase from './base';
 export default class Admiral extends AutoConsentCMPBase {
     name = 'Admiral';
 
+    private readonly consentCardSelector = 'div > div[class*=Card] > div[class*=Frame] > div[class*=Pills] > button[class*=Pills__StyledPill]';
+
+    private getVrmNotice() {
+        return Array.from(document.querySelectorAll<HTMLElement>('body > div')).find((element) => {
+            const text = element.innerText || '';
+            const rect = element.getBoundingClientRect();
+            const style = getComputedStyle(element);
+
+            return (
+                style.position === 'fixed' &&
+                rect.width > 0 &&
+                rect.height > 0 &&
+                text.includes('Your Privacy') &&
+                text.includes('VRM') &&
+                text.includes('Admiral')
+            );
+        });
+    }
+
+    private isVisibleElement(element: HTMLElement) {
+        const rect = element.getBoundingClientRect();
+        const style = getComputedStyle(element);
+
+        return rect.width > 0 && rect.height > 0 && style.display !== 'none' && style.visibility !== 'hidden';
+    }
+
+    private getVrmCloseButton() {
+        const notice = this.getVrmNotice();
+        const closeButton = notice?.querySelector<HTMLElement>('button[aria-label="Close"]');
+
+        return closeButton && this.isVisibleElement(closeButton) ? closeButton : null;
+    }
+
     get hasSelfTest(): boolean {
         return false;
     }
@@ -16,14 +49,11 @@ export default class Admiral extends AutoConsentCMPBase {
     }
 
     async detectCmp() {
-        return this.elementExists('div > div[class*=Card] > div[class*=Frame] > div[class*=Pills] > button[class*=Pills__StyledPill]');
+        return (await this.elementExists(this.consentCardSelector)) || Boolean(this.getVrmNotice());
     }
 
     async detectPopup() {
-        return this.elementVisible(
-            'div > div[class*=Card] > div[class*=Frame] > div[class*=Pills] > button[class*=Pills__StyledPill]',
-            'any',
-        );
+        return (await this.elementVisible(this.consentCardSelector, 'any')) || Boolean(this.getVrmNotice());
     }
 
     async optOut() {
@@ -32,6 +62,11 @@ export default class Admiral extends AutoConsentCMPBase {
 
         if (await this.waitForElement(rejectAllSelector, 500)) {
             return await this.click(rejectAllSelector);
+        }
+
+        const vrmCloseButton = this.getVrmCloseButton();
+        if (vrmCloseButton) {
+            return await this.clickElement(vrmCloseButton);
         }
 
         const purposesButtonSelector =

--- a/lib/cmps/admiral.ts
+++ b/lib/cmps/admiral.ts
@@ -3,7 +3,8 @@ import AutoConsentCMPBase from './base';
 export default class Admiral extends AutoConsentCMPBase {
     name = 'Admiral';
 
-    private readonly consentCardSelector = 'div > div[class*=Card] > div[class*=Frame] > div[class*=Pills] > button[class*=Pills__StyledPill]';
+    private readonly consentCardSelector =
+        'div > div[class*=Card] > div[class*=Frame] > div[class*=Pills] > button[class*=Pills__StyledPill]';
 
     private getVrmNotice() {
         return Array.from(document.querySelectorAll<HTMLElement>('body > div')).find((element) => {

--- a/tests/admiral.spec.ts
+++ b/tests/admiral.spec.ts
@@ -1,3 +1,12 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('admiral', [], {});
+generateCMPTests(
+    'Admiral',
+    [
+        'https://townhall.com/columnists/anthony-constantini/2026/07/23/break-googles-monopoly-for-good-n2679904',
+        'https://redstate.com/',
+        'https://twitchy.com/',
+        'https://hotair.com/',
+    ],
+    { testOptIn: false },
+);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1216839101556091?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CMP DOM heuristics and test URLs only; no auth, data, or core infrastructure changes.
> 
> **Overview**
> Extends the **Admiral** autoconsent CMP so it also recognizes a fixed **VRM “Your Privacy”** overlay (not just the pill/card UI), and can dismiss it by clicking **Close** when **Reject all** isn’t available.
> 
> Detection and popup checks now succeed if either the existing consent card selector or that VRM notice is present; `optOut` tries reject-all first, then the VRM close button, then the existing purposes → uncheck → save flow.
> 
> Adds Playwright coverage for Townhall, RedState, Twitchy, and HotAir with opt-in tests disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3b7992644f0e8885fb9bdba6576ad20a04668d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->