### PR TITLE
Fix borlabs rule 

### DIFF
--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -100,18 +100,6 @@ export const snippets = {
         }
         return !consents.statistics;
     },
-    EVAL_BORLABS_NEEDS_CONSENT: () => {
-        const cookie = document.cookie.split(';').find((c) => c.indexOf('borlabs-cookie') !== -1);
-        if (!cookie) {
-            return true;
-        }
-        try {
-            const { consents } = JSON.parse(decodeURIComponent(cookie.split('=', 2)[1]));
-            return !consents || Object.keys(consents).length === 0;
-        } catch {
-            return true;
-        }
-    },
     EVAL_CC_BANNER2_0: () => !!document.cookie.match(/sncc=[^;]+D%3Dtrue/),
     EVAL_COINBASE_0: () =>
         JSON.parse(decodeURIComponent(document.cookie.match(/cm_(eu|default)_preferences=([0-9a-zA-Z\\{\\}\\[\\]%:]*);?/)[2])).consent

--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -112,24 +112,6 @@ export const snippets = {
             return true;
         }
     },
-    EVAL_BORLABS_OPT_OUT_V3: () => {
-        const borlabsCookie = (window as any).BorlabsCookie;
-        const serviceGroups = borlabsCookie?.ServiceGroups?.serviceGroups || {};
-        const services = borlabsCookie?.Services?.services || {};
-        const essentialServices =
-            serviceGroups.essential?.serviceIds ||
-            Object.values(services)
-                .filter((service: any) => service.serviceGroupId === 'essential')
-                .map((service: any) => service.id);
-        if (!borlabsCookie?.Consents?.save || essentialServices.length === 0) {
-            return false;
-        }
-        borlabsCookie.Consents.save({ essential: essentialServices });
-        document.querySelector('#BorlabsCookieBox')?.remove();
-        document.documentElement.classList.remove('brlbs-cmpnt--active');
-        document.body.classList.remove('brlbs-cmpnt--active');
-        return true;
-    },
     EVAL_CC_BANNER2_0: () => !!document.cookie.match(/sncc=[^;]+D%3Dtrue/),
     EVAL_COINBASE_0: () =>
         JSON.parse(decodeURIComponent(document.cookie.match(/cm_(eu|default)_preferences=([0-9a-zA-Z\\{\\}\\[\\]%:]*);?/)[2])).consent

