### PR TITLE
test: add unit tests for addDeclarativeCMP

### DIFF
--- a/tests-wtr/web/add-declarative-cmp.test.ts
+++ b/tests-wtr/web/add-declarative-cmp.test.ts
@@ -1,0 +1,133 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import AutoConsent from '../../lib/web';
+import { Config } from '../../lib/types';
+import { AutoConsentCMPRule } from '../../lib/rules';
+import AutoConsentCMP from '../../lib/cmps/base';
+
+/**
+ * Creates a minimal Config object for testing
+ */
+function createTestConfig(overrides: Partial<Config> = {}): Config {
+    return {
+        enabled: false,
+        autoAction: null,
+        disabledCmps: [],
+        enablePrehide: false,
+        enableCosmeticRules: true,
+        enableGeneratedRules: true,
+        detectRetries: 0,
+        isMainWorld: false,
+        prehideTimeout: 2000,
+        enableHeuristicDetection: false,
+        heuristicMode: 'off',
+        visualTest: false,
+        logs: {
+            lifecycle: false,
+            rulesteps: false,
+            detectionsteps: false,
+            evals: false,
+            errors: false,
+            messages: false,
+            waits: false,
+        },
+        ...overrides,
+    };
+}
+
+/**
+ * Creates a minimal declarative ruleset for testing
+ */
+function createTestRuleset(overrides: Partial<AutoConsentCMPRule> = {}): AutoConsentCMPRule {
+    return {
+        name: 'test-declarative-cmp',
+        detectCmp: [],
+        detectPopup: [],
+        optOut: [],
+        optIn: [],
+        ...overrides,
+    };
+}
+
+describe('AutoConsent.addDeclarativeCMP', () => {
+    let sendMessageStub: sinon.SinonStub;
+    let autoconsent: AutoConsent;
+
+    beforeEach(() => {
+        sendMessageStub = sinon.stub().resolves();
+        const config = createTestConfig();
+        autoconsent = new AutoConsent(sendMessageStub, config, null);
+        sendMessageStub.resetHistory();
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('should add a rule with no minimumRuleStepVersion (defaults to 1)', () => {
+        const rulesBefore = autoconsent.rules.length;
+        const ruleset = createTestRuleset();
+
+        autoconsent.addDeclarativeCMP(ruleset);
+
+        expect(autoconsent.rules.length).to.equal(rulesBefore + 1);
+    });
+
+    it('should add a rule whose minimumRuleStepVersion equals the supported version', () => {
+        const rulesBefore = autoconsent.rules.length;
+        const ruleset = createTestRuleset({ minimumRuleStepVersion: 2 });
+
+        autoconsent.addDeclarativeCMP(ruleset);
+
+        expect(autoconsent.rules.length).to.equal(rulesBefore + 1);
+    });
+
+    it('should add a rule whose minimumRuleStepVersion is below the supported version', () => {
+        const rulesBefore = autoconsent.rules.length;
+        const ruleset = createTestRuleset({ minimumRuleStepVersion: 1 });
+
+        autoconsent.addDeclarativeCMP(ruleset);
+
+        expect(autoconsent.rules.length).to.equal(rulesBefore + 1);
+    });
+
+    it('should NOT add a rule whose minimumRuleStepVersion exceeds the supported version', () => {
+        const rulesBefore = autoconsent.rules.length;
+        const ruleset = createTestRuleset({ minimumRuleStepVersion: 3 });
+
+        autoconsent.addDeclarativeCMP(ruleset);
+
+        expect(autoconsent.rules.length).to.equal(rulesBefore);
+    });
+
+    it('should add an AutoConsentCMP instance carrying the original rule name', () => {
+        const ruleset = createTestRuleset({ name: 'my-custom-cmp' });
+
+        autoconsent.addDeclarativeCMP(ruleset);
+
+        const added = autoconsent.rules.find((r) => r.name === 'my-custom-cmp');
+        expect(added).to.exist;
+        expect(added).to.be.instanceOf(AutoConsentCMP);
+    });
+
+    it('should use the default runContext when the rule does not specify one', () => {
+        const ruleset = createTestRuleset({ name: 'no-run-context-cmp' });
+
+        autoconsent.addDeclarativeCMP(ruleset);
+
+        const added = autoconsent.rules.find((r) => r.name === 'no-run-context-cmp');
+        expect(added?.runContext).to.deep.equal({ main: true, frame: false, urlPattern: '' });
+    });
+
+    it('should use the runContext provided by the rule when specified', () => {
+        const ruleset = createTestRuleset({
+            name: 'custom-run-context-cmp',
+            runContext: { main: false, frame: true, urlPattern: 'example.com' },
+        });
+
+        autoconsent.addDeclarativeCMP(ruleset);
+
+        const added = autoconsent.rules.find((r) => r.name === 'custom-run-context-cmp');
+        expect(added?.runContext).to.deep.equal({ main: false, frame: true, urlPattern: 'example.com' });
+    });
+});

--- a/tests-wtr/web/add-declarative-cmp.test.ts
+++ b/tests-wtr/web/add-declarative-cmp.test.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import AutoConsent from '../../lib/web';
 import { Config } from '../../lib/types';
 import { AutoConsentCMPRule } from '../../lib/rules';
-import AutoConsentCMP from '../../lib/cmps/base';
+import { AutoConsentCMP } from '../../lib/cmps/base';
 
 /**
  * Creates a minimal Config object for testing


### PR DESCRIPTION
Adds unit test coverage for `AutoConsent.addDeclarativeCMP`, following the pattern established in #1119 for `filterCMPs`.

Covers:
- Rules with no `minimumRuleStepVersion` default to version 1 and get added
- Rules at or below `SUPPORTED_RULE_STEP_VERSION` get added
- Rules above `SUPPORTED_RULE_STEP_VERSION` are correctly skipped
- Added rules are `AutoConsentCMP` instances carrying the correct name
- `runContext` defaults and explicit overrides are respected

Contributes to #589 (not a full fix, since that issue covers broader `web.ts` coverage).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no modifications to production code or runtime behavior.
> 
> **Overview**
> Adds a new WTR test file **`tests-wtr/web/add-declarative-cmp.test.ts`** that exercises **`AutoConsent.addDeclarativeCMP`**, mirroring the style of existing **`filterCMPs`** coverage.
> 
> The suite stubs **`sendMessage`** and builds minimal **`Config`** / **`AutoConsentCMPRule`** fixtures, then verifies that rules are **added** when **`minimumRuleStepVersion`** is missing (treated as 1), equals **`SUPPORTED_RULE_STEP_VERSION`**, or is lower, and **not added** when it exceeds the supported version. It also checks that accepted rules become **`AutoConsentCMP`** instances with the right **`name`**, and that **`runContext`** uses the default **`{ main: true, frame: false, urlPattern: '' }`** or the rule’s explicit override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c274419e8ad376e140440925619837d6db9eded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->