### PR TITLE
Rule update: tohotheater-jp

### DIFF
--- a/rules/autoconsent/tohotheater-jp.json
+++ b/rules/autoconsent/tohotheater-jp.json
@@ -1,0 +1,20 @@
+{
+    "name": "tohotheater-jp",
+    "vendorUrl": "https://www.tohotheater.jp/",
+    "runContext": {
+        "urlPattern": "^https?://(?:[^/]+\\.)?tohotheater\\.jp/"
+    },
+    "prehideSelectors": [".optIn"],
+    "detectCmp": [{ "exists": ".optIn .js-optin-cookie-settings" }],
+    "detectPopup": [{ "visible": ".optIn" }],
+    "optIn": [{ "waitForThenClick": ".optIn .js-optin-accept-all-cookies" }],
+    "optOut": [
+        { "waitForThenClick": ".optIn .js-optin-cookie-settings" },
+        { "waitForThenClick": "label[for=\"TAB-02\"]" },
+        { "waitForThenClick": "label[for=\"TAB-02\"] + .tab-content .toggleSwitch__circle" },
+        { "waitForThenClick": "label[for=\"TAB-03\"]" },
+        { "waitForThenClick": "label[for=\"TAB-03\"] + .tab-content .toggleSwitch__circle" },
+        { "waitForThenClick": ".js-modal-save-settings" }
+    ],
+    "test": [{ "cookieContains": "__performanceCookieFlag__=0" }, { "cookieContains": "__targetingCookieFlag__=0" }]
+}

--- a/tests/tohotheater-jp.spec.ts
+++ b/tests/tohotheater-jp.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('tohotheater-jp', ['https://hlo.tohotheater.jp/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1216900868833434?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

No existing autoconsent exception was found in duckduckgo/privacy-configuration features/autoconsent.json or platform override autoconsent sections. Added a narrow site-specific rule for the custom TOHO Theater banner. PR creation was requested twice via the PR tool, but the environment requires user approval before creating it; compare URL is provided. Checks passed: npm run build-rules, npm run rule-syntax-check, focused Playwright spec, npm run lint, npm run prepublish. Regional validation covered core regions plus reported JP; behavior was consistent, so expanded regions were skipped under policy.

## Steps to test this PR:

- `npx playwright test tests/tohotheater-jp.spec.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated site-specific consent rule and test only; no changes to shared auth, data, or core autoconsent infrastructure.
> 
> **Overview**
> Adds a **site-specific autoconsent rule** for TOHO Theater Japan (`tohotheater.jp` and subdomains), covering their custom `.optIn` cookie banner.
> 
> **Opt-in** accepts all cookies via `.js-optin-accept-all-cookies`. **Opt-out** opens cookie settings, toggles off performance and targeting categories (TAB-02/TAB-03), and saves. Success is verified with cookies `__performanceCookieFlag__=0` and `__targetingCookieFlag__=0`.
> 
> A Playwright spec runs CMP tests against `https://hlo.tohotheater.jp/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ea4e52e4b7de325da349bb5c17df377763e6249. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->