### PR TITLE
Fix heuristic popup candidate pruning

### DIFF
--- a/lib/heuristics.ts
+++ b/lib/heuristics.ts
@@ -239,7 +239,8 @@ function getPopupLikeElements(timeout = POPUP_SEARCH_MAX_TIME): HTMLElement[] {
     for (let node = walker.nextNode(); node; node = walker.nextNode()) {
         found.push(node as HTMLElement);
     }
-    return excludeContainers(found);
+    // Empty positioned children should not displace a contentful popup container.
+    return excludeContainers(found.filter((element) => element.innerText?.trim()));
 }
 
 /**

--- a/tests-wtr/heuristics/get-actionable-popups.html
+++ b/tests-wtr/heuristics/get-actionable-popups.html
@@ -98,6 +98,21 @@
             <button>Accept All</button>
         </div>
 
+        <div id="popup-accept-with-empty-fixed-child" class="popup">
+            <p>We use cookies to improve your experience.</p>
+            <button>Accept All</button>
+            <div style="position: fixed"></div>
+        </div>
+
+        <div id="popup-with-contentful-fixed-child" class="popup">
+            <p>We use cookies to improve your experience.</p>
+            <button>Reject All</button>
+            <div id="contentful-fixed-child" style="position: fixed">
+                <p>We use cookies to improve your experience.</p>
+                <button>Accept All</button>
+            </div>
+        </div>
+
         <div id="popup-acknowledge-only" class="popup">
             <p>We use cookies to improve your experience.</p>
             <button>OK</button>

--- a/tests-wtr/heuristics/get-actionable-popups.ts
+++ b/tests-wtr/heuristics/get-actionable-popups.ts
@@ -71,6 +71,26 @@ describe('getActionablePopups', () => {
             expect(popups[0].buttons.filter((b) => b.regexClassification === 'accept')).to.have.length(1);
         });
 
+        it('keeps a contentful popup containing an empty fixed child', () => {
+            showPopup('popup-accept-with-empty-fixed-child');
+
+            const popups = getActionablePopups('tier2');
+
+            expect(popups).to.have.length(1);
+            expect(popups[0].element.id).to.equal('popup-accept-with-empty-fixed-child');
+            expect(popups[0].regexClassification).to.equal('tier2');
+        });
+
+        it('prefers a contentful fixed child over its contentful container', () => {
+            showPopup('popup-with-contentful-fixed-child');
+
+            const popups = getActionablePopups('tier2');
+
+            expect(popups).to.have.length(1);
+            expect(popups[0].element.id).to.equal('contentful-fixed-child');
+            expect(popups[0].regexClassification).to.equal('tier2');
+        });
+
         it('finds acknowledge-only popup with no reject buttons', () => {
             showPopup('popup-acknowledge-only');
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL:

## Description:

Prevent empty fixed or sticky descendants from displacing a contentful popup candidate during heuristic detection. This allows accept-only tier2 popups such as the US Bleacher Report modal to remain actionable while preserving innermost-candidate pruning for contentful nested popups and button deduplication.

Adds regression coverage for both empty and contentful nested fixed descendants.

## Steps to test this PR:

1. Run `npm run test:lib` (839 tests pass).
2. Run `npm run lint`.
3. Run `npm run prepublish`.
4. With the regional proxy test helper, visit the reported Bleacher Report liveblog using heuristic tier2 mode:
   - US: `HEURISTIC-TIER2`, popup found, action and self-test pass.
   - GB/DE: existing `Onetrust` rule passes.
5. Inspect final screenshots and confirm the popup is gone in all regions.
6. Repeat in a US iPhone-sized context; heuristic tier2 passes and the screenshot is clear.
7. Reload after US dismissal and confirm no new CMP detection occurs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9983fce-8ad1-40e8-a72c-136033048c20?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9983fce-8ad1-40e8-a72c-136033048c20&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

