### PR TITLE
Rule update: [m8-ab] [e2e test] [m8] unknowncmp:bbb.org — bbb.org #1

### DIFF
--- a/rules/autoconsent/bbb.json
+++ b/rules/autoconsent/bbb.json
@@ -1,25 +1,25 @@
 {
     "name": "bbb.org",
     "cosmetic": false,
-    "prehideSelectors": [".cookies-message"],
-    "detectCmp": [{ "exists": ".cookies-message" }],
-    "detectPopup": [{ "visible": ".cookies-message [name='allow-all']" }],
-    "optIn": [{ "click": ".cookies-message [name='allow-all']" }],
+    "prehideSelectors": ["iabbb-cookies-message > section"],
+    "detectCmp": [{ "exists": "iabbb-cookies-message" }],
+    "detectPopup": [{ "visible": "iabbb-cookies-message > section [name='allow-all']" }],
+    "optIn": [{ "click": "iabbb-cookies-message > section [name='allow-all']" }],
     "optOut": [
-        { "waitForVisible": ".cookies-message button.bds-button-unstyled" },
+        { "waitForVisible": "iabbb-cookies-message > section button.bds-button-unstyled" },
         { "wait": 500 },
-        { "click": ".cookies-message button.bds-button-unstyled" },
-        { "waitFor": ".cookies-policy-dialog[open]" },
+        { "click": "iabbb-cookies-message > section button.bds-button-unstyled" },
+        { "waitFor": "iabbb-cookies-message dialog[open]" },
         {
-            "click": ".cookies-policy-dialog fieldset input[type=radio][value=false]:not(:checked)",
+            "click": "iabbb-cookies-message dialog fieldset input[type=radio][value=false]:not(:checked)",
             "all": true,
             "optional": true
         },
         {
-            "click": ".cookies-policy-dialog button.bds-button"
+            "click": "iabbb-cookies-message dialog button.bds-button"
         },
         {
-            "waitForThenClick": ".cookies-message button.bds-button:not([name])"
+            "waitForThenClick": "iabbb-cookies-message > section button.bds-button:not([name])"
         }
     ]
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217065097714527?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-site autoconsent rule selector update with no auth, data, or shared runtime changes; wrong selectors would only affect bbb.org cookie handling.
> 
> **Overview**
> Updates the **bbb.org** autoconsent rule so detection and clicks target the site’s new cookie UI structure.
> 
> Selectors move from `.cookies-message` / `.cookies-policy-dialog` to the **`iabbb-cookies-message`** custom element, with the banner actions under **`section`** and the preferences UI under **`dialog`**. **Prehide**, **detectCmp**, **detectPopup**, **optIn**, and **optOut** steps are aligned to those paths; the opt-out sequence (open settings, optional radio toggles, confirm, final banner button) is unchanged in behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f32a7073023e51d4d82cee6d33fbcde783f048e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->