### PR TITLE
Rule update: Cookie pop-up displayed: TOHO-ONE

### DIFF
--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -211,6 +211,9 @@ export const snippets = {
     EVAL_TEALIUM_2: () => utag.gdpr.setConsentValue(true) || true,
     EVAL_TEALIUM_3: () => utag.gdpr.getConsentState() !== 1,
     EVAL_TEALIUM_DONOTSELL_CHECK: () => utag.gdpr.dns?.getDnsState() !== 1,
+    EVAL_TOHO_ONE_TEST: () =>
+        localStorage.getItem('CookieOptInAccepted') === 'true' &&
+        ['true', 'false'].includes(localStorage.getItem('CookiePerformanceAccepted')),
     EVAL_TESTCMP_STEP: () => !!document.querySelector('#reject-all'),
     EVAL_TESTCMP_0: () => window.results.results[0] === 'button_clicked',
     EVAL_TESTCMP_COSMETIC_0: () => window.results.results[0] === 'banner_hidden',

--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -211,9 +211,6 @@ export const snippets = {
     EVAL_TEALIUM_2: () => utag.gdpr.setConsentValue(true) || true,
     EVAL_TEALIUM_3: () => utag.gdpr.getConsentState() !== 1,
     EVAL_TEALIUM_DONOTSELL_CHECK: () => utag.gdpr.dns?.getDnsState() !== 1,
-    EVAL_TOHO_ONE_TEST: () =>
-        localStorage.getItem('CookieOptInAccepted') === 'true' &&
-        ['true', 'false'].includes(localStorage.getItem('CookiePerformanceAccepted')),
     EVAL_TESTCMP_STEP: () => !!document.querySelector('#reject-all'),
     EVAL_TESTCMP_0: () => window.results.results[0] === 'button_clicked',
     EVAL_TESTCMP_COSMETIC_0: () => window.results.results[0] === 'banner_hidden',

--- a/rules/autoconsent/toho-one.json
+++ b/rules/autoconsent/toho-one.json
@@ -1,0 +1,46 @@
+{
+    "name": "toho-one.com",
+    "vendorUrl": "https://www.toho-one.com/",
+    "runContext": {
+        "urlPattern": "^https?://www\\.toho-one\\.com/"
+    },
+    "prehideSelectors": [".fixed.bottom-0:has(a[href=\"https://www.toho.co.jp/company/cookie-policy\"])"],
+    "detectCmp": [
+        {
+            "exists": "xpath///div[contains(@class, 'fixed') and contains(., 'Cookieをブロック') and .//button[normalize-space()='Cookieの設定']]"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "xpath///div[contains(@class, 'fixed') and contains(., 'Cookieをブロック') and .//button[normalize-space()='Cookieの設定']]"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "xpath///div[contains(@class, 'fixed') and contains(., 'Cookieをブロック')]//button[normalize-space()='すべてのCookieを受け入れる']"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "xpath///div[contains(@class, 'fixed') and contains(., 'Cookieをブロック')]//button[normalize-space()='Cookieの設定']"
+        },
+        {
+            "waitFor": "input[type=checkbox]:checked:not(:disabled)"
+        },
+        {
+            "click": "input[type=checkbox]:checked:not(:disabled)",
+            "all": true
+        },
+        {
+            "waitForThenClick": "xpath///button[normalize-space()='設定を保存する']"
+        }
+    ],
+    "test": [
+        {
+            "wait": 500
+        },
+        {
+            "eval": "EVAL_TOHO_ONE_TEST"
+        }
+    ]
+}

--- a/rules/autoconsent/toho-one.json
+++ b/rules/autoconsent/toho-one.json
@@ -4,7 +4,6 @@
     "runContext": {
         "urlPattern": "^https?://www\\.toho-one\\.com/"
     },
-    "prehideSelectors": [".fixed.bottom-0:has(a[href=\"https://www.toho.co.jp/company/cookie-policy\"])"],
     "detectCmp": [
         {
             "exists": "xpath///div[contains(@class, 'fixed') and contains(., 'Cookieをブロック') and .//button[normalize-space()='Cookieの設定']]"
@@ -37,10 +36,9 @@
     ],
     "test": [
         {
-            "wait": 500
-        },
-        {
-            "eval": "EVAL_TOHO_ONE_TEST"
+            "waitForVisible": "xpath///div[contains(@class, 'fixed') and contains(., 'Cookieをブロック') and .//button[normalize-space()='Cookieの設定']]",
+            "timeout": 1000,
+            "check": "none"
         }
     ]
 }

--- a/rules/autoconsent/toho-one.json
+++ b/rules/autoconsent/toho-one.json
@@ -24,10 +24,16 @@
             "waitForThenClick": "xpath///div[contains(@class, 'fixed') and contains(., 'Cookieをブロック')]//button[normalize-space()='Cookieの設定']"
         },
         {
-            "waitFor": "input[type=checkbox]:checked:not(:disabled)"
+            "waitFor": [
+                "xpath///div[contains(@class, 'fixed') and .//button[normalize-space()='設定を保存する']]",
+                "input[type=checkbox]:checked:not(:disabled)"
+            ]
         },
         {
-            "click": "input[type=checkbox]:checked:not(:disabled)",
+            "click": [
+                "xpath///div[contains(@class, 'fixed') and .//button[normalize-space()='設定を保存する']]",
+                "input[type=checkbox]:checked:not(:disabled)"
+            ],
             "all": true
         },
         {

--- a/tests/toho-one.spec.ts
+++ b/tests/toho-one.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('toho-one.com', ['https://www.toho-one.com/login']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1216900868967099?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive site-specific autoconsent rule and test only; no changes to shared consent logic or security-sensitive paths.
> 
> **Overview**
> Adds **autoconsent coverage for TOHO-ONE** (`toho-one.com`), targeting the Japanese cookie banner on `www.toho-one.com`.
> 
> The new rule in `rules/autoconsent/toho-one.json` scopes to that host, detects the fixed overlay with “Cookieをブロック” / “Cookieの設定”, **opt-in** via “すべてのCookieを受け入れる”, and **opt-out** by opening settings, clearing checked checkboxes in the settings panel, and saving with “設定を保存する”. A self-test waits for the banner with a short timeout.
> 
> `tests/toho-one.spec.ts` wires the standard `generateCMPTests` runner for `toho-one.com` against `https://www.toho-one.com/login`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0b808229956f836b2abb94957641c7dc1646684. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->