### PR TITLE
Avoid heuristic reject on German revoke links

### DIFF
--- a/lib/heuristic-patterns.ts
+++ b/lib/heuristic-patterns.ts
@@ -257,7 +257,6 @@ const REJECT_PATTERNS_GERMAN = [
     'nicht zustimmen',
     'nicht einverstanden',
     'ich lehne ab',
-    'widerrufen',
     'mit erforderlichen einstellungen fortfahren',
     'mit erforderlichen cookies fortfahren',
     'mit notwendigen fortfahren',

--- a/tests-wtr/heuristics/heuristics-utils.test.ts
+++ b/tests-wtr/heuristics/heuristics-utils.test.ts
@@ -152,6 +152,10 @@ describe('classifyButtonTextRegex', () => {
     it('does not match partial exact string patterns', () => {
         expect(classifyButtonTextRegex('no problem')).to.equal('other');
     });
+
+    it('does not treat revoke links as reject buttons', () => {
+        expect(classifyButtonTextRegex('Widerrufen')).to.equal('other');
+    });
 });
 
 describe('classifyButtons', () => {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1216976138482715?focus=true

## Description:
Don’t click “widerrufen” on a German cookie popup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow heuristic tweak with a regression test; no auth, data, or broad pattern changes beyond one German exact-match removal.
> 
> **Overview**
> **German cookie-banner heuristics** no longer treat the exact label **Widerrufen** as a reject button.
> 
> That string was listed among German refusal patterns in `REJECT_PATTERNS_GERMAN`, so automated flows could click **revoke consent** controls instead of true reject actions. Removing the literal pattern leaves other German reject wording (e.g. *ablehnen*, *nein, danke*) unchanged.
> 
> A unit test asserts `Widerrufen` is classified as **other**, not **reject**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5616e2059266ae435a2020c93d71396081edb459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->