### PR TITLE
Remove incorrect cosmetic flag from scmp rule

### DIFF
--- a/rules/autoconsent/scmp.json
+++ b/rules/autoconsent/scmp.json
@@ -1,7 +1,6 @@
 {
     "name": "scmp",
     "vendorUrl": "https://www.scmp.com/",
-    "cosmetic": true,
     "runContext": {
         "urlPattern": "^https://(www\\.)?scmp\\.com/"
     },


### PR DESCRIPTION
## What changed

Removes `"cosmetic": true` from the `scmp` rule.

## Why

The rule was flagged as cosmetic, but its `optOut` performs a **genuine opt-out** through the Google Funding Choices modal, not just CSS hiding:

1. Click `.fc-cta-do-not-consent,.fc-cta-manage-options` ("Manage options")
2. Uncheck all checked consent/legitimate-interest preferences (`all: true`)
3. Click `.fc-confirm-choices` ("Confirm choices")

This writes a real TCF/Funding Choices consent-rejection state. The trailing `hide` step is only a fallback for the reject-less `GDPRBanner` variant.

A cosmetic rule is defined ([docs/rule-syntax.md](docs/rule-syntax.md)) as one that *"does not interact with the page, and only hide[s] the cookie pop-ups with CSS... useful for pop-ups that do not provide a Reject button."* SCMP's Funding Choices modal does provide a reject path and the rule uses it, so the flag was incorrect.

The flag was also functionally harmful: cosmetic rules are gated behind `enableCosmeticRules` and only used as a last resort (`lib/web.ts`), which would suppress this genuine opt-out.

## Verification

- Verified the live Funding Choices modal on scmp.com exposes the reject path (Manage options → 161 preference toggles, 42 checked → Confirm choices).
- `npm run rule-syntax-check` + `npm run build-rules` — pass
- `npx playwright test tests/scmp.spec.ts` — opt-out and opt-in both pass; engine now reports `isCosmetic: false`, `optOutResult: true`, `totalClicks: 3`
- `npm run lint` — clean

## Reviewer note

Regional proxy credentials weren't available in my environment, so I could not run the full US/GB/DE cross-region proxy sweep — verification was done from a single (GDPR/Funding-Choices) region plus the E2E test. The reasoning holds across regions since the rule performs a real opt-out wherever the FC modal appears, but a cross-region screenshot pass before merge would be worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata flag change on one rule file; no runtime logic changes, only correct classification so the existing opt-out steps run in the normal CMP path.
> 
> **Overview**
> Removes **`cosmetic: true`** from the **`scmp`** autoconsent rule so SCMP is treated as a normal CMP, not a CSS-only hide rule.
> 
> The rule’s **`optOut`** path drives Google Funding Choices (manage options → clear consent toggles → confirm), which records a real rejection—not just hiding **`GDPRBanner`**. With the cosmetic flag, the engine could skip or defer this rule behind **`enableCosmeticRules`** and only try cosmetic CMPs after non-cosmetic ones (**`filterCMPs`** / popup handling in **`lib/web.ts`**), which wrongly suppressed a genuine opt-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95273a1f30e9dfd1125418cc8659ee20fa22a8d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->