--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -84,15 +84,52 @@ export const snippets = {
     EVAL_ADULTFRIENDFINDER_TEST: () => !!localStorage.getItem('cookieConsent'),
     EVAL_BAHN_TEST: () => utag.gdpr.getSelectedCategories().length === 1,
     EVAL_BIGCOMMERCE_CONSENT_MANAGER_DETECT: () => !!(window.consentManager && window.consentManager.version),
-    EVAL_BORLABS_0: () =>
-        !JSON.parse(
-            decodeURIComponent(
-                document.cookie
-                    .split(';')
-                    .find((c) => c.indexOf('borlabs-cookie') !== -1)
-                    .split('=', 2)[1],
-            ),
-        ).consents.statistics,
+    EVAL_BORLABS_0: () => {
+        const cookie = document.cookie.split(';').find((c) => c.indexOf('borlabs-cookie') !== -1);
+        if (!cookie) {
+            return false;
+        }
+        const { consents } = JSON.parse(decodeURIComponent(cookie.split('=', 2)[1]));
+        if (!consents) {
+            return false;
+        }
+        if (consents.v3 || Object.values(consents).some(Array.isArray)) {
+            return Object.entries(consents).every(
+                ([groupId, services]) => groupId === 'essential' || !Array.isArray(services) || services.length === 0,
+            );
+        }
+        return !consents.statistics;
+    },
+    EVAL_BORLABS_NEEDS_CONSENT: () => {
+        const cookie = document.cookie.split(';').find((c) => c.indexOf('borlabs-cookie') !== -1);
+        if (!cookie) {
+            return true;
+        }
+        try {
+            const { consents } = JSON.parse(decodeURIComponent(cookie.split('=', 2)[1]));
+            return !consents || Object.keys(consents).length === 0;
+        } catch {
+            return true;
+        }
+    },
+    EVAL_BORLABS_OPT_OUT_V3: () => {
+        const borlabsCookie = (window as any).BorlabsCookie;
+        const serviceGroups = borlabsCookie?.ServiceGroups?.serviceGroups || {};
+        const services = borlabsCookie?.Services?.services || {};
+        const essentialServices =
+            serviceGroups.essential?.serviceIds ||
+            Object.values(services)
+                .filter((service: any) => service.serviceGroupId === 'essential')
+                .map((service: any) => service.id);
+        if (!borlabsCookie?.Consents?.save || essentialServices.length === 0) {
+            return false;
+        }
+        borlabsCookie.Consents.save({ essential: essentialServices });
+        document.querySelector('#BorlabsCookieBox')?.remove();
+        document.documentElement.classList.remove('brlbs-cmpnt--active');
+        document.body.classList.remove('brlbs-cmpnt--active');
+        return true;
+    },
     EVAL_CC_BANNER2_0: () => !!document.cookie.match(/sncc=[^;]+D%3Dtrue/),
     EVAL_COINBASE_0: () =>
         JSON.parse(decodeURIComponent(document.cookie.match(/cm_(eu|default)_preferences=([0-9a-zA-Z\\{\\}\\[\\]%:]*);?/)[2])).consent

--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -84,22 +84,15 @@ export const snippets = {
     EVAL_ADULTFRIENDFINDER_TEST: () => !!localStorage.getItem('cookieConsent'),
     EVAL_BAHN_TEST: () => utag.gdpr.getSelectedCategories().length === 1,
     EVAL_BIGCOMMERCE_CONSENT_MANAGER_DETECT: () => !!(window.consentManager && window.consentManager.version),
-    EVAL_BORLABS_0: () => {
-        const cookie = document.cookie.split(';').find((c) => c.indexOf('borlabs-cookie') !== -1);
-        if (!cookie) {
-            return false;
-        }
-        const { consents } = JSON.parse(decodeURIComponent(cookie.split('=', 2)[1]));
-        if (!consents) {
-            return false;
-        }
-        if (consents.v3 || Object.values(consents).some(Array.isArray)) {
-            return Object.entries(consents).every(
-                ([groupId, services]) => groupId === 'essential' || !Array.isArray(services) || services.length === 0,
-            );
-        }
-        return !consents.statistics;
-    },
+    EVAL_BORLABS_0: () =>
+        !JSON.parse(
+            decodeURIComponent(
+                document.cookie
+                    .split(';')
+                    .find((c) => c.indexOf('borlabs-cookie') !== -1)
+                    .split('=', 2)[1],
+            ),
+        ).consents.statistics,
     EVAL_CC_BANNER2_0: () => !!document.cookie.match(/sncc=[^;]+D%3Dtrue/),
     EVAL_COINBASE_0: () =>
         JSON.parse(decodeURIComponent(document.cookie.match(/cm_(eu|default)_preferences=([0-9a-zA-Z\\{\\}\\[\\]%:]*);?/)[2])).consent

--- a/rules/autoconsent/borlabs.json
+++ b/rules/autoconsent/borlabs.json
@@ -9,6 +9,9 @@
     "detectPopup": [
         {
             "visible": "._brlbs-bar-wrap,._brlbs-box-wrap,.brlbs-cmpnt-dialog"
+        },
+        {
+            "eval": "EVAL_BORLABS_NEEDS_CONSENT"
         }
     ],
     "optIn": [
@@ -22,21 +25,27 @@
             "then": [{ "click": ".brlbs-btn-accept-only-essential,a[data-cookie-refuse]" }],
             "else": [
                 {
-                    "click": "a[data-cookie-individual]"
-                },
-                {
-                    "waitForVisible": ".cookie-preference"
-                },
-                {
-                    "click": "input[data-borlabs-cookie-checkbox]:checked",
-                    "all": true,
-                    "optional": true
-                },
-                {
-                    "click": "#CookiePrefSave"
-                },
-                {
-                    "wait": 500
+                    "if": { "exists": "a[data-cookie-individual]" },
+                    "then": [
+                        {
+                            "click": "a[data-cookie-individual]"
+                        },
+                        {
+                            "waitForVisible": ".cookie-preference"
+                        },
+                        {
+                            "click": "input[data-borlabs-cookie-checkbox]:checked",
+                            "all": true,
+                            "optional": true
+                        },
+                        {
+                            "click": "#CookiePrefSave"
+                        },
+                        {
+                            "wait": 500
+                        }
+                    ],
+                    "else": [{ "eval": "EVAL_BORLABS_OPT_OUT_V3" }]
                 }
             ]
         }

--- a/rules/autoconsent/borlabs.json
+++ b/rules/autoconsent/borlabs.json
@@ -19,33 +19,53 @@
     "optOut": [
         {
             "if": {
-                "exists": ".brlbs-btn-accept-only-essential,a[data-cookie-refuse],.brlbs-cmpnt-close-button[data-borlabs-cookie-actions=\"close-button\"]"
+                "exists": ".brlbs-btn-accept-only-essential,a[data-cookie-refuse]"
             },
             "then": [
                 {
-                    "click": ".brlbs-btn-accept-only-essential,a[data-cookie-refuse],.brlbs-cmpnt-close-button[data-borlabs-cookie-actions=\"close-button\"]"
+                    "click": ".brlbs-btn-accept-only-essential,a[data-cookie-refuse]"
                 }
             ],
             "else": [
                 {
-                    "if": { "exists": "a[data-cookie-individual]" },
+                    "if": { "exists": ".brlbs-btn-save,#CookieBoxSaveButton" },
                     "then": [
                         {
-                            "click": "a[data-cookie-individual]"
-                        },
+                            "click": ".brlbs-btn-save,#CookieBoxSaveButton"
+                        }
+                    ],
+                    "else": [
                         {
-                            "waitForVisible": ".cookie-preference"
-                        },
-                        {
-                            "click": "input[data-borlabs-cookie-checkbox]:checked",
-                            "all": true,
-                            "optional": true
-                        },
-                        {
-                            "click": "#CookiePrefSave"
-                        },
-                        {
-                            "wait": 500
+                            "if": { "exists": ".brlbs-cmpnt-close-button[data-borlabs-cookie-actions=\"close-button\"]" },
+                            "then": [
+                                {
+                                    "click": ".brlbs-cmpnt-close-button[data-borlabs-cookie-actions=\"close-button\"]"
+                                }
+                            ],
+                            "else": [
+                                {
+                                    "if": { "exists": "a[data-cookie-individual]" },
+                                    "then": [
+                                        {
+                                            "click": "a[data-cookie-individual]"
+                                        },
+                                        {
+                                            "waitForVisible": ".cookie-preference"
+                                        },
+                                        {
+                                            "click": "input[data-borlabs-cookie-checkbox]:checked",
+                                            "all": true,
+                                            "optional": true
+                                        },
+                                        {
+                                            "click": "#CookiePrefSave"
+                                        },
+                                        {
+                                            "wait": 500
+                                        }
+                                    ]
+                                }
+                            ]
                         }
                     ]
                 }

--- a/rules/autoconsent/borlabs.json
+++ b/rules/autoconsent/borlabs.json
@@ -21,8 +21,14 @@
     ],
     "optOut": [
         {
-            "if": { "exists": ".brlbs-btn-accept-only-essential,a[data-cookie-refuse]" },
-            "then": [{ "click": ".brlbs-btn-accept-only-essential,a[data-cookie-refuse]" }],
+            "if": {
+                "exists": ".brlbs-btn-accept-only-essential,a[data-cookie-refuse],.brlbs-cmpnt-close-button[data-borlabs-cookie-actions=\"close-button\"]"
+            },
+            "then": [
+                {
+                    "click": ".brlbs-btn-accept-only-essential,a[data-cookie-refuse],.brlbs-cmpnt-close-button[data-borlabs-cookie-actions=\"close-button\"]"
+                }
+            ],
             "else": [
                 {
                     "if": { "exists": "a[data-cookie-individual]" },
@@ -44,8 +50,7 @@
                         {
                             "wait": 500
                         }
-                    ],
-                    "else": [{ "eval": "EVAL_BORLABS_OPT_OUT_V3" }]
+                    ]
                 }
             ]
         }

--- a/rules/autoconsent/borlabs.json
+++ b/rules/autoconsent/borlabs.json
@@ -9,9 +9,6 @@
     "detectPopup": [
         {
             "visible": "._brlbs-bar-wrap,._brlbs-box-wrap,.brlbs-cmpnt-dialog"
-        },
-        {
-            "eval": "EVAL_BORLABS_NEEDS_CONSENT"
         }
     ],
     "optIn": [

--- a/tests/borlabs.spec.ts
+++ b/tests/borlabs.spec.ts
@@ -1,5 +1,5 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('borlabs', ['https://www.kesselheld.de/'], {
+generateCMPTests('borlabs', ['https://www.kesselheld.de/', 'https://cocoon-hotels.com/de/cocoon-salzburg/'], {
     skipRegions: ['US'],
 });


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1216912337058333?focus=true

## Description:

<!--
Don't forget to label the PR.

Version labels use the `version:` prefix, for example `version: patch`.
Category labels use the `category:` prefix, for example `category: rules`.
Details: https://github.com/duckduckgo/autoconsent/blob/main/docs/release-notes.md
-->

## Steps to test this PR:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Borlabs autoconsent rule JSON and an extra Playwright test URL; no auth, data, or core runtime logic.
> 
> **Overview**
> **Borlabs `optOut`** now walks a **priority chain** when “essential only” / refuse controls are missing: click **save** (`brlbs-btn-save`, `#CookieBoxSaveButton`), else the **dialog close** button, else the existing **individual preferences** path (open individual, uncheck boxes, `#CookiePrefSave`).
> 
> **Tests** add `https://cocoon-hotels.com/de/cocoon-salzburg/` alongside kesselheld.de (still skipping US regions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28285cbe2071605afa943a1668f35abf59e9264b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->