### PR TITLE
Fix Pandectes mobile settings timing

### DIFF
--- a/rules/autoconsent/pandectes.json
+++ b/rules/autoconsent/pandectes.json
@@ -20,10 +20,12 @@
     "optOut": [
         {
             "if": { "visible": "#pandectes-banner .cc-deny" },
-            "then": [{ "click": "#pandectes-banner .cc-deny" }],
+            "then": [{ "waitForThenClick": "#pandectes-banner .cc-deny" }],
             "else": [
-                { "click": "#pandectes-banner .cc-settings" },
-                { "waitForThenClick": ".pd-cp-ui-rejectAll" },
+                { "waitForThenClick": "#pandectes-banner .cc-settings" },
+                { "waitForVisible": ".pd-cp-ui-rejectAll" },
+                { "click": ".pd-cp-ui-rejectAll" },
+                { "waitForVisible": ".pd-cp-ui-save" },
                 { "click": ".pd-cp-ui-save" }
             ]
         }

--- a/tests/pandectes-mobile.spec.ts
+++ b/tests/pandectes-mobile.spec.ts
@@ -1,0 +1,7 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('pandectes', ['https://www.loopearplugs.com/'], {
+    mobile: true,
+    onlyRegions: ['US'],
+    testOptIn: false,
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1216696146846112?focus=true

## Description:

- Wait for Pandectes settings controls to become visible before clicking through the fallback opt-out path.
- Add a mobile US regression spec for loopearplugs.com, where the region picker is present alongside Pandectes.

## Steps to test this PR:

- `npm run rule-syntax-check` - passed
- Regional proxy helper: `https://hollandscountryclothing.co.uk/` from GB - passed; Pandectes opt-out and self-test succeeded, screenshot showed banner cleared
- `npm run prepublish` - passed
- Attempted `https://www.loopearplugs.com/` from US mobile via regional proxy after the initial reproduction; subsequent requests returned the site's `local_rate_limited` page, so a post-change live retry on that exact URL could not complete in this run
- Attempted `REGION=US npx playwright test tests/pandectes-mobile.spec.ts --project iphoneSE --reporter=line`; it also hit `local_rate_limited` and did not exercise the CMP
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8273b1c-8078-4209-a6e6-3399f7ee391e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8273b1c-8078-4209-a6e6-3399f7ee391e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

