### PR TITLE
Introduce test region sets

### DIFF
--- a/.agents/skills/proxy-testing/SKILL.md
+++ b/.agents/skills/proxy-testing/SKILL.md
@@ -4,8 +4,19 @@ description: Test autoconsent via regional proxies in Playwright. Use when verif
 ---
 
 # Proxy Testing
+This skill provides a JS library to run autoconsent via regional proxies in Playwright.
 
-All rule changes must be tested across ALL supported geographic regions to catch regional popup variations. This skill provides a JS library to run autoconsent via regional proxies in Playwright.
+Rule changes are verified with a two-level regional policy.
+The **core region set** (default for detection, iteration, and verification) covers `us` (CCPA), `gb` (UK GDPR), `de` (EEA GDPR), plus the reported region from the task when specified (if the reported region is not a supported proxy region, use the closest supported one, e.g. `es` for `pt`). Iterate in the single most relevant region; run the full core set once when the fix is stable.
+
+Escalate to the **expanded set** (`us`, `gb`, `de`, `fr`, `nl`, `pl`, `au`, `ca`, `jp`) if any of these is true:
+- core results diverge
+- the rule contains region-dependent logic
+- the fix relies on language-specific or brittle structural selectors
+- the change touches a widely-used generic rule (as final pre-PR validation)
+- a non-core region named in the report behaves differently.
+
+The remaining GDPR/EEA regions (`ch`, `no`, `it`, `es`, `se`, `dk`) are optional even in an expanded pass: test them only when named in the report or clearly relevant (e.g. the site's ccTLD).
 
 Important! Autoconsent results can have false positives. When testing, always inspect the screenshots and confirm that opt-out was successful.
 
@@ -74,7 +85,10 @@ export default defineConfig({
 ## API
 
 - `testUrl(url, regionKey, options?)` — test one URL in a single region; launches a proxied browser, runs autoconsent, returns a `TestResult`.
-- `testRegions(url, regions?, options?)` — test one URL across several regions (defaults to all supported regions), a fresh browser per region; returns `TestResult[]`.
+- `testRegions(url, regions?, options?)` — test one URL across several regions (defaults to `CORE_REGIONS`), a fresh browser per region; returns `TestResult[]`. Remember to include the reported region when not already covered.
+- `CORE_REGIONS` — the core region set (default); add the reported region when not already covered.
+- `EXPANDED_REGIONS` — the expanded region set used on escalation.
+- `ALL_REGIONS` — all supported regions.
 - `testPage(page, url, regionKey, options?)` — run a full test on a page you created yourself (you own the browser/context); returns a `TestResult`.
 - `injectAutoconsent(page, options?)` — set up isolated-world injection; call before `page.goto()`. Returns a context (`received`, `hasMessage`, `waitForCompletion`, `waitForMessage`, `collectResult`).
 - `buildProxyConfig(regionKey)` — build the Playwright `{ server, username, password }` proxy object for a region from its env vars.
@@ -108,7 +122,7 @@ await browser.close();
 
 1. Run `npm run build-rules` after changing rule JSON.
 2. Smoke-test each regional proxy.
-3. Test in ALL supported regions.
+3. Verify on the core region set (`us`, `gb`, `de` + reported region); escalate to the expanded set per the policy above.
 4. Inspect screenshots, not just API results.
 5. Reload after dismissal and confirm the rule does not keep matching, unless cosmetic-only.
 

--- a/.agents/skills/proxy-testing/scripts/regional-proxy.mjs
+++ b/.agents/skills/proxy-testing/scripts/regional-proxy.mjs
@@ -82,7 +82,14 @@ const contentScript = fs.readFileSync(path.join(projectRoot, 'dist/autoconsent.p
 const rulesJson = JSON.parse(fs.readFileSync(path.join(projectRoot, 'rules/rules.json'), 'utf-8'));
 const fullRules = rulesJson.autoconsent;
 
-export const DEFAULT_REGIONS = ['us', 'gb', 'au', 'ca', 'de', 'fr', 'nl', 'ch', 'no', 'it', 'es', 'pl', 'se', 'dk', 'jp'];
+/** All supported proxy regions. */
+export const ALL_REGIONS = ['us', 'gb', 'au', 'ca', 'de', 'fr', 'nl', 'ch', 'no', 'it', 'es', 'pl', 'se', 'dk', 'jp'];
+
+/** Core pass: default verification set (CCPA, UK GDPR, EEA GDPR). Add the reported region when not already covered. */
+export const CORE_REGIONS = ['us', 'gb', 'de'];
+
+/** Expanded pass: escalation set covering all non-GDPR regimes plus GDPR representatives. */
+export const EXPANDED_REGIONS = ['us', 'gb', 'de', 'fr', 'nl', 'pl', 'au', 'ca', 'jp'];
 
 /**
  * Build the Playwright proxy object for a region.
@@ -560,11 +567,11 @@ export async function testUrl(url, regionKey, options = {}) {
 /**
  * Test one URL across several regions.
  * @param {string} url
- * @param {string[]} [regions]
+ * @param {string[]} [regions] Defaults to the core pass; pass EXPANDED_REGIONS or ALL_REGIONS to widen.
  * @param {Partial<TestOptions>} [options]
  * @returns {Promise<TestResult[]>}
  */
-export async function testRegions(url, regions = DEFAULT_REGIONS, options = {}) {
+export async function testRegions(url, regions = CORE_REGIONS, options = {}) {
     const results = [];
     for (const region of regions) {
         results.push(await testUrl(url, region, options));

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ CMPs behave differently by region:
 
 Use `if`/`then`/`else` to handle regional variants within a single rule.
 
-**All rule changes MUST be tested across ALL supported geographic regions** to catch regional popup variations. Test from real geographic locations using available regional testing tooling (e.g. `proxy-testing` skill).
+**Test all rule changes across the core region set** — US, GB, DE, plus the reported region from the task (or the closest supported proxy region, e.g. ES for PT) — using the `proxy-testing` skill. Escalate to the expanded set according to the skill's policy.
 
 ### Generic vs Site-Specific Rules
 
@@ -116,14 +116,15 @@ shadow root or same-origin iframe.
 
 ### Updating existing rules
 - If an existing generic rule fails on a specific site: first look for other sites with the same failure (spec sites, data/coverage.json, publicwww). If the issue applies to more sites, update the generic rule; if the issue is truly site-specific, prefer making a site-specific rule or a config exception. Never change a generic rule to fix a site-specific implementation problem.
-- After updating an existing generic rule, do a heavy testing run: all known sites (specs + data/coverage.json + publicwww) using available regional testing tooling. Inspect both API results and screenshots.
+- After updating an existing generic rule, do a heavy testing run: all known sites (specs + data/coverage.json + publicwww) across the expanded set. Inspect both API results AND screenshots.
 - if a site-specific rule is obsolete (the site switched CMP in ALL regions), propose removal.
 - if a popup does not provide an opt-out button, `optOut` _may_ click "dismiss"/"acknowledge" instead. Check with the existing heuristic patterns in /lib/heuristic-patterns.ts for reference.
 - do not keep outdated selectors in changed rules, unless they are actually used in some conditions
 - If the pop-up has an explicit "reject"-like button, you should first consider why HEURISTIC rule didn't handle it. A fix to the heuristic rule is always preferred to a new rule, as long as it doesn't cause potential false-positives on other sites.
 
 ### Verification guidelines
-- **Regional testing is mandatory** for any rule change — CMPs behave differently under GDPR (EU), CCPA (US), and other jurisdictions. Run the rule against different regions using available regional testing tooling before considering the change done.
+- **Regional testing is mandatory** for any rule change — CMPs behave differently under GDPR (EU), CCPA (US), and other jurisdictions. Run the rule against different regions using `proxy-testing` skill before considering the change done. Iterate on the fix in the single most relevant region and run the verification according to the skill's policy.
+- **Mobile policy**: by default test desktop across the current set's regions, plus one mobile sanity check in the region where the popup reproduces. If the mobile sanity check differs from desktop (different popup, rule, or outcome), expand mobile across the current set's regions. If the original report is from a mobile OS, test both desktop and mobile from the start.
 - When verifying a rule, **look at the screenshots** on top of the API results — sometimes a rule reports success, but the popup is not actually handled - a screenshot will detect this.
 - **Watch out for race conditions**. A common pitfall is that a rule starts clicking before JS handlers are ready. If you detect this, add an appropriate wait step before the click, preferably based on a specific DOM state. Unconditional `wait` is a LAST RESORT because it leads to a poor UX.
 - **Watch out for false positive detections**. Always verify that the rule does NOT match after the popup is dismissed and the page is reloaded. Over-detection can lead to reload loops.
@@ -183,4 +184,4 @@ After creating or modifying a rule:
 3. `npx playwright test tests/<name>.spec.ts` — run the E2E test
 4. `npm run prepublish` — full build including extension bundle
 5. Validate that the rule stops matching after the popup is dismissed and the page is reloaded (unless it's a cosmetic rule).
-6. Check the rule works across all supported geographic regions using available regional testing tooling.
+6. Check the rule works across regions as per guidelines above.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1163321984198618/task/1216914112743588?focus=true

## Description:
See also https://dub.duckduckgo.com/duckduckgo/tracker-radar-internal/pull/651
<!--
Don't forget to label the PR.

Version labels use the `version:` prefix, for example `version: patch`.
Category labels use the `category:` prefix, for example `category: rules`.
Details: https://github.com/duckduckgo/autoconsent/blob/main/docs/release-notes.md
-->

## Steps to test this PR:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and proxy-test helper defaults only; no autoconsent rule or runtime engine changes.
> 
> **Overview**
> Replaces **test every supported proxy region by default** with a **two-tier regional verification policy** for rule work and the `proxy-testing` skill.
> 
> **`regional-proxy.mjs`** splits the old single default list into **`CORE_REGIONS`** (`us`, `gb`, `de`), **`EXPANDED_REGIONS`** (core plus `fr`, `nl`, `pl`, `au`, `ca`, `jp`), and **`ALL_REGIONS`** (full supported list). **`testRegions`** now defaults to the core set instead of all regions.
> 
> **`proxy-testing` SKILL** documents when to iterate in one relevant region vs run the full core set, when to escalate to the expanded set (divergent results, region-dependent rules, brittle selectors, generic-rule pre-PR checks, etc.), and that extra GDPR/EEA proxies stay optional unless the report or site context warrants them.
> 
> **`AGENTS.md`** aligns agent guidance: mandatory testing on the core set plus the reported region (or closest proxy), escalation per the skill, expanded-set heavy runs after generic rule updates, explicit **`proxy-testing`** references, and a new **mobile policy** (desktop across the current set + one mobile sanity check, expand when mobile differs or the report is mobile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b9cd921817052f2e39985d2819270877b7b0004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->