### PR TITLE
make youtube-mobile more reliable

### DIFF
--- a/rules/autoconsent/youtube-mobile.json
+++ b/rules/autoconsent/youtube-mobile.json
@@ -10,6 +10,7 @@
         { "wait": 500 }
     ],
     "optOut": [
+        { "wait": 500 },
         {
             "waitForThenClick": "ytm-consent-bump-v2-renderer .privacy-terms + .one-col-dialog-buttons c3-material-button:nth-child(2) button, ytm-consent-bump-v2-renderer .privacy-terms + .one-col-dialog-buttons ytm-button-renderer:nth-child(2) button"
         },


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1216914673332134?focus=true

## Description:

<!--
Don't forget to label the PR.

Version labels use the `version:` prefix, for example `version: patch`.
Category labels use the `category:` prefix, for example `category: rules`.
Details: https://github.com/duckduckgo/autoconsent/blob/main/docs/release-notes.md
-->

## Steps to test this PR:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single timing step in a consent automation rule; no auth, data, or core app logic changes.
> 
> **Overview**
> Improves reliability of the **youtube-mobile** autoconsent rule by adding a **500ms wait** at the start of the `optOut` sequence, before `waitForThenClick` on the reject/limited-consent button.
> 
> This matches the existing post-click wait in `optOut` and similar patterns in other rules (e.g. bing), giving the mobile consent bump time to finish rendering before the second button is targeted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb15ef9a2543126181c6b31079510746b95d0526. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->