### PR TITLE
Rule update: Cookie popup on gmx.com

### DIFF
--- a/rules/autoconsent/gmx-permission.json
+++ b/rules/autoconsent/gmx-permission.json
@@ -4,7 +4,7 @@
     "runContext": {
         "main": false,
         "frame": true,
-        "urlPattern": "^https://plus\\.gmx\\.com/lt\\?"
+        "urlPattern": "^https://([a-z0-9-]+\\.)?gmx\\.com/"
     },
     "prehideSelectors": ["#overlay.cmp"],
     "detectCmp": [

--- a/rules/autoconsent/gmx-permission.json
+++ b/rules/autoconsent/gmx-permission.json
@@ -4,7 +4,7 @@
     "runContext": {
         "main": false,
         "frame": true,
-        "urlPattern": "^https://plus\\.gmx\\.com/lt\\?.*[?&]ref=https%253A%252F%252F([a-z0-9-]+\\.)?gmx\\.com(?:[&%]|$)"
+        "urlPattern": "^https://plus\\.gmx\\.com/lt(?:[?#]|$)"
     },
     "prehideSelectors": ["#overlay.cmp"],
     "detectCmp": [

--- a/rules/autoconsent/gmx-permission.json
+++ b/rules/autoconsent/gmx-permission.json
@@ -1,0 +1,53 @@
+{
+    "name": "gmx-permission",
+    "vendorUrl": "https://www.gmx.com",
+    "runContext": {
+        "main": false,
+        "frame": true,
+        "urlPattern": "^https://plus\\.gmx\\.com/lt\\?"
+    },
+    "prehideSelectors": ["#overlay.cmp"],
+    "detectCmp": [
+        {
+            "exists": "#overlay.cmp"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#overlay[role=dialog]"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "#save-all-conditionally, #save-all"
+        }
+    ],
+    "optOut": [
+        {
+            "if": {
+                "exists": "#edit-purpose-settings"
+            },
+            "then": [
+                {
+                    "waitForThenClick": "#edit-purpose-settings"
+                },
+                {
+                    "waitForVisible": "#save-purpose-settings"
+                },
+                {
+                    "waitForThenClick": "#save-purpose-settings"
+                }
+            ],
+            "else": [
+                {
+                    "waitForThenClick": "#save-purpose-settings"
+                }
+            ]
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "ui_cid=OPTOUT"
+        }
+    ]
+}

--- a/rules/autoconsent/gmx-permission.json
+++ b/rules/autoconsent/gmx-permission.json
@@ -25,22 +25,34 @@
     "optOut": [
         {
             "if": {
-                "exists": "#edit-purpose-settings"
+                "exists": "#deny"
             },
             "then": [
                 {
-                    "waitForThenClick": "#edit-purpose-settings"
-                },
-                {
-                    "waitForVisible": "#save-purpose-settings"
-                },
-                {
-                    "waitForThenClick": "#save-purpose-settings"
+                    "waitForThenClick": "#deny"
                 }
             ],
             "else": [
                 {
-                    "waitForThenClick": "#save-purpose-settings"
+                    "if": {
+                        "exists": "#edit-purpose-settings"
+                    },
+                    "then": [
+                        {
+                            "waitForThenClick": "#edit-purpose-settings"
+                        },
+                        {
+                            "waitForVisible": "#save-purpose-settings"
+                        },
+                        {
+                            "waitForThenClick": "#save-purpose-settings"
+                        }
+                    ],
+                    "else": [
+                        {
+                            "waitForThenClick": "#save-purpose-settings"
+                        }
+                    ]
                 }
             ]
         }

--- a/rules/autoconsent/gmx-permission.json
+++ b/rules/autoconsent/gmx-permission.json
@@ -4,7 +4,7 @@
     "runContext": {
         "main": false,
         "frame": true,
-        "urlPattern": "^https://([a-z0-9-]+\\.)?gmx\\.com/"
+        "urlPattern": "^https://plus\\.gmx\\.com/lt\\?.*[?&]ref=https%253A%252F%252F([a-z0-9-]+\\.)?gmx\\.com(?:[&%]|$)"
     },
     "prehideSelectors": ["#overlay.cmp"],
     "detectCmp": [

--- a/tests/gmx-permission.spec.ts
+++ b/tests/gmx-permission.spec.ts
@@ -1,5 +1,5 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('gmx-permission', ['https://support.gmx.com/'], {
+generateCMPTests('gmx-permission', ['https://www.gmx.com/', 'https://support.gmx.com/'], {
     mobile: true,
 });

--- a/tests/gmx-permission.spec.ts
+++ b/tests/gmx-permission.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('gmx-permission', ['https://support.gmx.com/'], {
+    mobile: true,
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217052799657482?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New consent automation rule and tests only; no changes to core extension or security-sensitive logic.
> 
> **Overview**
> Adds a new **gmx-permission** autoconsent rule for GMX’s consent overlay loaded from `plus.gmx.com/lt` in a frame (not the main document). The rule pre-hides `#overlay.cmp`, detects the CMP and dialog, accepts via `#save-all-conditionally` / `#save-all`, and opts out via `#deny` or a fallback path through purpose settings. Success is verified with `ui_cid=OPTOUT`.
> 
> A Playwright spec runs CMP tests against `https://www.gmx.com/` and `https://support.gmx.com/` with mobile enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f18eed47c7f0d42f31c2e9b079152c5bd274bd59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->