### PR TITLE
Revert "Fix Pornhub reload loop by merging compact cookie banner rule"

### DIFF
--- a/rules/autoconsent/pornhub-compact-cookie-banner.json
+++ b/rules/autoconsent/pornhub-compact-cookie-banner.json
@@ -1,0 +1,28 @@
+{
+    "name": "pornhub-compact-cookie-banner",
+    "runContext": {
+        "urlPattern": "^https://(www\\.)?pornhub\\.com/"
+    },
+    "cosmetic": false,
+    "prehideSelectors": ["#cookieBanner.cbShort"],
+    "detectCmp": [
+        {
+            "exists": "#cookieBanner.cbShort .cbCloseButton"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#cookieBanner.cbShort .cbCloseButton"
+        }
+    ],
+    "optIn": [
+        {
+            "click": "#cookieBanner.cbShort .cbCloseButton"
+        }
+    ],
+    "optOut": [
+        {
+            "click": "#cookieBanner.cbShort .cbCloseButton"
+        }
+    ]
+}

--- a/rules/autoconsent/pornhub.json
+++ b/rules/autoconsent/pornhub.json
@@ -4,17 +4,15 @@
         "urlPattern": "^https://(www\\.)?pornhub\\.com/"
     },
     "cosmetic": false,
-    "prehideSelectors": ["#cookieBanner #cookieBannerContent", "#cookieBanner.cbShort"],
+    "prehideSelectors": ["#cookieBanner #cookieBannerContent"],
     "detectCmp": [
         {
-            "visible": "#cookieBanner #cookieBannerContent, #globalCookieBanner, #cookieBanner.cbShort",
-            "check": "any"
+            "exists": "#cookieBanner #cookieBannerContent, #globalCookieBanner"
         }
     ],
     "detectPopup": [
         {
-            "visible": "#cookieBanner #cookieBannerContent, #globalCookieBanner, #cookieBanner.cbShort .cbCloseButton",
-            "check": "any"
+            "visible": "#cookieBanner #cookieBannerContent, #globalCookieBanner"
         }
     ],
     "optIn": [
@@ -23,16 +21,6 @@
         }
     ],
     "optOut": [
-        {
-            "if": {
-                "visible": "#cookieBanner.cbShort .cbCloseButton"
-            },
-            "then": [
-                {
-                    "waitForThenClick": "#cookieBanner.cbShort .cbCloseButton"
-                }
-            ]
-        },
         {
             "if": {
                 "exists": "#globalCookieBanner .js-customizeGlobalCookies"
@@ -55,18 +43,6 @@
             "else": [
                 {
                     "waitForThenClick": "#cookieBanner button.cbSecondaryCTA"
-                }
-            ]
-        }
-    ],
-    "test": [
-        {
-            "any": [
-                {
-                    "cookieContains": "cookieConsent=2"
-                },
-                {
-                    "cookieContains": "cookieBannerState"
                 }
             ]
         }

--- a/tests/pornhub.spec.ts
+++ b/tests/pornhub.spec.ts
@@ -1,6 +1,5 @@
 import generateCMPTests from '../playwright/runner';
 
 generateCMPTests('pornhub.com', ['https://pornhub.com/'], {
-    expectedRuns: 1,
-    testSelfTest: false,
+    expectedRuns: 2,
 });


### PR DESCRIPTION
Reverts duckduckgo/autoconsent#1463

This is still causing reload loops.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live CMP handling on a high-traffic site; wrong detection or clicks could worsen reload loops or leave banners stuck, though the change intentionally reverts a known-broken merge.
> 
> **Overview**
> Reverts the **#1463** approach that folded the short (`cbShort`) cookie banner into `pornhub.com`, because it still triggered **reload loops**.
> 
> A dedicated rule **`pornhub-compact-cookie-banner`** is restored: it prehides `#cookieBanner.cbShort`, detects the compact close button, and clicks it for both opt-in and opt-out. The main **`pornhub.com`** rule again only targets the full banner content and `#globalCookieBanner`, without compact-banner selectors or the conditional close-button opt-out branch. The cookie self-test block on `pornhub.com` is removed as part of this split.
> 
> Playwright coverage is updated so **`expectedRuns` is 2** (two rules can run on the same URL) and the **`testSelfTest: false`** override is dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 321484978dcba04726c760f613ba9289a3e6cb8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->