### PR TITLE
Rule update: Cookie popup on ctv.co.jp

### DIFF
--- a/rules/autoconsent/ctv-disneyonice.json
+++ b/rules/autoconsent/ctv-disneyonice.json
@@ -1,0 +1,9 @@
+{
+    "name": "ctv-disneyonice",
+    "urlPattern": "^https://www\\.ctv\\.co\\.jp/disneyonice(?:/|[?#]|$)",
+    "prehideSelectors": [".box-cookie"],
+    "detectCmp": [{ "exists": ".box-cookie .box-cookie__inner" }],
+    "detectPopup": [{ "visible": ".box-cookie .box-cookie__inner" }],
+    "optOut": [{ "waitForThenClick": ".box-cookie .btn-normal.is-small" }],
+    "test": [{ "cookieContains": "disney_cc=ok" }]
+}

--- a/rules/autoconsent/ctv-disneyonice.json
+++ b/rules/autoconsent/ctv-disneyonice.json
@@ -4,6 +4,7 @@
     "prehideSelectors": [".box-cookie"],
     "detectCmp": [{ "exists": ".box-cookie .box-cookie__inner" }],
     "detectPopup": [{ "visible": ".box-cookie .box-cookie__inner" }],
+    "optIn": [{ "waitForThenClick": ".box-cookie .btn-normal.is-small" }],
     "optOut": [{ "waitForThenClick": ".box-cookie .btn-normal.is-small" }],
     "test": [{ "cookieContains": "disney_cc=ok" }]
 }

--- a/rules/autoconsent/ctv-disneyonice.json
+++ b/rules/autoconsent/ctv-disneyonice.json
@@ -1,6 +1,8 @@
 {
     "name": "ctv-disneyonice",
-    "urlPattern": "^https://www\\.ctv\\.co\\.jp/disneyonice(?:/|[?#]|$)",
+    "runContext": {
+        "urlPattern": "^https://www\\.ctv\\.co\\.jp/disneyonice(?:/|[?#]|$)"
+    },
     "prehideSelectors": [".box-cookie"],
     "detectCmp": [{ "exists": ".box-cookie .box-cookie__inner" }],
     "detectPopup": [{ "visible": ".box-cookie .box-cookie__inner" }],

--- a/tests/ctv-disneyonice.spec.ts
+++ b/tests/ctv-disneyonice.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('ctv-disneyonice', ['https://www.ctv.co.jp/disneyonice/'], {
+    testOptIn: false,
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217096753158477?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated new autoconsent rule and test only; no changes to shared consent infrastructure or security-sensitive paths.
> 
> **Overview**
> Adds autoconsent coverage for the **Disney on Ice** cookie banner on `https://www.ctv.co.jp/disneyonice/`.
> 
> The new rule `ctv-disneyonice` scopes via URL pattern, pre-hides `.box-cookie`, detects the popup with `.box-cookie .box-cookie__inner`, and dismisses it by clicking `.box-cookie .btn-normal.is-small` for both opt-in and opt-out. Success is verified with cookie `disney_cc=ok`.
> 
> A Playwright spec runs CMP tests against that URL with `testOptIn: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 756a2d87603dea85ce84293cbaac575457419ee6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->