### PR TITLE
Rule update: simyo-nl

### DIFF
--- a/rules/autoconsent/simyo-nl.json
+++ b/rules/autoconsent/simyo-nl.json
@@ -1,0 +1,35 @@
+{
+    "name": "simyo-nl",
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?simyo\\.nl/"
+    },
+    "prehideSelectors": ["[data-testid=\"cookie-wall\"]"],
+    "detectCmp": [
+        {
+            "visible": "[data-testid=\"cookie-wall\"]"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "[data-testid=\"cookie-wall\"]"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "[data-testid=\"cookie-wall\"] [data-testid=\"cookie-accept-action\"]"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "[data-testid=\"cookie-wall\"] .cookie-bar__footer button[data-id=\"0\"]",
+            "comment": "Weigeren"
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "acceptCookies=0"
+        }
+    ]
+}

--- a/tests/simyo-nl.spec.ts
+++ b/tests/simyo-nl.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('simyo-nl', ['https://www.simyo.nl/klantenservice/roaming'], { testOptIn: false, testSelfTest: true });


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1216979498489579?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

No autoconsent exception was found for www.simyo.nl in privacy-configuration; only an existing generated-rule entry for mijn.simyo.nl appeared. Added a site-scoped simyo-nl rule using stable [data-testid="cookie-wall"] markup, clicking the explicit Weigeren button and validating acceptCookies=0. PublicWWW did not find other indexed sites with the same cookie-wall markup, so a generic rule was not warranted. Post-dismiss reload check showed no visible CMP detection after the consent cookie was set. Final prepublish build passed.

## Steps to test this PR:

- `npm run build-rules && npx playwright test tests/simyo-nl.spec.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new site-specific autoconsent rule and test only; no changes to shared runner logic or existing rules beyond this addition.
> 
> **Overview**
> Adds autoconsent coverage for **www.simyo.nl** (public site), where privacy-configuration had no exception and only **mijn.simyo.nl** had a generated rule.
> 
> The new `simyo-nl` rule targets the `[data-testid="cookie-wall"]` CMP: prehide/detect on that element, **optIn** via `cookie-accept-action`, and **optOut** by clicking the footer **Weigeren** button (`data-id="0"`). Self-test expects `acceptCookies=0` after opt-out.
> 
> A Playwright spec runs against `https://www.simyo.nl/klantenservice/roaming` with opt-in tests disabled and self-test enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd78d3f6c6e679f76ce2f9affdf0a7573a200922. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->