### PR TITLE
Rule update: scmp

### DIFF
--- a/rules/autoconsent/scmp.json
+++ b/rules/autoconsent/scmp.json
@@ -18,10 +18,49 @@
     ],
     "optIn": [
         {
+            "waitForVisible": ".fc-dialog-container",
+            "timeout": 4000,
+            "optional": true
+        },
+        {
+            "if": {
+                "visible": ".fc-dialog-container"
+            },
+            "then": [
+                {
+                    "click": ".fc-cta-consent"
+                }
+            ]
+        },
+        {
             "waitForThenClick": "[data-qa=\"GDPRBanner-Button\"]"
         }
     ],
     "optOut": [
+        {
+            "waitForVisible": ".fc-dialog-container",
+            "timeout": 4000,
+            "optional": true
+        },
+        {
+            "if": {
+                "visible": ".fc-dialog-container"
+            },
+            "then": [
+                {
+                    "click": ".fc-cta-do-not-consent,.fc-cta-manage-options"
+                },
+                {
+                    "click": ".fc-preference-consent:checked,.fc-preference-legitimate-interest:checked",
+                    "all": true,
+                    "optional": true
+                },
+                {
+                    "click": ".fc-confirm-choices",
+                    "optional": true
+                }
+            ]
+        },
         {
             "hide": "[data-qa=\"GDPRBanner-Container\"]"
         }

--- a/rules/autoconsent/scmp.json
+++ b/rules/autoconsent/scmp.json
@@ -18,13 +18,13 @@
     ],
     "optIn": [
         {
-            "waitForVisible": ".fc-dialog-container",
+            "waitForVisible": ".fc-consent-root .fc-dialog-container",
             "timeout": 4000,
             "optional": true
         },
         {
             "if": {
-                "visible": ".fc-dialog-container"
+                "visible": ".fc-consent-root .fc-dialog-container"
             },
             "then": [
                 {
@@ -38,13 +38,13 @@
     ],
     "optOut": [
         {
-            "waitForVisible": ".fc-dialog-container",
+            "waitForVisible": ".fc-consent-root .fc-dialog-container",
             "timeout": 4000,
             "optional": true
         },
         {
             "if": {
-                "visible": ".fc-dialog-container"
+                "visible": ".fc-consent-root .fc-dialog-container"
             },
             "then": [
                 {

--- a/rules/autoconsent/scmp.json
+++ b/rules/autoconsent/scmp.json
@@ -1,0 +1,29 @@
+{
+    "name": "scmp",
+    "vendorUrl": "https://www.scmp.com/",
+    "cosmetic": true,
+    "runContext": {
+        "urlPattern": "^https://(www\\.)?scmp\\.com/"
+    },
+    "prehideSelectors": ["[data-qa=\"GDPRBanner-Container\"]"],
+    "detectCmp": [
+        {
+            "exists": "[data-qa=\"GDPRBanner-Container\"] [data-qa=\"GDPRBanner-Button\"]"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "[data-qa=\"GDPRBanner-Container\"] [data-qa=\"GDPRBanner-Button\"]"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "[data-qa=\"GDPRBanner-Button\"]"
+        }
+    ],
+    "optOut": [
+        {
+            "hide": "[data-qa=\"GDPRBanner-Container\"]"
+        }
+    ]
+}

--- a/rules/autoconsent/scmp.json
+++ b/rules/autoconsent/scmp.json
@@ -19,7 +19,7 @@
     "optIn": [
         {
             "waitForVisible": ".fc-consent-root .fc-dialog-container",
-            "timeout": 4000,
+            "timeout": 1000,
             "optional": true
         },
         {

--- a/tests/scmp.spec.ts
+++ b/tests/scmp.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('scmp', [
+    'https://www.scmp.com/news/asia/east-asia/article/3362748/2-japan-quake-victims-ordered-back-aeon-mall-store-secure-cash',
+]);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217113353478050?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

No existing SCMP autoconsent exception or privacy-configuration PR was found. Added rules/autoconsent/scmp.json and tests/scmp.spec.ts. The SCMP accept-only cookie banner is now hidden for opt-out; GDPR-region Funding Choices modals are handled first. The visible blue AI search prompt remaining in screenshots is not a cookie/consent dialog.

## Steps to test this PR:

- `npx playwright test tests/scmp.spec.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New site-specific autoconsent JSON and test only; no changes to shared runner or consent engine behavior.
> 
> **Overview**
> Adds **autoconsent coverage for scmp.com** via a new cosmetic rule and matching Playwright spec.
> 
> The rule targets SCMP’s `[data-qa="GDPRBanner-Container"]` banner: **opt-in** clicks the banner button (after an optional Google Funding Choices accept), and **opt-out** dismisses Funding Choices when present then **hides** the GDPR banner instead of accepting. Detection and prehide use the same `data-qa` selectors on `^https://(www\.)?scmp\.com/`.
> 
> `tests/scmp.spec.ts` wires the rule into the shared `generateCMPTests` runner against one news article URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28f69bee2e91e13eb14ff444a60d7279dfce20e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->