### PR TITLE
Coverage data update

### DIFF
--- a/data/coverage.json
+++ b/data/coverage.json
@@ -1,11 +1,12 @@
 {
   "Admiral": {
     "DE": {
-      "sites": 2,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://www.dexerto.com/",
+        "http://www.dict.cc/",
         "http://www.golfpost.de/"
       ],
       "failingSites": [],
@@ -13,30 +14,30 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 24,
+      "sites": 19,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.nationalclubgolfer.com/",
-        "http://www.queerty.com/",
-        "http://millwallonline.com/",
-        "http://www.golfpost.com/",
-        "http://www.celticquicknews.co.uk/"
+        "http://forums.bluemoon-mcfc.co.uk/",
+        "http://www.lexusownersclub.co.uk/",
+        "http://www.comingsoon.net/",
+        "http://www.toyotaownersclub.com/",
+        "http://www.grandoldteam.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 21,
+      "sites": 9,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.realclearpolling.com/",
-        "http://cyclinguptodate.com/",
-        "http://www.dexerto.com/",
-        "http://finviz.com/",
-        "http://www.lgbtqnation.com/"
+        "http://www.crosswalk.com/",
+        "http://www.christianity.com/",
+        "http://redstate.com/",
+        "http://townhall.com/",
+        "http://twitchy.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -70,15 +71,15 @@
   },
   "Complianz banner": {
     "DE": {
-      "sites": 51,
+      "sites": 52,
       "errors": 0,
       "selfTestFailures": 2,
       "exampleSites": [
-        "http://www.elterngeld.de/",
-        "http://fritzboxes.de/",
-        "http://www.googlewatchblog.de/",
-        "http://smartvorlagen.de/",
-        "http://westfalia-mobil.com/"
+        "http://esut.de/",
+        "http://wlan.net/",
+        "http://addis-techblog.de/",
+        "http://www.simon42.com/",
+        "http://magazin-metamorphosen.de/"
       ],
       "failingSites": [
         "http://greece-moments.com/",
@@ -88,20 +89,19 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 35,
+      "sites": 29,
       "errors": 0,
-      "selfTestFailures": 5,
+      "selfTestFailures": 4,
       "exampleSites": [
-        "http://svr.co.uk/",
-        "http://www.britishathletics.org.uk/",
-        "http://hampsonauctions.com/",
+        "http://kynren.com/",
         "http://www.ypc.co.uk/",
-        "http://gloriousgarden.co.uk/"
+        "http://www.royalwolverhampton.nhs.uk/",
+        "http://sailboatdata.com/",
+        "http://mcscertified.com/"
       ],
       "failingSites": [
         "http://www.bedfordshirehospitals.nhs.uk/",
-        "http://www.buckshealthcare.nhs.uk/",
-        "http://www.diamondleague.com/",
+        "http://www.mkuh.nhs.uk/",
         "http://www.splitmyfare.co.uk/",
         "http://www.thedecoratorsforum.com/"
       ],
@@ -109,15 +109,15 @@
       "errorSites": []
     },
     "US": {
-      "sites": 16,
+      "sites": 13,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://amsterdamexperiences.nl/",
         "http://blackcitadelrpg.com/",
-        "http://castatefair.com/",
         "http://www.gun-tests.com/",
-        "http://localaccidentreports.com/",
-        "http://www.brinkleyrv.com/"
+        "http://www.mvd.newmexico.gov/",
+        "http://www.thestranger.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -126,12 +126,11 @@
   },
   "Complianz categories": {
     "DE": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.aussenrollo.de/",
-        "http://www.taxi.de/"
+        "http://www.aussenrollo.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -140,45 +139,47 @@
   },
   "Complianz notice": {
     "DE": {
-      "sites": 28,
+      "sites": 29,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://bondagevalley.cc/",
-        "http://www.czech-tourist.de/",
+        "http://justiz.de/",
+        "http://www.hno-aerzte-im-netz.de/",
+        "http://silo.tips/",
         "http://www.tuxedocomputers.com/",
-        "http://gg.deals/",
-        "http://www.cheatengine.org/"
+        "http://gg.deals/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 24,
+      "sites": 29,
       "errors": 0,
-      "selfTestFailures": 0,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://top.product-expert.co.uk/",
-        "http://www.thelightingsuperstore.co.uk/",
-        "http://www.onlytease.com/",
-        "http://youtubemp3free.com/",
-        "http://www.gaydemon.com/"
+        "http://uquiz.com/",
+        "http://www.hastings.gov.uk/",
+        "http://www.tapatalk.com/",
+        "http://www.gaydemon.com/",
+        "http://gg.deals/"
       ],
-      "failingSites": [],
+      "failingSites": [
+        "http://bonsoiroflondon.com/"
+      ],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 31,
+      "sites": 29,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.thelightphone.com/",
-        "http://bondagevalley.cc/",
+        "http://www.prairiemoon.com/",
+        "http://login.voya.com/",
         "http://www.ou.edu/",
-        "http://youtubemp3free.com/",
-        "http://www.adn.com/"
+        "http://www.bobswatches.com/",
+        "http://help.etsy.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -187,28 +188,26 @@
   },
   "Complianz opt-out": {
     "DE": {
-      "sites": 14,
+      "sites": 13,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.patienteninfo-service.de/",
+        "http://trauer.ovb-online.de/",
         "http://edelstahl24.com/",
-        "http://woom.com/",
-        "http://www.kas.de/",
-        "http://supplementinspektor.de/"
+        "http://www.museum.de/",
+        "http://www.dtv.de/",
+        "http://woom.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 3,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://hotwifecaps.com/",
-        "http://www.abbywinters.com/",
-        "http://www.bearingboys.co.uk/"
+        "http://www.abbywinters.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -219,30 +218,28 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.everbank.com/",
-        "http://www.abbywinters.com/",
-        "http://www.finra.org/",
-        "http://www.topendsports.com/",
-        "http://www.tiaa.org/"
+        "http://www.michaels.com/",
+        "http://www.deltafaucet.com/",
+        "http://brokercheck.finra.org/",
+        "http://www.academy.com/",
+        "http://www.komu.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.michaels.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "Complianz optin": {
     "DE": {
-      "sites": 29,
+      "sites": 30,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://aktienfinder.net/",
-        "http://mediendienst-integration.de/",
         "http://www.kvbawue.de/",
-        "http://www.frankfurt-tipp.de/",
-        "http://www.bautzen.de/"
+        "http://www.svb.de/",
+        "http://www.hertz.de/",
+        "http://www.kvb.koeln/",
+        "http://www.lfl.bayern.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
@@ -252,14 +249,14 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 17,
+      "sites": 14,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.hertz.co.uk/",
-        "http://www.royalfree.nhs.uk/",
-        "http://www.3m.co.uk/",
-        "http://www.surreycc.gov.uk/",
+        "http://www.modelsport.co.uk/",
+        "http://www.roku.com/",
+        "http://www.united.com/",
+        "http://www.nationalgrid.com/",
         "http://www.rnoh.nhs.uk/"
       ],
       "failingSites": [],
@@ -285,29 +282,29 @@
   },
   "Cookie Information Banner": {
     "DE": {
-      "sites": 6,
+      "sites": 7,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://consumer.huawei.com/",
+        "http://www.makita.de/",
+        "http://skylum.com/",
         "http://www.colorline.de/",
-        "http://www.visitdenmark.de/",
-        "http://www.hifiklubben.de/",
-        "http://www.makita.de/"
+        "http://www.danfoss.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 6,
+      "sites": 7,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://consumer.huawei.com/",
+        "http://skylum.com/",
         "http://www.cashconverters.co.uk/",
-        "http://www.makitauk.com/",
-        "http://www.westbrookcycles.co.uk/",
+        "http://www.wealthify.com/",
         "http://www.sinful.co.uk/"
       ],
       "failingSites": [],
@@ -317,60 +314,64 @@
   },
   "Cybotcookiebot": {
     "DE": {
-      "sites": 385,
+      "sites": 394,
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://csd-berlin.de/",
-        "http://www.kunstpark-shop.de/",
-        "http://www.kuenstlersozialkasse.de/",
-        "http://www.fronius.com/",
-        "http://www.smartsteuer.de/"
+        "http://deine-massanfertigung.de/",
+        "http://www.sbroker.de/",
+        "http://www.azlyrics.com/",
+        "http://www.edersee.com/",
+        "http://www.schwarzwald-tourismus.info/"
       ],
       "failingSites": [
-        "http://www.bonobology.com/"
+        "http://wero-wallet.eu/"
       ],
       "unsuccessfulSites": [
+        "http://teamspeak.com/",
         "http://www.apotheke-adhoc.de/",
         "http://www.bingenheimersaatgut.de/",
-        "http://www.jamesedition.com/"
+        "http://www.bsag.de/",
+        "http://www.vbn.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 389,
+      "sites": 392,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.icaew.com/",
-        "http://www.wymetro.com/",
-        "http://viovet.co.uk/",
-        "http://www.kenhub.com/",
-        "http://www.seascanner.co.uk/"
+        "http://exeter-airport.co.uk/",
+        "http://www.newlook.com/",
+        "http://www.londonmuseum.org.uk/",
+        "http://www.vivobarefoot.com/",
+        "http://www.bournemouthairport.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.victorianplumbing.co.uk/",
         "http://victorianplumbing.co.uk/",
-        "http://www.bax-shop.co.uk/",
+        "http://www.victorianplumbing.co.uk/",
+        "http://www.chefandbrewer.com/",
         "http://www.ucas.com/",
-        "http://www.greenekinginns.co.uk/"
+        "http://www.hungryhorse.co.uk/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 100,
+      "sites": 99,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.bisecthosting.com/",
-        "http://www.bonobology.com/",
-        "http://www.parkinson.org/",
-        "http://www.sram.com/",
-        "http://www.runnings.com/"
+        "http://eero.com/",
+        "http://www.wordonfire.org/",
+        "http://www.ruralking.com/",
+        "http://www.rheem.com/",
+        "http://ocfair.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [],
+      "unsuccessfulSites": [
+        "http://www.thingiverse.com/"
+      ],
       "errorSites": []
     }
   },
@@ -390,15 +391,15 @@
   },
   "EZoic": {
     "DE": {
-      "sites": 30,
+      "sites": 35,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.slingacademy.com/",
-        "http://www.metric-conversions.org/",
-        "http://colony-guide.de/",
-        "http://de.manuals.plus/",
-        "http://emojis.wiki/"
+        "http://abfall-info.de/",
+        "http://inside-sim.de/",
+        "http://tastenkombination.info/",
+        "http://kuechegemacht.de/",
+        "http://imagecolorpicker.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
@@ -409,15 +410,15 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 62,
+      "sites": 66,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.kyivpost.com/",
-        "http://computingforgeeks.com/",
-        "http://celebsindepth.com/",
-        "http://www.diydoctor.org.uk/",
-        "http://woodworkingadvisor.com/"
+        "http://airfryfoods.com/",
+        "http://www.homeessentialsguide.com/",
+        "http://www.dealdrop.com/",
+        "http://carelearning.org.uk/",
+        "http://www.metric-conversions.org/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
@@ -434,24 +435,26 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://de.norton.com/",
-        "http://www.ffb.de/",
+        "http://www.wyndhamhotels.com/",
         "http://rs-online.com/",
-        "http://www.audi.com/",
-        "http://www.avast.com/"
+        "http://www.ccleaner.com/",
+        "http://www.avira.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [],
+      "unsuccessfulSites": [
+        "http://www.avira.com/"
+      ],
       "errorSites": []
     },
     "GB": {
-      "sites": 22,
+      "sites": 24,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.tescoinsurance.com/",
-        "http://identity.tescobank.com/",
-        "http://www.bhphotovideo.com/",
-        "http://rswww.com/",
+        "http://www.rac.co.uk/",
+        "http://www.postoffice.co.uk/",
+        "http://www.avg.com/",
+        "http://www.experian.co.uk/",
         "http://travelodge.co.uk/"
       ],
       "failingSites": [],
@@ -463,10 +466,10 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.sherwin-williams.com/",
-        "http://us.norton.com/",
         "http://www.worldmarket.com/",
-        "http://www.avast.com/",
+        "http://us.norton.com/",
+        "http://www.virginatlantic.com/",
+        "http://www.sherwin-williams.com/",
         "http://www.ccleaner.com/"
       ],
       "failingSites": [],
@@ -486,37 +489,37 @@
       "exampleSites": [
         "http://devforum.roblox.com/",
         "http://www.canon.de/",
-        "http://www.mcafee.com/"
+        "http://www.thefork.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 6,
+      "sites": 7,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://devforum.roblox.com/",
+        "http://www.thefork.com/",
         "http://www.calor.co.uk/",
         "http://www.canon.co.uk/",
         "http://www.computershare.com/",
-        "http://www.thefork.co.uk/"
+        "http://www.depositprotection.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 6,
+      "sites": 7,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://globalnews.ca/",
+        "http://devforum.roblox.com/",
+        "http://www.computershare.com/",
         "http://login.computershare.com/",
         "http://support.lenovo.com/",
-        "http://www.motorola.com/",
-        "http://www.computershare.com/"
+        "http://www.amwater.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -525,69 +528,71 @@
   },
   "HEURISTIC-REJECT": {
     "DE": {
-      "sites": 723,
+      "sites": 737,
       "errors": 1,
-      "selfTestFailures": 65,
+      "selfTestFailures": 69,
       "exampleSites": [
-        "http://comicvine.gamespot.com/",
-        "http://www.trost-und-andacht.de/",
-        "http://deutsches-schulportal.de/",
-        "http://www.roller.de/",
-        "http://projekte-leicht-gemacht.de/"
+        "http://www.rheinhessen-sparkasse.de/",
+        "http://www.sskduesseldorf.de/",
+        "http://supabase.com/",
+        "http://www.teleskop-express.de/",
+        "http://nordvpn.com/"
       ],
       "failingSites": [
-        "http://www.nachhaltiges-zuhause.de/",
-        "http://www.shmf.de/",
-        "http://www.ukbonn.de/",
-        "http://vevor.de/",
-        "http://www.bonobology.com/"
+        "http://www.dorotheum.com/",
+        "http://www.kraeuterhaus.de/",
+        "http://www.breitbandmessung.de/",
+        "http://www.deutsches-museum.de/",
+        "http://www.lbv.de/"
       ],
       "unsuccessfulSites": [
-        "http://app.temu.com/",
-        "http://www.temu.com/"
+        "http://www.stradivarius.com/"
       ],
       "errorSites": [
         "http://ya.ru/"
       ]
     },
     "GB": {
-      "sites": 443,
+      "sites": 464,
       "errors": 0,
-      "selfTestFailures": 47,
+      "selfTestFailures": 42,
       "exampleSites": [
-        "http://sellercentral.amazon.co.uk/",
-        "http://www.sunderland.gov.uk/",
-        "http://www.westsussex.gov.uk/",
-        "http://www.image-line.com/",
-        "http://nordpass.com/"
+        "http://www.titantravel.co.uk/",
+        "http://www.orkney.com/",
+        "http://www.roanyer.com/",
+        "http://www.klm.com/",
+        "http://www.investcentre.co.uk/"
       ],
       "failingSites": [
-        "http://www.elsevier.com/",
-        "http://www.methodist.org.uk/",
-        "http://www.lpsg.com/",
-        "http://www.audacityteam.org/",
-        "http://www.toffeeweb.com/"
+        "http://www.quilter.com/",
+        "http://www.easternwestern.co.uk/",
+        "http://www.vintagestory.at/",
+        "http://www.jlpjobs.com/",
+        "http://www.rarewaves.com/"
       ],
-      "unsuccessfulSites": [],
+      "unsuccessfulSites": [
+        "http://www.cbinsights.com/",
+        "http://www.temu.com/"
+      ],
       "errorSites": []
     },
     "US": {
-      "sites": 150,
+      "sites": 146,
       "errors": 0,
-      "selfTestFailures": 22,
+      "selfTestFailures": 15,
       "exampleSites": [
-        "http://www.beamng.com/",
-        "http://www.emoryhealthcare.org/",
-        "http://www.medifind.com/",
-        "http://secure.ally.com/",
-        "http://www.brightspeed.com/"
+        "http://www.infinitecampus.com/",
+        "http://www.playvids.com/",
+        "http://www.frndlytv.com/",
+        "http://fleshbot.com/",
+        "http://www.patriots.com/"
       ],
       "failingSites": [
-        "http://www.ambetterhealth.com/",
-        "http://www.raymondjames.com/",
-        "http://www.livingspaces.com/",
-        "http://www.eyemed.com/",
-        "http://www.airport.guide/"
+        "http://learn.ligonier.org/",
+        "http://www.lpsg.com/",
+        "http://www.vintagestory.at/",
+        "http://www.lemonade.com/",
+        "http://www.audacityteam.org/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
@@ -595,64 +600,64 @@
   },
   "HEURISTIC-TIER1": {
     "DE": {
-      "sites": 67,
+      "sites": 66,
       "errors": 0,
-      "selfTestFailures": 5,
+      "selfTestFailures": 10,
       "exampleSites": [
-        "http://openwrt.org/",
-        "http://www.bilibili.tv/",
-        "http://www.model-kartei.de/",
-        "http://www.4kdownload.com/",
-        "http://www.eporner.com/"
+        "http://ancient-trance.de/",
+        "http://www.youramateurporn.com/",
+        "http://ww3.cad.de/",
+        "http://privacysavvy.com/",
+        "http://www.kultweet.de/"
       ],
       "failingSites": [
+        "http://www.tourdepologne.pl/",
         "http://dubisthalle.de/",
-        "http://lecker-rezepte.com/",
+        "http://enjoyhotels.com/",
         "http://ww3.cad.de/",
-        "http://www.bsi.bund.de/",
-        "http://www.eva-herman.net/"
+        "http://lecker-rezepte.com/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 85,
+      "sites": 89,
       "errors": 0,
-      "selfTestFailures": 22,
+      "selfTestFailures": 20,
       "exampleSites": [
-        "http://www.agoda.com/",
-        "http://about.me/",
-        "http://www.4kdownload.com/",
-        "http://www.williamgee.co.uk/",
-        "http://choosewhere.com/"
+        "http://trends.google.com/",
+        "http://uk.empirescort.com/",
+        "http://diy-kitchens.com/",
+        "http://www.symbolab.com/",
+        "http://www.cinemaparadiso.co.uk/"
       ],
       "failingSites": [
-        "http://www.traffic.gov.scot/",
-        "http://choosewhere.com/",
-        "http://lesboqueens.com/",
-        "http://nethouseprices.com/",
-        "http://modporn.com/"
+        "http://www.gloshospitals.nhs.uk/",
+        "http://citymaps.uk/",
+        "http://www.nakedwanderings.com/",
+        "http://www.broadbandspeedtest.org.uk/",
+        "http://www.vintag.es/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 107,
+      "sites": 106,
       "errors": 0,
-      "selfTestFailures": 16,
+      "selfTestFailures": 17,
       "exampleSites": [
-        "http://www.curseforge.com/",
+        "http://vxxx.com/",
+        "http://www.floridablue.com/",
+        "http://xhamster19.com/",
         "http://www.manufacturedhomes.com/",
-        "http://www.baptistjax.com/",
-        "http://ge.xhamster.desi/",
-        "http://www.bible.com/"
+        "http://ge.xhamster.desi/"
       ],
       "failingSites": [
-        "http://www.spydialer.com/",
-        "http://modporn.com/",
-        "http://www.nakedwanderings.com/",
-        "http://www.rit.edu/",
-        "http://www.acog.org/"
+        "http://www.laweekly.com/",
+        "http://www.skyward.com/",
+        "http://www.manufacturedhomes.com/",
+        "http://www.adam4adam.com/",
+        "http://www.blueletterbible.org/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
@@ -660,22 +665,22 @@
   },
   "HEURISTIC-TIER2": {
     "DE": {
-      "sites": 113,
+      "sites": 112,
       "errors": 0,
-      "selfTestFailures": 23,
+      "selfTestFailures": 22,
       "exampleSites": [
-        "http://www.bbc.com/",
-        "http://radiopaedia.org/",
-        "http://tx-board.de/",
-        "http://garvillo.com/",
-        "http://www.tomtom.com/"
+        "http://ec.europa.eu/",
+        "http://de.iban.com/",
+        "http://onlybestporn.com/",
+        "http://spicymature.com/",
+        "http://www.ladies.de/"
       ],
       "failingSites": [
-        "http://updf.com/",
+        "http://www.royalenfield.com/",
         "http://bistummainz.de/",
-        "http://www.heimat-info.de/",
-        "http://www.tomtom.com/",
-        "http://www.vaticannews.va/"
+        "http://docs.fortinet.com/",
+        "http://updf.com/",
+        "http://pureinfotech.com/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
@@ -683,41 +688,41 @@
     "GB": {
       "sites": 112,
       "errors": 0,
-      "selfTestFailures": 23,
+      "selfTestFailures": 22,
       "exampleSites": [
-        "http://www.weather2travel.com/",
-        "http://wellporn.com/",
-        "http://www.nottinghamshire.gov.uk/",
-        "http://jerkmate.com/",
-        "http://www.mrskin.com/"
+        "http://www.accu.co.uk/",
+        "http://novaramedia.com/",
+        "http://www.tripp.co.uk/",
+        "http://www.your-move.co.uk/",
+        "http://www.resolver.co.uk/"
       ],
       "failingSites": [
-        "http://www.hriuk.org/",
-        "http://www.villaplus.com/",
         "http://www.your-move.co.uk/",
-        "http://www.publicrecordsearch.co.uk/",
-        "http://ostechnix.com/"
+        "http://www.onlypedia.net/",
+        "http://www.balfesbikes.co.uk/",
+        "http://www.bankofengland.co.uk/",
+        "http://teamcycles.com/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 103,
+      "sites": 101,
       "errors": 0,
-      "selfTestFailures": 19,
+      "selfTestFailures": 22,
       "exampleSites": [
-        "http://savagearms.com/",
-        "http://www.playerauctions.com/",
-        "http://www.dunhamssports.com/",
-        "http://www.history.com/",
-        "http://www.hbo.com/"
+        "http://nuwber.com/",
+        "http://www.swinglifestyle.com/",
+        "http://docs.fortinet.com/",
+        "http://www.discoveryplus.com/",
+        "http://www.dunhamssports.com/"
       ],
       "failingSites": [
+        "http://pornworksai.com/",
+        "http://bigbrothernetwork.com/",
         "http://www.vaticannews.va/",
-        "http://www.dochub.com/",
-        "http://heartyhomecook.com/",
-        "http://weedmaps.com/",
-        "http://www.a2gov.org/"
+        "http://login.regions.com/",
+        "http://www.swinglifestyle.com/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
@@ -725,38 +730,38 @@
   },
   "Klaro": {
     "DE": {
-      "sites": 69,
+      "sites": 66,
       "errors": 0,
-      "selfTestFailures": 4,
+      "selfTestFailures": 3,
       "exampleSites": [
-        "http://www.sovd-sh.de/",
-        "http://www.aidshilfe.de/",
-        "http://www.uni-frankfurt.de/",
-        "http://www.gls.de/",
-        "http://web1.karlsruhe.de/"
+        "http://wogibtswas.de/",
+        "http://forum.iobroker.net/",
+        "http://www.zug-ticket-kaufen.de/",
+        "http://www.nordart.de/",
+        "http://www.gartentraum.de/"
       ],
       "failingSites": [
         "http://wogibtswas.de/",
         "http://www.avery-zweckform.com/",
-        "http://www.cducsu.de/",
         "http://www.selgros.de/"
       ],
       "unsuccessfulSites": [
         "http://www.audio-markt.de/",
+        "http://www.eintracht.de/",
         "http://www.oberberg-aktuell.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 12,
+      "sites": 16,
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
         "http://opencourtdata.uk/",
-        "http://www.dundee.ac.uk/",
-        "http://www.dudley.gov.uk/",
-        "http://www.avery.co.uk/",
-        "http://www.merton.gov.uk/"
+        "http://www.unicef.org/",
+        "http://www.merton.gov.uk/",
+        "http://www.brighton-hove.gov.uk/",
+        "http://www.ukcolumn.org/"
       ],
       "failingSites": [
         "http://www.avery.co.uk/"
@@ -767,10 +772,11 @@
       "errorSites": []
     },
     "US": {
-      "sites": 1,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://poets.org/",
         "http://ucanr.edu/"
       ],
       "failingSites": [],
@@ -780,12 +786,11 @@
   },
   "Moove": {
     "DE": {
-      "sites": 5,
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://cafe-merlin.de/",
-        "http://kulturnews.de/",
+        "http://medicoconsult.de/",
         "http://spiegel-der-gesundheit.de/",
         "http://tutorialforlinux.com/",
         "http://www.top-10-liste.de/"
@@ -799,10 +804,10 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://tutorialforlinux.com/",
+        "http://basc.org.uk/",
         "http://hoa.org.uk/",
         "http://osmouk.com/",
-        "http://skygarden.london/",
+        "http://www.whitbread.co.uk/",
         "http://the-ear.net/"
       ],
       "failingSites": [],
@@ -810,61 +815,64 @@
       "errorSites": []
     },
     "US": {
-      "sites": 5,
+      "sites": 6,
       "errors": 0,
-      "selfTestFailures": 0,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://applemagazine.com/"
+        "http://applemagazine.com/",
+        "http://sustainablykindliving.com/",
+        "http://www.globalcitizensolutions.com/",
+        "http://www.parentsquare.com/"
       ],
-      "failingSites": [],
+      "failingSites": [
+        "http://www.globalcitizensolutions.com/"
+      ],
       "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "Onetrust": {
     "DE": {
-      "sites": 599,
-      "errors": 1,
+      "sites": 610,
+      "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.polestar.com/",
-        "http://www.mapquest.com/",
-        "http://www.oralb.de/",
-        "http://www.klarna.com/",
-        "http://www.pullandbear.com/"
+        "http://www.allrecipes.com/",
+        "http://www.rohde-schwarz.com/",
+        "http://www.grohe.com/",
+        "http://www.thieme-connect.de/",
+        "http://ethz.ch/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
         "http://blackroll.com/",
-        "http://www.myswitzerland.com/",
-        "http://kahoot.com/",
-        "http://www.sbb.ch/",
-        "http://wikitravel.org/"
+        "http://elektroshopwagner.de/",
+        "http://gamma.app/",
+        "http://www.espn.com/",
+        "http://www.campingwagner.de/"
       ],
-      "errorSites": [
-        "http://www.medicalnewstoday.com/"
-      ]
+      "errorSites": []
     },
     "GB": {
-      "sites": 1223,
+      "sites": 1195,
       "errors": 2,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.staysure.co.uk/",
-        "http://www.theaa.com/",
-        "http://www.parents.com/",
-        "http://www.espn.com/",
-        "http://collections.vam.ac.uk/"
+        "http://sainsburys.jobs/",
+        "http://www.statista.com/",
+        "http://healthservicediscounts.com/",
+        "http://www.urbanoutfitters.com/",
+        "http://www.bennetts.co.uk/"
       ],
       "failingSites": [
         "http://www.healthline.com/"
       ],
       "unsuccessfulSites": [
-        "http://sudoku.com/",
-        "http://www.coingecko.com/",
+        "http://goldsmiths.co.uk/",
         "http://www.pprune.org/",
-        "http://www.fifa.com/",
-        "http://www.nspcc.org.uk/"
+        "http://sudoku.com/",
+        "http://www.espn.co.uk/",
+        "http://www.goldsmiths.co.uk/"
       ],
       "errorSites": [
         "http://www.healthline.com/",
@@ -872,37 +880,38 @@
       ]
     },
     "US": {
-      "sites": 651,
+      "sites": 683,
       "errors": 0,
-      "selfTestFailures": 1,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.bmwusa.com/",
-        "http://www.budget.com/",
-        "http://www.crunchyroll.com/",
-        "http://www.flashscore.com/",
-        "http://www.phonak.com/"
+        "http://www.dallascowboys.com/",
+        "http://coinmarketcap.com/",
+        "http://support.southwest.com/",
+        "http://www.seahawks.com/",
+        "http://www.johnnyseeds.com/"
       ],
-      "failingSites": [
-        "http://www.seikowatches.com/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [
+        "http://www.ups.com/",
+        "http://www.bmwusa.com/",
         "http://www.silversea.com/",
-        "http://www.pillsbury.com/",
         "http://www.ynab.com/",
-        "http://www.trustpilot.com/",
-        "http://www.centurylink.com/"
+        "http://www.bettycrocker.com/"
       ],
       "errorSites": []
     }
   },
   "PrimeBox CookieBar": {
     "DE": {
-      "sites": 2,
+      "sites": 6,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://en.luxuretv.com/",
         "http://odir.org/",
-        "http://www.buchfreund.de/"
+        "http://www.weimar.de/",
+        "http://www.buchfreund.de/",
+        "http://www.hautschutzengel.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -913,11 +922,23 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://www.rctcbc.gov.uk/",
+        "http://map.projectzomboid.com/",
         "http://www.homipi.co.uk/",
-        "http://radioreferenceuk.co.uk/",
         "http://whoiscallingyou.co.uk/",
-        "http://www.calendar-uk.co.uk/",
-        "http://www.courtserve.net/"
+        "http://www.northlanarkshire.gov.uk/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 2,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://map.projectzomboid.com/",
+        "http://www.lockheedmartin.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -930,9 +951,9 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.lohi.de/",
+        "http://kotaku.com/",
+        "http://upway.de/",
         "http://www.dafont.com/",
-        "http://www.goldgoblin.net/",
         "http://www.infobel.com/",
         "http://www.kalenderkostenlos.de/"
       ],
@@ -941,14 +962,14 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 8,
+      "sites": 6,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://all.rugby/",
         "http://kotaku.com/",
-        "http://www.ibtimes.co.uk/",
         "http://www.dafont.com/",
+        "http://www.fsolver.com/",
+        "http://www.techtimes.com/",
         "http://www.ipsos.com/"
       ],
       "failingSites": [],
@@ -970,95 +991,95 @@
   },
   "Sourcepoint-frame": {
     "DE": {
-      "sites": 400,
+      "sites": 423,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.ehorses.de/",
-        "http://satisfactory.wiki.gg/",
-        "http://www.bisafans.de/",
-        "http://www.economist.com/",
-        "http://www.zerogpt.com/"
+        "http://calamitymod.wiki.gg/",
+        "http://www.meinestadt.de/",
+        "http://trauer.sueddeutsche.de/",
+        "http://www.finanzen.ch/",
+        "http://www.lebensfreunde.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.golem.de/",
-        "http://www.1000ps.de/",
-        "http://www.bergfex.at/",
-        "http://www.faz.net/",
-        "http://www.zinsen-berechnen.de/"
+        "http://www.redensarten-index.de/",
+        "http://www.rheinische-anzeigenblaetter.de/",
+        "http://www.rechner.club/",
+        "http://www.rundschau-online.de/",
+        "http://www.haustec.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 286,
+      "sites": 280,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://onlineradiobox.com/",
-        "http://www.pbo.co.uk/",
-        "http://www.thewestmorlandgazette.co.uk/",
-        "http://www.creativebloq.com/",
-        "http://www.nwemail.co.uk/"
+        "http://www.pcgamesn.com/",
+        "http://www.onlinepianist.com/",
+        "http://www.forcesnews.com/",
+        "http://markets.businessinsider.com/",
+        "http://limbuscompany.wiki.gg/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.theargus.co.uk/",
+        "http://www.leaderlive.co.uk/",
+        "http://www.makeuseof.com/",
         "http://www.newsshopper.co.uk/",
-        "http://www.thewestmorlandgazette.co.uk/",
-        "http://www.somersetcountygazette.co.uk/",
-        "http://www.clactonandfrintongazette.co.uk/"
+        "http://www.whatcar.com/",
+        "http://www.thisisoxfordshire.co.uk/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 33,
+      "sites": 30,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.y8.com/",
-        "http://www.theguardian.com/",
         "http://www.transfermarkt.com/",
-        "http://www.weremember.com/",
-        "http://www.abc15.com/"
+        "http://www.newschannel5.com/",
+        "http://www.refinery29.com/",
+        "http://www.radiotimes.com/",
+        "http://www.courttv.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://faroutmagazine.co.uk/",
-        "http://www.news5cleveland.com/",
-        "http://www.techtarget.com/",
-        "http://www.lex18.com/",
-        "http://www.myfitnesspal.com/"
+        "http://www.abc15.com/",
+        "http://www.fox13now.com/",
+        "http://www.military.com/",
+        "http://www.refinery29.com/",
+        "http://www.newschannel5.com/"
       ],
       "errorSites": []
     }
   },
   "Tealium": {
     "DE": {
-      "sites": 26,
+      "sites": 30,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.mainova.de/",
+        "http://www.ti.com/",
         "http://dsl.1und1.de/",
         "http://www.tui.com/",
-        "http://telekomhilft.telekom.de/",
-        "http://shopseite.telekom.de/"
+        "http://www.1und1.de/",
+        "http://mobile.1und1.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 27,
+      "sites": 28,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.firstdirect.com/",
-        "http://www.heathrow.com/",
-        "http://www.firstchoice.co.uk/",
         "http://www.disneystore.co.uk/",
-        "http://www.nisbets.co.uk/"
+        "http://www.visiondirect.co.uk/",
+        "http://www.hsbc.com/",
+        "http://www.carhartt.com/",
+        "http://www.business.hsbc.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -1070,10 +1091,10 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://www.allaboutvision.com/",
-        "http://www.jacquielawson.com/",
+        "http://www.americangreetings.com/",
         "http://www.bluemountain.com/",
-        "http://www.dominos.com/",
-        "http://www.framesdirect.com/"
+        "http://www.jacquielawson.com/",
+        "http://www.penguinrandomhouse.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -1086,6 +1107,7 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://loaded.com/",
         "http://www.alamy.com/",
         "http://www.alamy.de/",
         "http://www.pdfgear.com/"
@@ -1095,32 +1117,30 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 47,
+      "sites": 52,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://www.swelluk.com/",
-        "http://www.cdkeys.com/",
-        "http://www.alamy.com/",
-        "http://judge.me/",
-        "http://thepaintshed.com/"
+        "http://www.maxphoto.co.uk/",
+        "http://www.coolstays.com/",
+        "http://www.shortform.com/",
+        "http://www.opieoils.co.uk/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.maxphoto.co.uk/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 18,
+      "sites": 15,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://usafacts.org/",
+        "http://www.catholic.com/",
         "http://www.provenwinners.com/",
-        "http://streamfind.com/",
-        "http://www.pdfgear.com/",
-        "http://www.comic-con.org/",
-        "http://usafacts.org/"
+        "http://www.knoxcounty.org/",
+        "http://www.kubotausa.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -1144,15 +1164,14 @@
   },
   "TrustArc-top": {
     "DE": {
-      "sites": 8,
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://docs.citrix.com/",
         "http://learning.sap.com/",
-        "http://www.samsung.com/",
-        "http://www.sap.com/",
-        "http://www.ibm.com/",
-        "http://www.hpe.com/"
+        "http://www.fishersci.de/",
+        "http://www.ibm.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -1163,11 +1182,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://diy.com/",
-        "http://www.akaipro.com/",
-        "http://www.diy.com/",
+        "http://www.squarespace.com/",
+        "http://www.racingpost.com/",
         "http://www.diy.ie/",
-        "http://www.trade-point.co.uk/"
+        "http://www.fishersci.co.uk/",
+        "http://www.honor.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -1178,14 +1197,14 @@
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://us.store.bambulab.com/",
-        "http://www.pepboys.com/",
         "http://zappos.com/",
         "http://www.adt.com/",
-        "http://www.fishersci.com/"
+        "http://www.republicservices.com/",
+        "http://www.ibm.com/",
+        "http://www.thermofisher.com/"
       ],
       "failingSites": [
-        "http://us.store.bambulab.com/"
+        "http://www.remax.com/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
@@ -1193,10 +1212,11 @@
   },
   "UK Cookie Consent": {
     "GB": {
-      "sites": 1,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
+        "http://uk.humaxdigital.com/",
         "http://www.markpack.org.uk/"
       ],
       "failingSites": [
@@ -1217,21 +1237,6 @@
       "failingSites": [],
       "unsuccessfulSites": [
         "http://www.offen.net/"
-      ],
-      "errorSites": []
-    }
-  },
-  "WP DSGVO Tools": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://ptk-hessen.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://ptk-hessen.de/"
       ],
       "errorSites": []
     }
@@ -1281,23 +1286,23 @@
   },
   "acris": {
     "DE": {
-      "sites": 11,
+      "sites": 12,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://12seemeilen.de/",
-        "http://ersatzteilshop.de/",
+        "http://www.rekubik.de/",
+        "http://sallys-blog.de/",
         "http://www.berrybase.de/",
-        "http://www.ersatzteilshop.de/",
-        "http://www.baer-schuhe.de/"
+        "http://www.leguano.eu/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://12seemeilen.de/",
+        "http://www.leguano.eu/",
         "http://www.baer-schuhe.de/",
         "http://www.befestigungsfuchs.de/",
         "http://www.bresser.de/",
-        "http://www.leguano.eu/"
+        "http://www.campingplus.de/"
       ],
       "errorSites": []
     }
@@ -1357,12 +1362,15 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 2,
+      "sites": 7,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://aliexpress.com/",
-        "http://www.aliexpress.com/"
+        "http://a.aliexpress.com/",
+        "http://scicentric.org/",
+        "http://bdsmlust.com/",
+        "http://courtslistings.co.uk/",
+        "http://saturdaykitchenrecipes.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -1375,27 +1383,10 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://amazon.de/",
         "http://www.amazon.ca/",
         "http://www.amazon.co.uk/",
-        "http://www.amazon.es/",
-        "http://www.amazon.fr/",
-        "http://www.amazon.it/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.amazon.ca/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 6,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.amazon.ie/",
-        "http://www.amazon.ca/",
-        "http://www.amazon.co.uk/",
-        "http://www.amazon.es/",
+        "http://www.amazon.de/",
         "http://www.amazon.fr/"
       ],
       "failingSites": [],
@@ -1404,18 +1395,31 @@
       ],
       "errorSites": []
     },
-    "US": {
-      "sites": 5,
+    "GB": {
+      "sites": 7,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.amazon.ca/",
+        "http://amazon.co.uk/",
+        "http://www.amazon.ie/",
+        "http://www.amazon.co.uk/",
+        "http://www.amazon.it/",
+        "http://www.amazon.es/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 4,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.amazon.co.uk/",
         "http://www.amazon.de/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.amazon.ca/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
@@ -1437,17 +1441,6 @@
       "selfTestFailures": 0,
       "exampleSites": [
         "http://www.americanexpress.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
-    "US": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://resy.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -1492,12 +1485,11 @@
   },
   "aquasana.com": {
     "US": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.martinguitar.com/",
-        "http://www.westmarine.com/"
+        "http://www.martinguitar.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -1521,11 +1513,10 @@
   },
   "asus": {
     "DE": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://rog.asus.com/",
         "http://www.asus.com/"
       ],
       "failingSites": [],
@@ -1533,11 +1524,10 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://rog.asus.com/",
         "http://www.asus.com/"
       ],
       "failingSites": [],
@@ -1549,7 +1539,7 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://rog.asus.com/"
+        "http://www.asus.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -1582,26 +1572,24 @@
   },
   "aws.amazon.com": {
     "DE": {
-      "sites": 3,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://aws.amazon.com/",
-        "http://docs.aws.amazon.com/",
-        "http://s3.amazonaws.com/"
+        "http://docs.aws.amazon.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 4,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://aws.amazon.com/",
         "http://docs.aws.amazon.com/",
-        "http://health.aws.amazon.com/",
         "http://s3.amazonaws.com/"
       ],
       "failingSites": [],
@@ -1620,27 +1608,31 @@
   },
   "axeptio": {
     "DE": {
-      "sites": 4,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://bmw.europe-moto.com/",
-        "http://docs.mistral.ai/",
         "http://mistral.ai/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [],
+      "unsuccessfulSites": [
+        "http://mistral.ai/"
+      ],
       "errorSites": []
     },
     "GB": {
-      "sites": 1,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://mistral.ai/"
+        "http://mistral.ai/",
+        "http://www.naimaudio.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [],
+      "unsuccessfulSites": [
+        "http://mistral.ai/"
+      ],
       "errorSites": []
     },
     "US": {
@@ -1659,7 +1651,7 @@
   },
   "aylo-cookie-banner": {
     "DE": {
-      "sites": 4,
+      "sites": 6,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [],
@@ -1679,29 +1671,29 @@
   },
   "b-cookie": {
     "DE": {
-      "sites": 12,
+      "sites": 11,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://4kpornvideos.tv/",
         "http://www.machotube.tv/",
+        "http://www.boy18tube.com/",
         "http://www.brutalgays.net/",
-        "http://www.meatyhunks.com/",
-        "http://www.good-gay.tv/"
+        "http://www.icegaytube.tv/",
+        "http://www.xgaytube.tv/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 18,
+      "sites": 17,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.gaypornarchive.com/",
-        "http://www.onlygaymen.com/",
-        "http://hairydivas.com/",
-        "http://www.machotube.tv/",
+        "http://4kpornvideos.tv/",
+        "http://www.good-gay.tv/",
+        "http://www.poshgay.com/",
+        "http://www.verygayboys.com/",
         "http://www.boy18tube.com/"
       ],
       "failingSites": [],
@@ -1709,15 +1701,15 @@
       "errorSites": []
     },
     "US": {
-      "sites": 10,
+      "sites": 9,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.meatyhunks.com/",
+        "http://goodpornvids.com/",
+        "http://www.boy18tube.com/",
         "http://www.icegaytube.tv/",
-        "http://www.brutalgays.net/",
-        "http://www.xgaytube.tv/",
-        "http://www.icegay.tv/"
+        "http://www.gaymenring.com/",
+        "http://www.xgaytube.tv/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -1726,14 +1718,14 @@
   },
   "baden-wuerttemberg.de": {
     "DE": {
-      "sites": 11,
+      "sites": 6,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://sozialministerium.baden-wuerttemberg.de/",
         "http://finanzamt-bw.fv-bwl.de/",
         "http://km.baden-wuerttemberg.de/",
-        "http://zsl-bw.de/",
+        "http://www.bildungsplaene-bw.de/",
+        "http://vm.baden-wuerttemberg.de/",
         "http://www.baden-wuerttemberg.de/"
       ],
       "failingSites": [],
@@ -1807,11 +1799,13 @@
     }
   },
   "bbb.org": {
-    "GB": {
-      "sites": 2,
+    "US": {
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
-      "exampleSites": [],
+      "exampleSites": [
+        "http://www.bbb.org/"
+      ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
@@ -1863,11 +1857,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://batterystation.co.uk/",
+        "http://guardianbookshop.com/",
         "http://heinnie.com/",
-        "http://www.batterystation.co.uk/",
-        "http://www.menkind.co.uk/",
-        "http://uk.muji.eu/"
+        "http://uk.muji.eu/",
+        "http://worldofwater.com/",
+        "http://system76.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -1878,11 +1872,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://bravocompanyusa.com/",
         "http://simplicity.com/",
         "http://smkw.com/",
-        "http://www.tackledirect.com/",
-        "http://thedrardisshow.com/",
-        "http://www.sarcoinc.com/"
+        "http://system76.com/",
+        "http://www.tackledirect.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -1904,12 +1898,13 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 2,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://bing.com/",
-        "http://www.bing.com/"
+        "http://www.bing.com/",
+        "http://www2.bing.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -1918,30 +1913,24 @@
   },
   "borlabs": {
     "DE": {
-      "sites": 67,
+      "sites": 70,
       "errors": 0,
-      "selfTestFailures": 5,
+      "selfTestFailures": 9,
       "exampleSites": [
-        "http://www.online-physiotherapie.de/",
-        "http://report24.news/",
-        "http://www.hrworks.de/",
-        "http://mal-alt-werden.de/",
-        "http://kochenausliebe.com/"
+        "http://norsan.de/",
+        "http://granfondo-cycling.com/",
+        "http://www.bildungsurlauber.de/",
+        "http://www.helgoland.de/",
+        "http://grundschul-blog.de/"
       ],
       "failingSites": [
-        "http://kameramuseum.de/",
-        "http://www.apfelpatient.de/",
-        "http://www.gearnews.de/",
+        "http://www.smarthomeassistent.de/",
         "http://www.ra-kotz.de/",
-        "http://www.verbandsbuero.de/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.bildungsurlauber.de/",
-        "http://www.bergtour-online.de/",
         "http://www.delamar.de/",
-        "http://sigma.bike/",
-        "http://thevea.de/"
+        "http://www.gearnews.de/",
+        "http://www.naturundheilen.de/"
       ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
@@ -1958,11 +1947,10 @@
   },
   "bundesregierung.de": {
     "DE": {
-      "sites": 3,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.bundeskanzler.de/",
         "http://www.bundesregierung.de/"
       ],
       "failingSites": [],
@@ -1983,11 +1971,11 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 5,
+      "sites": 6,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.oxfordproducts.com/",
+        "http://www.henrykrank.com/",
         "http://www.sosandar.com/"
       ],
       "failingSites": [],
@@ -1995,12 +1983,11 @@
       "errorSites": []
     },
     "US": {
-      "sites": 3,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://hvacdirect.com/",
-        "http://www.mossberg.com/"
+        "http://hvacdirect.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -2009,28 +1996,26 @@
   },
   "cassie": {
     "DE": {
-      "sites": 3,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://new.abb.com/",
-        "http://sports.tipico.de/",
-        "http://www.dfds.com/"
+        "http://new.abb.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 10,
+      "sites": 7,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://help.open.ac.uk/",
-        "http://www.itv.com/",
-        "http://students.open.ac.uk/",
-        "http://www.rnib.org.uk/",
-        "http://www.dfds.com/"
+        "http://itv.com/",
+        "http://www.open.ac.uk/",
+        "http://www.dfds.com/",
+        "http://www.durham.gov.uk/",
+        "http://www.itv.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -2062,11 +2047,10 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 3,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://link.springer.com/",
         "http://www.nature.com/",
         "http://www.scientificamerican.com/"
       ],
@@ -2090,44 +2074,44 @@
   },
   "cc_banner": {
     "DE": {
-      "sites": 14,
+      "sites": 12,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.motoruf.de/",
-        "http://distrowatch.com/",
-        "http://fahrrad-routenplan.de/",
-        "http://gamcore.ch/",
-        "http://gamcore.com/"
+        "http://bmirechner.net/",
+        "http://www.regierung-mv.de/",
+        "http://www.restaurant-reservieren-lieferservice.de/",
+        "http://www.semperoper.de/",
+        "http://www.lumedis.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 7,
+      "sites": 9,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://www.ukcampsite.co.uk/",
-        "http://gamcore.com/",
+        "http://www.thegardencinema.co.uk/",
+        "http://meetyou.me/",
         "http://narrowboats.apolloduck.co.uk/",
-        "http://www.apolloduck.co.uk/",
-        "http://www.thegooddogguide.com/"
+        "http://www.apolloduck.co.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 7,
+      "sites": 6,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://gamcore.com/",
-        "http://govsalaries.com/",
-        "http://nytimes-crosswords.com/",
         "http://www.umass.edu/",
+        "http://govsalaries.com/",
+        "http://nytminicrossword.com/",
+        "http://www.corporationwiki.com/",
         "http://www.fantasynamegenerators.com/"
       ],
       "failingSites": [],
@@ -2163,21 +2147,20 @@
   },
   "civic-cookie-control": {
     "DE": {
-      "sites": 13,
+      "sites": 11,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://de.msi.com/",
-        "http://losteria.net/",
+        "http://www.msi.com/",
+        "http://www.suzuki.de/",
         "http://motorrad.suzuki.de/",
-        "http://www.nordicnest.de/",
-        "http://www.volkswagenbank.de/"
+        "http://nordicnest.de/",
+        "http://www.nordicnest.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
         "http://de.msi.com/",
         "http://nordicnest.de/",
-        "http://www.gigaset.com/",
         "http://www.msi.com/",
         "http://www.nordicnest.de/"
       ],
@@ -2188,19 +2171,19 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.esht.nhs.uk/",
-        "http://www.thepighotel.com/",
-        "http://www.ox.ac.uk/",
-        "http://www.swimming.org/",
-        "http://www.hants.gov.uk/"
+        "http://nationalhighways.co.uk/",
+        "http://www.ipswich.gov.uk/",
+        "http://www.coventry.gov.uk/",
+        "http://www.kingsseeds.com/",
+        "http://le.ac.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.bacs.co.uk/",
-        "http://www.gold.ac.uk/",
-        "http://www.sheffield.ac.uk/",
-        "http://tspc.co.uk/",
-        "http://www.energyombudsman.org/"
+        "http://historicengland.org.uk/",
+        "http://www.cps.gov.uk/",
+        "http://www.ukphonebook.com/",
+        "http://www.horsham.gov.uk/",
+        "http://www.sheffield.ac.uk/"
       ],
       "errorSites": []
     },
@@ -2226,7 +2209,7 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.din-5008-richtlinien.de/",
+        "http://www.engelke-optik-shop.de/",
         "http://www.happy-mahlzeit.com/"
       ],
       "failingSites": [],
@@ -2236,32 +2219,36 @@
   },
   "click.io": {
     "DE": {
-      "sites": 2,
+      "sites": 3,
       "errors": 0,
-      "selfTestFailures": 2,
+      "selfTestFailures": 3,
       "exampleSites": [
         "http://politpro.eu/",
-        "http://www.treccani.it/"
+        "http://www.dizy.com/",
+        "http://www.songtextemania.com/"
       ],
       "failingSites": [
         "http://politpro.eu/",
-        "http://www.treccani.it/"
+        "http://www.dizy.com/",
+        "http://www.songtextemania.com/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 3,
+      "sites": 4,
       "errors": 0,
-      "selfTestFailures": 3,
+      "selfTestFailures": 4,
       "exampleSites": [
-        "http://www.aplaceinthesun.com/",
         "http://www.avsim.com/",
+        "http://www.joinmyband.co.uk/",
+        "http://www.moneymagpie.com/",
         "http://www.shetnews.co.uk/"
       ],
       "failingSites": [
-        "http://www.aplaceinthesun.com/",
         "http://www.avsim.com/",
+        "http://www.joinmyband.co.uk/",
+        "http://www.moneymagpie.com/",
         "http://www.shetnews.co.uk/"
       ],
       "unsuccessfulSites": [],
@@ -2270,7 +2257,7 @@
   },
   "clinch": {
     "DE": {
-      "sites": 7,
+      "sites": 10,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [],
@@ -2292,11 +2279,13 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 2,
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://freespeechunion.org/",
         "http://gardenuk.co.uk/",
+        "http://vote-scope.com/",
         "http://www.myhsn.co.uk/"
       ],
       "failingSites": [],
@@ -2317,59 +2306,55 @@
   },
   "consentmanager.net": {
     "DE": {
-      "sites": 607,
+      "sites": 597,
       "errors": 0,
-      "selfTestFailures": 0,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.segmueller.de/",
-        "http://pflanzensache.de/",
-        "http://www.gtabase.com/",
-        "http://www.gdv.de/",
-        "http://linuxize.com/"
+        "http://www.mitsubishi-motors.de/",
+        "http://www.travemuende-tourismus.de/",
+        "http://www.dasoertliche.de/",
+        "http://www.essen.de/",
+        "http://emmikochteinfach.de/"
       ],
-      "failingSites": [],
+      "failingSites": [
+        "http://www.coingecko.com/"
+      ],
       "unsuccessfulSites": [
-        "http://bluray-disc.de/",
-        "http://www.diesachsen.de/",
-        "http://www.gelbe-liste.de/",
+        "http://www.median-kliniken.de/",
+        "http://www.swm.de/",
+        "http://www.rehakliniken.de/",
         "http://www.volksstimme.de/",
-        "http://www.swhl.de/"
+        "http://www.gelbe-liste.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 390,
-      "errors": 1,
+      "sites": 378,
+      "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.netweather.tv/",
-        "http://www.ranker.com/",
-        "http://www.thegamer.com/",
-        "http://www.besteveralbums.com/",
-        "http://www.howtoisolve.com/"
+        "http://spreadsheetplanet.com/",
+        "http://gardenerspath.com/",
+        "http://spikeybits.com/",
+        "http://www.chamberofcommerce.uk/",
+        "http://www.earthtrekkers.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://towardsdatascience.com/",
-        "http://www.theclassicvaluer.com/"
-      ],
-      "errorSites": [
-        "http://towardsdatascience.com/"
-      ]
+      "unsuccessfulSites": [],
+      "errorSites": []
     },
     "US": {
-      "sites": 326,
+      "sites": 304,
       "errors": 0,
-      "selfTestFailures": 2,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.media.io/",
+        "http://drfone.wondershare.com/",
+        "http://www.thedailymeal.com/",
+        "http://www.inkitt.com/",
         "http://www.bosch-home.com/",
-        "http://www.chowhound.com/",
-        "http://jalopnik.com/",
-        "http://www.letour.fr/"
+        "http://www.chowhound.com/"
       ],
       "failingSites": [
-        "http://rusticrootsliving.com/",
         "http://www.healthspectra.com/"
       ],
       "unsuccessfulSites": [],
@@ -2377,17 +2362,34 @@
     }
   },
   "consentmo": {
-    "GB": {
+    "DE": {
       "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://saharalondon.com/",
-        "http://www.bestwaystore.co.uk/",
-        "http://www.pooky.com/"
+        "http://rebike.com/",
+        "http://silberkraft.com/",
+        "http://www.keenfootwear.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 19,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://nextdaypaint.co.uk/",
+        "http://www.nutritiongeeks.co/",
+        "http://www.justfabrics.co.uk/",
+        "http://teddybaldassarre.com/",
+        "http://justfabrics.co.uk/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://marshallsgarden.com/"
+      ],
       "errorSites": []
     },
     "US": {
@@ -2395,14 +2397,17 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://lectricebikes.com/",
+        "http://shop.panasonic.com/",
         "http://teddybaldassarre.com/",
-        "http://www.gouletpens.com/",
-        "http://www.jonesroadbeauty.com/",
-        "http://www.lionbrand.com/"
+        "http://www.arhaus.com/",
+        "http://www.lionbrand.com/",
+        "http://www.keenfootwear.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [],
+      "unsuccessfulSites": [
+        "http://www.arhaus.com/",
+        "http://www.gouletpens.com/"
+      ],
       "errorSites": []
     }
   },
@@ -2444,47 +2449,45 @@
   },
   "cookie-law-info": {
     "DE": {
-      "sites": 9,
+      "sites": 10,
       "errors": 0,
-      "selfTestFailures": 1,
+      "selfTestFailures": 0,
       "exampleSites": [
         "http://www.deutscherpflegebeistand.de/",
+        "http://edelmetalltest.de/",
+        "http://www.sexgeschichten.de/",
         "http://mammutmarsch.de/",
-        "http://www.fitundattraktiv.de/",
-        "http://technischetipps.com/",
-        "http://www.sexgeschichten.de/"
+        "http://reihenfolge.org/"
       ],
-      "failingSites": [
-        "http://www.e-mobileo.de/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 13,
+      "sites": 14,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.portsmouth.gov.uk/",
-        "http://patientsknowbest.com/",
-        "http://britishspeedway.co.uk/",
-        "http://teachmeanatomy.info/",
-        "http://premiumsound.co.uk/"
+        "http://talkingpicturestv.co.uk/",
+        "http://premiumsound.co.uk/",
+        "http://just4one.com/",
+        "http://rivercottage.net/",
+        "http://patientsknowbest.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 5,
+      "sites": 7,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://teachmeanatomy.info/",
-        "http://www.ehlers-danlos.com/",
-        "http://www.mysextoyguide.com/",
         "http://www.sportsinjuryclinic.net/",
-        "http://www.uchealth.org/"
+        "http://therealfooddietitians.com/",
+        "http://wistatefair.com/",
+        "http://www.uchealth.org/",
+        "http://www.mysextoyguide.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -2493,80 +2496,91 @@
   },
   "cookie-script": {
     "DE": {
-      "sites": 36,
+      "sites": 40,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.myabandonware.com/",
-        "http://www.backstagepro.de/",
-        "http://n8n.io/",
-        "http://www.fetisch.de/",
-        "http://www.kaufmich.com/"
+        "http://www.marktcom.de/",
+        "http://www.garnstudio.com/",
+        "http://www.ferienhausmiete.de/",
+        "http://www.aktionspreis.de/",
+        "http://www.vrm-trauer.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
         "http://de.eurovelo.com/",
         "http://www.aachen-gedenkt.de/",
-        "http://www.aktionspreis.de/"
+        "http://www.aktionspreis.de/",
+        "http://www.webcam-netzwerk.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 72,
+      "sites": 70,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.powertoolworld.co.uk/",
-        "http://www.hollyland.com/",
-        "http://www.hamptons.co.uk/",
-        "http://www.ecotricity.co.uk/",
-        "http://home.bargains/"
+        "http://www.williamhbrown.co.uk/",
+        "http://www.thamesclippers.com/",
+        "http://www.wessexwater.co.uk/",
+        "http://www.english-heritage.org.uk/",
+        "http://www.fetish.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://motionarray.com/",
-        "http://www.schoolguide.co.uk/"
+        "http://www.jurawatches.co.uk/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 13,
+      "sites": 14,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.watchmojo.com/",
+        "http://airadvisor.com/",
         "http://assistedlivingcenter.com/",
         "http://www.247games.com/",
         "http://www.signalhire.com/",
-        "http://sermoncentral.com/"
+        "http://www.fluentu.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://airadvisor.com/",
-        "http://assistedlivingcenter.com/",
-        "http://www.assistedlivingcenter.com/"
+        "http://airadvisor.com/"
       ],
+      "errorSites": []
+    }
+  },
+  "cookieacceptbar": {
+    "US": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.streamlight.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
   "cookieconsent2": {
     "DE": {
-      "sites": 20,
+      "sites": 19,
       "errors": 0,
-      "selfTestFailures": 6,
+      "selfTestFailures": 5,
       "exampleSites": [
-        "http://boardgamegeek.com/",
-        "http://www.runnea.de/",
-        "http://gepris.dfg.de/",
+        "http://www.kinoprogramm.com/",
         "http://www.elektrikerwissen.de/",
-        "http://www.kinoprogramm.com/"
+        "http://gepris.dfg.de/",
+        "http://www.proxmox.com/",
+        "http://www.ausbildungsstellen.de/"
       ],
       "failingSites": [
         "http://maclookup.app/",
-        "http://www.scm-shop.de/",
         "http://www.offiziellecharts.de/",
         "http://www.proxmox.com/",
-        "http://www.runnea.de/"
+        "http://www.rechnerabisz.de/",
+        "http://www.scm-shop.de/"
       ],
       "unsuccessfulSites": [
         "http://www.daibau.de/"
@@ -2574,22 +2588,22 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 17,
+      "sites": 18,
       "errors": 0,
       "selfTestFailures": 8,
       "exampleSites": [
-        "http://ahdb.org.uk/",
-        "http://www.proxmox.com/",
+        "http://thegolfshoponline.co.uk/",
+        "http://www.sparepartsworld.co.uk/",
         "http://dkmgames.com/",
-        "http://www.librarieswest.org.uk/",
-        "http://www.bigmotoringworld.co.uk/"
+        "http://en.pornoreino.com/",
+        "http://www.tagvenue.com/"
       ],
       "failingSites": [
-        "http://www.visitnorthumberland.com/",
+        "http://dkmgames.com/",
         "http://en.pornoreino.com/",
-        "http://www.mobilityshop.co.uk/",
-        "http://www.cuh.nhs.uk/",
-        "http://www.librarieswest.org.uk/"
+        "http://maclookup.app/",
+        "http://www.librarieswest.org.uk/",
+        "http://www.proxmox.com/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
@@ -2616,43 +2630,40 @@
   },
   "cookieconsent3": {
     "DE": {
-      "sites": 38,
+      "sites": 34,
       "errors": 0,
-      "selfTestFailures": 4,
+      "selfTestFailures": 3,
       "exampleSites": [
-        "http://www.testsieger.de/",
-        "http://polizei.brandenburg.de/",
-        "http://www.anker.com/",
-        "http://www.qnap.com/",
-        "http://www.modelle-hamburg.de/"
+        "http://www.rosenhof-schultheis.de/",
+        "http://bestbuyersguide.org/",
+        "http://www.online-handelsregister.de/",
+        "http://pathfinderwiki.com/",
+        "http://coros.com/"
       ],
       "failingSites": [
+        "http://brdmap.de/",
         "http://polizei.brandenburg.de/",
-        "http://www.crealitycloud.com/",
-        "http://www.kuechen-atlas.de/",
         "http://www.studentenwerk-leipzig.de/"
       ],
       "unsuccessfulSites": [
-        "http://www.hagen.de/",
         "http://www.qnap.com/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 24,
+      "sites": 25,
       "errors": 0,
-      "selfTestFailures": 4,
+      "selfTestFailures": 3,
       "exampleSites": [
-        "http://adexa.co.uk/",
-        "http://www.moviequotedb.com/",
-        "http://fitshop.co.uk/",
-        "http://www.anker.com/",
-        "http://selfridges.com/"
+        "http://www.soundcore.com/",
+        "http://app.opencve.io/",
+        "http://www.sleepfoundation.org/",
+        "http://www.canford.co.uk/",
+        "http://www.podbean.com/"
       ],
       "failingSites": [
         "http://www.canford.co.uk/",
         "http://www.pitchero.com/",
-        "http://www.sleepfoundation.org/",
         "http://www.sqa.org.uk/"
       ],
       "unsuccessfulSites": [
@@ -2667,25 +2678,25 @@
       "errors": 0,
       "selfTestFailures": 6,
       "exampleSites": [
-        "http://casterconnection.com/",
-        "http://www.hawaiianairlines.com/",
-        "http://www.umms.org/",
+        "http://cinemark.com/",
         "http://www.icruise.com/",
-        "http://www.alaskaair.com/"
+        "http://www.buildzoom.com/",
+        "http://www.ankersolix.com/",
+        "http://www.qnap.com/"
       ],
       "failingSites": [
         "http://progressivevotersguide.com/",
         "http://www.crealitycloud.com/",
-        "http://www.healthspectra.com/",
-        "http://www.sleepapnea.org/",
-        "http://www.sleepfoundation.org/"
+        "http://www.umms.org/",
+        "http://www.reverbnation.com/",
+        "http://www.sleepapnea.org/"
       ],
       "unsuccessfulSites": [
         "http://cinemark.com/",
-        "http://www.hawaiianairlines.com/",
-        "http://www.prnewswire.com/",
-        "http://www.buildzoom.com/",
-        "http://www.cinemark.com/"
+        "http://greatbigcanvas.com/",
+        "http://www.alaskaair.com/",
+        "http://www.breastcancer.org/",
+        "http://www.prnewswire.com/"
       ],
       "errorSites": []
     }
@@ -2717,19 +2728,18 @@
   },
   "cookiefirst.com": {
     "DE": {
-      "sites": 54,
+      "sites": 55,
       "errors": 0,
-      "selfTestFailures": 4,
+      "selfTestFailures": 3,
       "exampleSites": [
-        "http://www.beltz.de/",
-        "http://cairo.de/",
-        "http://www.maxfunsports.com/",
         "http://wein.cc/",
-        "http://www.arts-outdoors.de/"
+        "http://www.blutspende.de/",
+        "http://www.fremdenverkehrsamt.com/",
+        "http://www.autokostencheck.de/",
+        "http://www.leasingkostencheck.de/"
       ],
       "failingSites": [
         "http://www.beltz.de/",
-        "http://www.berlin-recycling.de/",
         "http://www.krankenhaus.de/",
         "http://www.weinmann-schanz.de/"
       ],
@@ -2741,15 +2751,15 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 29,
+      "sites": 31,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://carmats.co.uk/",
-        "http://www.classicfootballshirts.co.uk/",
-        "http://www.lsengineers.co.uk/",
         "http://www.vertumotors.com/",
-        "http://www.selcobw.com/"
+        "http://www.gtech.co.uk/",
+        "http://rab.equipment/",
+        "http://www.jollyes.co.uk/",
+        "http://subaru.co.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -2769,12 +2779,11 @@
   },
   "cookiehub": {
     "DE": {
-      "sites": 5,
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://kotlinlang.org/",
-        "http://warthunder.com/",
         "http://www.jetbrains.com/",
         "http://www.victronenergy.com/",
         "http://www.victronenergy.de/"
@@ -2784,14 +2793,14 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 13,
+      "sites": 15,
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.yha.org.uk/",
-        "http://energysavingtrust.org.uk/",
+        "http://clubhousegolf.co.uk/",
         "http://www.bigbarn.co.uk/",
-        "http://www.clubhousegolf.co.uk/",
+        "http://zoe.com/",
+        "http://www.jetbrains.com/",
         "http://www.auctionhouse.co.uk/"
       ],
       "failingSites": [
@@ -2801,10 +2810,11 @@
       "errorSites": []
     },
     "US": {
-      "sites": 2,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://www.binghamton.edu/",
         "http://www.jetbrains.com/",
         "http://www.victronenergy.com/"
       ],
@@ -2815,17 +2825,14 @@
   },
   "cookieinfo": {
     "GB": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.construction.co.uk/",
         "http://www.private-eye.co.uk/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://www.construction.co.uk/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
@@ -2843,62 +2850,61 @@
   },
   "cookieyes": {
     "DE": {
-      "sites": 47,
+      "sites": 48,
       "errors": 0,
-      "selfTestFailures": 1,
+      "selfTestFailures": 2,
       "exampleSites": [
-        "http://meshtastic.org/",
-        "http://www.computerhope.com/",
-        "http://www.redgifs.com/",
+        "http://www.selbststaendig.de/",
+        "http://www.jackjones.com/",
         "http://www.med-mag.de/",
-        "http://digipart.com/"
+        "http://www.truenas.com/",
+        "http://mubi.com/"
       ],
       "failingSites": [
+        "http://macpaw.com/",
         "http://www.usz.ch/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 199,
-      "errors": 1,
+      "sites": 204,
+      "errors": 0,
       "selfTestFailures": 14,
       "exampleSites": [
-        "http://mubi.com/",
-        "http://www.attwoolls.co.uk/",
-        "http://www.museumsassociation.org/",
-        "http://espc.com/",
-        "http://pourmoi.co.uk/"
+        "http://www.centreofexcellence.com/",
+        "http://www.simplyfeet.co.uk/",
+        "http://www.s4c.cymru/",
+        "http://www.comparebanks.co.uk/",
+        "http://www.wheelbase.co.uk/"
       ],
       "failingSites": [
+        "http://www.visitherefordshire.co.uk/",
         "http://www.sockshop.co.uk/",
-        "http://www.nbt.nhs.uk/",
         "http://www.sealey.co.uk/",
-        "http://www.swiftgroup.co.uk/",
-        "http://www.parkingeye.co.uk/"
+        "http://www.chards.co.uk/",
+        "http://www.foyles.co.uk/"
       ],
       "unsuccessfulSites": [],
-      "errorSites": [
-        "http://towardsdatascience.com/"
-      ]
+      "errorSites": []
     },
     "US": {
-      "sites": 56,
+      "sites": 58,
       "errors": 0,
       "selfTestFailures": 16,
       "exampleSites": [
+        "http://www.truenas.com/",
         "http://www.phoenix.gov/",
-        "http://iopscience.iop.org/",
-        "http://resupply.com/",
-        "http://edfinancial.studentaid.gov/",
-        "http://comfortalife.com/"
+        "http://taxfoundation.org/",
+        "http://www.kink.com/",
+        "http://www.nastygal.com/"
       ],
       "failingSites": [
-        "http://www.phoenix.gov/",
-        "http://press.princeton.edu/",
-        "http://www.razer.com/",
         "http://traveloregon.com/",
-        "http://www.artnet.com/"
+        "http://macpaw.com/",
+        "http://www.phoenix.gov/",
+        "http://taxfoundation.org/",
+        "http://portlandgeneral.com/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
@@ -2906,22 +2912,24 @@
   },
   "corona-in-zahlen.de": {
     "DE": {
-      "sites": 2,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://camslib.com/",
         "http://hubite.com/",
         "http://radio-horen.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
+        "http://camslib.com/",
         "http://hubite.com/",
         "http://radio-horen.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 7,
+      "sites": 6,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
@@ -2935,24 +2943,26 @@
       "unsuccessfulSites": [
         "http://camslib.com/",
         "http://hubite.com/",
-        "http://www.huntingdonshire.gov.uk/",
-        "http://www.ukclimbing.com/",
-        "http://www.houseofnames.com/"
+        "http://ldwa.org.uk/",
+        "http://radio-live-uk.com/",
+        "http://www.ukclimbing.com/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 2,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://hubite.com/",
-        "http://www.lsu.edu/"
+        "http://www.lsu.edu/",
+        "http://www.usu.edu/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
         "http://hubite.com/",
-        "http://www.lsu.edu/"
+        "http://www.lsu.edu/",
+        "http://www.usu.edu/"
       ],
       "errorSites": []
     }
@@ -2979,6 +2989,17 @@
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
+    },
+    "US": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.curseforge.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
     }
   },
   "dailymotion-us": {
@@ -2996,15 +3017,15 @@
   },
   "datagrail": {
     "DE": {
-      "sites": 7,
+      "sites": 8,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://developer.hashicorp.com/",
+        "http://www.uaudio.com/",
         "http://linktr.ee/",
-        "http://www.fairphone.com/",
+        "http://www.netgear.com/",
         "http://www.fortinet.com/",
-        "http://www.netgear.com/"
+        "http://www.malwarebytes.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -3018,7 +3039,7 @@
         "http://developer.hashicorp.com/",
         "http://linktr.ee/",
         "http://www.uaudio.com/",
-        "http://www.fortinet.com/",
+        "http://www.netgear.com/",
         "http://www.malwarebytes.com/"
       ],
       "failingSites": [],
@@ -3026,52 +3047,50 @@
       "errorSites": []
     },
     "US": {
-      "sites": 25,
+      "sites": 18,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://developer.hashicorp.com/",
+        "http://www.aura.com/",
+        "http://www.classicindustries.com/",
         "http://www.malwarebytes.com/",
-        "http://go.audacy.com/",
-        "http://nj.pseg.com/",
-        "http://owalalife.com/",
-        "http://www.classicindustries.com/"
+        "http://www.fortinet.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
         "http://www.aura.com/",
-        "http://www.malwarebytes.com/"
+        "http://www.fortinet.com/"
       ],
       "errorSites": []
     }
   },
   "didomi": {
     "DE": {
-      "sites": 100,
+      "sites": 101,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.thepioneer.de/",
-        "http://www.marketscreener.com/",
-        "http://www.csfd.cz/",
-        "http://www.allocine.fr/",
-        "http://www.aol.com/"
+        "http://www.gamestar.de/",
+        "http://www.handyhase.de/",
+        "http://www.rajce.idnes.cz/",
+        "http://context.reverso.net/",
+        "http://www.allocine.fr/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://backmarket.de/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 78,
+      "sites": 74,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.netmums.com/",
-        "http://www.nestoria.co.uk/",
-        "http://nothing.tech/",
-        "http://www.harvester.co.uk/",
-        "http://www.boredpanda.com/"
+        "http://www.rajce.idnes.cz/",
+        "http://www.tobycarvery.co.uk/",
+        "http://www.everymancinema.com/",
+        "http://context.reverso.net/",
+        "http://emojipedia.org/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -3082,14 +3101,16 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.landmarktheatres.com/",
         "http://www.theweathernetwork.com/",
-        "http://www.webnovel.com/",
-        "http://hibid.com/",
-        "http://www.netmums.com/"
+        "http://www.logos.com/",
+        "http://newrepublic.com/",
+        "http://getemoji.com/",
+        "http://hibid.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [],
+      "unsuccessfulSites": [
+        "http://9gag.com/"
+      ],
       "errorSites": []
     }
   },
@@ -3145,13 +3166,11 @@
   },
   "dmgmedia-us": {
     "US": {
-      "sites": 3,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://metro.co.uk/",
-        "http://www.dailymail.co.uk/",
-        "http://www.dailymail.com/"
+        "http://metro.co.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -3173,13 +3192,13 @@
   },
   "ebay": {
     "DE": {
-      "sites": 6,
+      "sites": 7,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://ebay.de/",
-        "http://pages.ebay.de/",
-        "http://www.ebay.at/",
+        "http://www.ebay.de/",
+        "http://www.ebay.com/",
         "http://www.ebay.ca/",
         "http://www.ebay.co.uk/"
       ],
@@ -3192,11 +3211,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://ebay.co.uk/",
         "http://www.ebay.fr/",
+        "http://pages.ebay.co.uk/",
+        "http://www.ebay.ca/",
         "http://www.ebay.co.uk/",
-        "http://www.ebay.com.au/",
-        "http://www.ebay.de/"
+        "http://www.ebay.ie/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -3230,11 +3249,10 @@
   },
   "elsevier-pure": {
     "GB": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://experts.exeter.ac.uk/",
         "http://profiles.ucl.ac.uk/"
       ],
       "failingSites": [],
@@ -3244,15 +3262,15 @@
   },
   "eu-cookie-compliance-banner": {
     "DE": {
-      "sites": 20,
+      "sites": 17,
       "errors": 0,
       "selfTestFailures": 4,
       "exampleSites": [
-        "http://www.staatsgalerie.de/",
+        "http://www.brd.nrw.de/",
         "http://www.mannheim.de/",
-        "http://www.finanzverwaltung.nrw.de/",
         "http://www.tim-online.nrw.de/",
-        "http://www.gardasee.de/"
+        "http://www.bezreg-koeln.nrw.de/",
+        "http://www.finanzamt.nrw.de/"
       ],
       "failingSites": [
         "http://www.bra.nrw.de/",
@@ -3261,21 +3279,22 @@
         "http://www.schulministerium.nrw/"
       ],
       "unsuccessfulSites": [
+        "http://biooekonomie.de/",
         "http://www.bfn.de/",
         "http://www.statistikportal.de/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 28,
+      "sites": 25,
       "errors": 0,
       "selfTestFailures": 3,
       "exampleSites": [
-        "http://www.rbwm.gov.uk/",
-        "http://www.leicestershire.gov.uk/",
         "http://www.genuki.org.uk/",
-        "http://www.stereophile.com/",
-        "http://www.local.gov.uk/"
+        "http://faculty.educ.cam.ac.uk/",
+        "http://www.naturespot.org/",
+        "http://www.westminster.gov.uk/",
+        "http://www.croydon.gov.uk/"
       ],
       "failingSites": [
         "http://www.bto.org/",
@@ -3291,27 +3310,25 @@
       "errorSites": []
     },
     "US": {
-      "sites": 16,
+      "sites": 13,
       "errors": 0,
-      "selfTestFailures": 3,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.ccjm.org/",
-        "http://healthcare.utah.edu/",
-        "http://www.mcgill.ca/",
-        "http://www.stereophile.com/",
-        "http://www.adventhealth.com/"
+        "http://www.usccb.org/",
+        "http://www.wake.gov/",
+        "http://www.aa.org/",
+        "http://www.escort-ads.com/",
+        "http://www.ccjm.org/"
       ],
       "failingSites": [
-        "http://www.honorhealth.com/",
-        "http://www.mcgill.ca/",
-        "http://www.nowfoods.com/"
+        "http://www.mcgill.ca/"
       ],
       "unsuccessfulSites": [
         "http://bible.usccb.org/",
-        "http://www.adventhealth.com/",
         "http://www.uvm.edu/",
+        "http://www.ccjm.org/",
         "http://www.dar.org/",
-        "http://www.usccb.org/"
+        "http://www.escort-ads.com/"
       ],
       "errorSites": []
     }
@@ -3356,11 +3373,12 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 4,
+      "sites": 5,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://britishbakingrecipes.co.uk/",
+        "http://www.kingmods.net/",
         "http://www.nigella.com/",
         "http://www.physicsandmathstutor.com/",
         "http://www.w3schools.com/"
@@ -3372,29 +3390,29 @@
   },
   "fides": {
     "DE": {
-      "sites": 12,
+      "sites": 11,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://arstechnica.com/",
-        "http://www.vogue.de/",
-        "http://www.ad-magazin.de/",
+        "http://www.ironman.com/",
+        "http://www.wired.com/",
+        "http://www.cntraveller.de/",
         "http://www.vogue.com/",
-        "http://www.wired.com/"
+        "http://www.newyorker.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 24,
+      "sites": 25,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.nytimes.com/",
-        "http://www.ironman.com/",
+        "http://www.tatler.com/",
+        "http://www.vanityfair.com/",
         "http://www.wired.com/",
-        "http://www.glamourmagazine.co.uk/",
+        "http://www.gq.com/",
         "http://www.cntraveller.com/"
       ],
       "failingSites": [],
@@ -3402,11 +3420,12 @@
       "errorSites": []
     },
     "US": {
-      "sites": 1,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.ironman.com/"
+        "http://www.ironman.com/",
+        "http://www.teenvogue.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -3461,44 +3480,41 @@
   },
   "funding-choices": {
     "DE": {
-      "sites": 255,
+      "sites": 235,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.libreoffice-forum.de/",
-        "http://mundowin.com/",
-        "http://www.bestenzitate.com/",
-        "http://www.ferienfeiertagedeutschland.de/",
-        "http://www.abbreviations.com/"
+        "http://www.skylinewebcams.com/",
+        "http://www.campingfrance.com/",
+        "http://www.gsmarena.com/",
+        "http://www.sendungverpasst.at/",
+        "http://www.worldometers.info/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://ev-database.org/",
-        "http://www.cpuid.com/",
-        "http://www.germanlisting.com/",
-        "http://www.bubbleshooter.de/",
-        "http://www.pfarrei-deutschland.de/"
+        "http://lexis-rechtsanwaelte.de/",
+        "http://www.bayerische-spezialitaeten.net/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 510,
+      "sites": 480,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.british-birdsongs.uk/",
-        "http://mollygram.com/",
-        "http://advancestudy.org/",
-        "http://www.webcamtaxi.com/",
-        "http://www.emuparadise.me/"
+        "http://www.partsgateway.co.uk/",
+        "http://www.openinghourspostoffice.co.uk/",
+        "http://www.celebscouples.com/",
+        "http://lyricsmeanings.com/",
+        "http://flightqueue.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://fileinfo.com/",
-        "http://tuner-online.com/",
-        "http://procalculator.co.uk/",
-        "http://www.nonleaguematters.co.uk/",
-        "http://www.mikegravel.org/"
+        "http://gramsnap.com/",
+        "http://www.pubsgalore.co.uk/",
+        "http://www.irishlottery.com/",
+        "http://www.marketbeat.com/",
+        "http://www.online-tech-tips.com/"
       ],
       "errorSites": []
     },
@@ -3549,15 +3565,44 @@
       "errorSites": []
     }
   },
+  "gmx-permission": {
+    "GB": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 1,
+      "exampleSites": [
+        "http://mlogin.gmx.com/"
+      ],
+      "failingSites": [
+        "http://mlogin.gmx.com/"
+      ],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 1,
+      "exampleSites": [
+        "http://mlogin.gmx.com/"
+      ],
+      "failingSites": [
+        "http://mlogin.gmx.com/"
+      ],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    }
+  },
   "google-consent-standalone": {
     "DE": {
-      "sites": 4,
+      "sites": 5,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://chromewebstore.google.com/",
         "http://local.google.com/",
         "http://maps.google.com/",
+        "http://news.google.com/",
+        "http://store.google.com/",
         "http://translate.google.com/"
       ],
       "failingSites": [],
@@ -3565,15 +3610,15 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 12,
+      "sites": 10,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://news.google.co.uk/",
-        "http://news.google.com/",
-        "http://store.google.com/",
-        "http://translate.google.co.uk/",
-        "http://maps.google.com/"
+        "http://translate.google.com/",
+        "http://local.google.com/",
+        "http://maps.google.co.uk/",
+        "http://maps.google.com/",
+        "http://www.fitbit.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -3582,30 +3627,30 @@
   },
   "google-cookiebar": {
     "DE": {
-      "sites": 17,
+      "sites": 12,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://lens.google/",
+        "http://aistudio.google.com/",
+        "http://search.google/",
         "http://calendar.google.com/",
         "http://cloud.google.com/",
-        "http://photos.google.com/",
-        "http://developer.android.com/"
+        "http://developer.chrome.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 25,
+      "sites": 24,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://drive.google.com/",
+        "http://docs.cloud.google.com/",
         "http://firebase.google.com/",
         "http://www.android.com/",
-        "http://workspace.google.com/",
-        "http://chat.google.com/",
-        "http://deepmind.google/"
+        "http://developers.google.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -3614,30 +3659,29 @@
   },
   "google.com": {
     "DE": {
-      "sites": 5,
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://images.google.de/",
-        "http://ipv4.google.com/",
-        "http://pics-x.com/",
+        "http://images.google.com/",
         "http://search.google.com/",
-        "http://www.google.com/"
+        "http://www.google.com/",
+        "http://www.google.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 6,
+      "sites": 8,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://fleshbot.com/",
         "http://images.google.co.uk/",
         "http://images.google.com/",
-        "http://search.google.com/",
-        "http://www.google.co.uk/",
-        "http://www.google.com/"
+        "http://www.google.com/",
+        "http://www.registersecurely.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -3658,21 +3702,19 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 25,
+      "sites": 23,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.data.gov.uk/",
-        "http://www.uhsussex.nhs.uk/",
-        "http://www.ulh.nhs.uk/",
-        "http://www.find-court-tribunal.service.gov.uk/",
-        "http://www.gov.uk/"
+        "http://view-immigration-status.service.gov.uk/",
+        "http://www.universal-credit.service.gov.uk/",
+        "http://findajob.dwp.gov.uk/",
+        "http://www.camden.gov.uk/",
+        "http://national-infrastructure-consenting.planninginspectorate.gov.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://teaching-vacancies.service.gov.uk/",
         "http://www.civilservicepensionscheme.org.uk/",
-        "http://www.thepensionsregulator.gov.uk/",
         "http://www.uhsussex.nhs.uk/"
       ],
       "errorSites": []
@@ -3693,7 +3735,7 @@
   "healthline-media": {
     "DE": {
       "sites": 2,
-      "errors": 1,
+      "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://www.healthline.com/",
@@ -3701,9 +3743,7 @@
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
-      "errorSites": [
-        "http://www.medicalnewstoday.com/"
-      ]
+      "errorSites": []
     },
     "GB": {
       "sites": 3,
@@ -3747,11 +3787,11 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.countryliving.com/",
-        "http://www.bicycling.com/",
-        "http://www.biography.com/",
-        "http://www.runnersworld.com/",
-        "http://www.womenshealthmag.com/"
+        "http://www.esquire.com/",
+        "http://www.menshealth.com/",
+        "http://www.prevention.com/",
+        "http://www.goodhousekeeping.com/",
+        "http://www.cosmopolitan.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -3776,17 +3816,6 @@
     }
   },
   "hu-manity": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://lusina.de/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "GB": {
       "sites": 1,
       "errors": 0,
@@ -3801,51 +3830,49 @@
   },
   "hubspot": {
     "DE": {
-      "sites": 5,
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://blog.hubspot.de/",
         "http://element.io/",
         "http://www.paulcamper.de/",
-        "http://www.supermicro.com/",
-        "http://www.xe.com/"
+        "http://www.supermicro.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 7,
+      "sites": 6,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://blog.hubspot.com/",
         "http://secure.hushmail.com/",
-        "http://www.camplify.co.uk/",
+        "http://www.bristolwater.co.uk/",
+        "http://www.sunsave.energy/",
         "http://www.epubor.com/",
-        "http://www.ukpropertyaccountants.co.uk/"
+        "http://www.hubspot.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 6,
+      "sites": 5,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://blog.hubspot.com/",
-        "http://www.supermicro.com/",
+        "http://www.aafp.org/",
         "http://www.hancockwhitney.com/",
         "http://www.hisense-usa.com/",
-        "http://www.kff.org/"
+        "http://www.supermicro.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
         "http://www.aafp.org/",
-        "http://www.hancockwhitney.com/",
-        "http://www.kff.org/"
+        "http://www.hancockwhitney.com/"
       ],
       "errorSites": []
     }
@@ -3934,52 +3961,53 @@
   },
   "iubenda": {
     "DE": {
-      "sites": 17,
+      "sites": 14,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://www.repubblica.it/",
-        "http://www.giallozafferano.de/",
-        "http://www.topeak.com/",
-        "http://www.elastic.co/",
-        "http://www.automateexcel.com/"
+        "http://www.flyeralarm.com/",
+        "http://metricool.com/",
+        "http://www.weg.de/",
+        "http://www.arduino.cc/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 20,
+      "sites": 24,
       "errors": 0,
-      "selfTestFailures": 4,
+      "selfTestFailures": 6,
       "exampleSites": [
-        "http://www.barbour.com/",
-        "http://www.frolicme.com/",
-        "http://www.howdeninsurance.co.uk/",
-        "http://www.wexphotovideo.com/",
-        "http://www.marinesuperstore.com/"
+        "http://batterseapowerstation.co.uk/",
+        "http://newblinds.co.uk/",
+        "http://www.fowlersparts.co.uk/",
+        "http://www.lastminute.com/",
+        "http://www.arduino.cc/"
       ],
       "failingSites": [
         "http://paintnuts.co.uk/",
         "http://www.empressmills.co.uk/",
-        "http://www.howdeninsurance.co.uk/",
+        "http://www.fowlersparts.co.uk/",
+        "http://www.zestcarrental.com/",
         "http://www.rightbiz.co.uk/"
       ],
-      "unsuccessfulSites": [],
+      "unsuccessfulSites": [
+        "http://www.spectator.com.au/"
+      ],
       "errorSites": []
     },
     "US": {
       "sites": 3,
       "errors": 0,
-      "selfTestFailures": 1,
+      "selfTestFailures": 0,
       "exampleSites": [
         "http://docs.arduino.cc/",
-        "http://theausl.com/",
+        "http://fightingirish.com/",
         "http://www.arduino.cc/"
       ],
-      "failingSites": [
-        "http://theausl.com/"
-      ],
+      "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     }
@@ -4001,7 +4029,7 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://bigdave44.com/"
+        "http://insidecroydon.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -4040,7 +4068,7 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://onlybokep.com/",
+        "http://www.dhbbank.de/",
         "http://www.pp39.cn/"
       ],
       "failingSites": [],
@@ -4048,12 +4076,10 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 3,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://joiparadise.com/",
-        "http://onlybokep.com/",
         "http://www.pp39.cn/"
       ],
       "failingSites": [],
@@ -4116,16 +4142,14 @@
       "errorSites": []
     },
     "US": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://guides.justwatch.com/",
         "http://www.justwatch.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://guides.justwatch.com/",
         "http://www.justwatch.com/"
       ],
       "errorSites": []
@@ -4133,20 +4157,21 @@
   },
   "ketch": {
     "DE": {
-      "sites": 12,
+      "sites": 11,
       "errors": 0,
-      "selfTestFailures": 1,
+      "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.accuweather.com/",
-        "http://forums.elderscrollsonline.com/",
+        "http://www.forbes.com/",
+        "http://www.newsweek.com/",
         "http://kinsta.com/",
-        "http://www.dndbeyond.com/",
-        "http://www.southpark.de/"
+        "http://time.com/",
+        "http://www.accuweather.com/"
       ],
-      "failingSites": [
-        "http://www.dndbeyond.com/"
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://www.forbes.com/",
+        "http://www.imax.com/"
       ],
-      "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
@@ -4154,30 +4179,30 @@
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
+        "http://bitwarden.com/",
+        "http://www.forbes.com/",
+        "http://www.pbs.org/",
         "http://www.familyhandyman.com/",
-        "http://www.sra.org.uk/",
-        "http://www.channel5.com/",
-        "http://www.tasteofhome.com/",
-        "http://www.cbsnews.com/"
+        "http://www.dndbeyond.com/"
       ],
       "failingSites": [
         "http://www.dndbeyond.com/"
       ],
       "unsuccessfulSites": [
-        "http://www.forbes.com/"
+        "http://rumble.com/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 41,
+      "sites": 44,
       "errors": 0,
       "selfTestFailures": 2,
       "exampleSites": [
-        "http://www.sce.com/",
+        "http://www.kcra.com/",
+        "http://firstwatch.com/",
         "http://www.equifax.com/",
         "http://www.sunbeltrentals.com/",
-        "http://www.wisn.com/",
-        "http://www.wesh.com/"
+        "http://www.sonicdrivein.com/"
       ],
       "failingSites": [
         "http://magic.wizards.com/",
@@ -4186,8 +4211,8 @@
       "unsuccessfulSites": [
         "http://www.arbys.com/",
         "http://www.buffalowildwings.com/",
+        "http://www.cbinsights.com/",
         "http://www.dunkindonuts.com/",
-        "http://www.imax.com/",
         "http://www.sonicdrivein.com/"
       ],
       "errorSites": []
@@ -4247,26 +4272,26 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://uk.linkedin.com/",
-        "http://es.linkedin.com/",
-        "http://www.linkedin.com/",
         "http://it.linkedin.com/",
-        "http://de.linkedin.com/"
+        "http://nl.linkedin.com/",
+        "http://uk.linkedin.com/",
+        "http://ch.linkedin.com/",
+        "http://es.linkedin.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 21,
+      "sites": 20,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://de.linkedin.com/",
+        "http://je.linkedin.com/",
         "http://gb.linkedin.com/",
-        "http://es.linkedin.com/",
-        "http://ie.linkedin.com/",
-        "http://za.linkedin.com/"
+        "http://fr.linkedin.com/",
+        "http://be.linkedin.com/",
+        "http://ca.linkedin.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -4275,15 +4300,15 @@
   },
   "microsoft.com": {
     "DE": {
-      "sites": 27,
+      "sites": 26,
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://account.microsoft.com/",
-        "http://windows.microsoft.com/",
-        "http://teams.live.com/",
-        "http://dotnet.microsoft.com/",
-        "http://community.powerplatform.com/"
+        "http://explore.microsoft.com/",
+        "http://devblogs.microsoft.com/",
+        "http://microsoftedge.microsoft.com/",
+        "http://www.microsoft.com/",
+        "http://www.xbox.com/"
       ],
       "failingSites": [
         "http://windows.microsoft.com/"
@@ -4294,15 +4319,15 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 32,
+      "sites": 31,
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://microsoft.com/",
-        "http://forms.office.com/",
-        "http://azure.microsoft.com/",
-        "http://copilot.cloud.microsoft/",
-        "http://support.xbox.com/"
+        "http://community.powerplatform.com/",
+        "http://dotnet.microsoft.com/",
+        "http://explore.microsoft.com/",
+        "http://www.office.com/",
+        "http://microsoft.com/"
       ],
       "failingSites": [
         "http://windows.microsoft.com/"
@@ -4330,7 +4355,7 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.miles-and-more.com/"
+        "http://account.miles-and-more.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -4443,46 +4468,50 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 2,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://m.ok.ru/",
-        "http://ok.ru/"
+        "http://ok.ru/",
+        "http://www.ok.ru/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
         "http://m.ok.ru/",
-        "http://ok.ru/"
+        "http://ok.ru/",
+        "http://www.ok.ru/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 2,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://m.ok.ru/",
-        "http://ok.ru/"
+        "http://ok.ru/",
+        "http://www.ok.ru/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
         "http://m.ok.ru/",
-        "http://ok.ru/"
+        "http://ok.ru/",
+        "http://www.ok.ru/"
       ],
       "errorSites": []
     }
   },
   "om": {
     "DE": {
-      "sites": 7,
+      "sites": 6,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://www.ash-berlin.eu/",
-        "http://www.awm-muenchen.de/",
         "http://www.bergsteigen.com/",
-        "http://www.uni-kiel.de/",
+        "http://www.malteser.de/",
+        "http://www.tedi.com/",
         "http://www.uni-saarland.de/"
       ],
       "failingSites": [],
@@ -4526,7 +4555,7 @@
     }
   },
   "openai": {
-    "DE": {
+    "GB": {
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
@@ -4534,9 +4563,7 @@
         "http://openai.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [
-        "http://openai.com/"
-      ],
+      "unsuccessfulSites": [],
       "errorSites": []
     }
   },
@@ -4574,40 +4601,40 @@
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.todoist.com/",
-        "http://www.spokeo.com/",
+        "http://support.riotgames.com/",
+        "http://de.scribd.com/",
+        "http://www.alltrails.com/",
         "http://www.leagueoflegends.com/",
-        "http://www.newegg.com/",
-        "http://support.riotgames.com/"
+        "http://www.semanticscholar.org/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 46,
+      "sites": 49,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.leagueoflegends.com/",
-        "http://www.womansworld.com/",
-        "http://www.complex.com/",
-        "http://www.snows.co.uk/",
-        "http://uk.fender.com/"
+        "http://www.steveneagell.co.uk/",
+        "http://www.harley-davidson.com/",
+        "http://sportsshoes.com/",
+        "http://support.riotgames.com/",
+        "http://uk.hornby.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 145,
+      "sites": 137,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://store.finalfantasyxiv.com/",
-        "http://www.healthcentral.com/",
-        "http://www.governmentjobs.com/",
-        "http://www.miamiherald.com/",
+        "http://4patriots.com/",
+        "http://www.timesfreepress.com/",
+        "http://www.city-journal.org/",
+        "http://support.riotgames.com/",
         "http://weathertech.com/"
       ],
       "failingSites": [],
@@ -4688,37 +4715,44 @@
   },
   "pandectes": {
     "DE": {
-      "sites": 1,
+      "sites": 8,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://alteserien.de/",
+        "http://de.roborock.com/",
+        "http://eu.meaco.com/",
+        "http://hoefer-shop.com/",
         "http://www.ugreen.com/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [],
+      "unsuccessfulSites": [
+        "http://snocks.com/"
+      ],
       "errorSites": []
     },
     "GB": {
-      "sites": 12,
+      "sites": 22,
       "errors": 0,
-      "selfTestFailures": 0,
+      "selfTestFailures": 1,
       "exampleSites": [
-        "http://www.ugreen.com/",
-        "http://wearewild.com/",
-        "http://ottolenghi.co.uk/",
-        "http://rokalondon.com/",
-        "http://www.keenfootwear.co.uk/"
+        "http://ai.ugreen.com/",
+        "http://www.panelcompany.co.uk/",
+        "http://hollandscountryclothing.co.uk/",
+        "http://uk.ugreen.com/",
+        "http://wearewild.com/"
       ],
-      "failingSites": [],
+      "failingSites": [
+        "http://www.sam-turner.co.uk/"
+      ],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 3,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://shokz.com/",
         "http://www.fleetfeet.com/",
         "http://www.ryobitools.com/"
       ],
@@ -4744,10 +4778,11 @@
   },
   "paypal-us": {
     "US": {
-      "sites": 2,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://history.paypal.com/",
         "http://venmo.com/",
         "http://www.paypal.com/"
       ],
@@ -4758,10 +4793,11 @@
   },
   "paypal.com": {
     "DE": {
-      "sites": 1,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://securepayments.paypal.com/",
         "http://www.paypal.com/"
       ],
       "failingSites": [],
@@ -4855,28 +4891,15 @@
   },
   "pmc": {
     "US": {
-      "sites": 12,
+      "sites": 10,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://www.rollingstone.com/",
         "http://robbreport.com/",
-        "http://www.indiewire.com/",
+        "http://soaps.sheknows.com/",
         "http://stylecaster.com/",
-        "http://variety.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
-  "police-uk": {
-    "GB": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.thamesvalley.police.uk/"
+        "http://www.indiewire.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -4885,48 +4908,75 @@
   },
   "pornhat": {
     "DE": {
-      "sites": 8,
+      "sites": 12,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://hello.porn/",
-        "http://homo.xxx/",
-        "http://www.pornhat.one/",
+        "http://www.omg.xxx/",
+        "http://www.freepornvideos.xxx/",
+        "http://www.porn4fans.com/",
         "http://max.porn/",
-        "http://www.fullvideos.xxx/"
+        "http://www.perfektdamen.co/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 5,
+      "sites": 10,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://hello.porn/",
+        "http://homo.xxx/",
         "http://many.xxx/",
-        "http://ok.xxx/",
-        "http://www.perfectgirls.xxx/",
-        "http://www.pornhat.com/"
+        "http://www.fullvideos.xxx/",
+        "http://www.freepornvideos.xxx/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 8,
+      "sites": 9,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://hello.porn/",
-        "http://www.perfectgirls.xxx/",
-        "http://www.pornhat.com/",
+        "http://www.fullvideos.xxx/",
+        "http://www.porn4fans.com/",
+        "http://many.xxx/",
         "http://ok.xxx/",
-        "http://www.porn4fans.com/"
+        "http://www.pornhat.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
+      "errorSites": []
+    }
+  },
+  "pornhub-compact-cookie-banner": {
+    "GB": {
+      "sites": 2,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://ww.pornhub.com/",
+        "http://www.pornhub.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 2,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://ww.pornhub.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://ww.pornhub.com/"
+      ],
       "errorSites": []
     }
   },
@@ -5047,49 +5097,49 @@
   },
   "quantcast": {
     "DE": {
-      "sites": 87,
+      "sites": 84,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://linuxconfig.org/",
-        "http://www.kreuzwort-raetsel.net/",
-        "http://www.miniplay.com/",
-        "http://www.ultimate-guitar.com/",
-        "http://lexikon.stangl.eu/"
+        "http://www.mathworks.com/",
+        "http://lexikon.stangl.eu/",
+        "http://meinairfryer.de/",
+        "http://www.schwimmbadcheck.de/",
+        "http://www.misterwhat.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://drivers.softpedia.com/",
-        "http://vitablo.de/",
-        "http://www.songlyrics.com/",
-        "http://tkp.at/",
-        "http://routenplaner24.net/"
+        "http://meinairfryer.de/",
+        "http://radsportaktuell.de/",
+        "http://meteoatlas.de/",
+        "http://www.chatcrypt.com/",
+        "http://www.mathworks.com/"
       ],
       "errorSites": []
     },
     "GB": {
-      "sites": 221,
+      "sites": 214,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.batimes.com.ar/",
-        "http://www.wiltshire999s.co.uk/",
-        "http://www.yourdictionary.com/",
-        "http://www.sainsburysmagazine.co.uk/",
-        "http://www.tunefind.com/"
+        "http://www.visitwiltshire.co.uk/",
+        "http://www.ultimate-guitar.com/",
+        "http://uk.freecycle.org/",
+        "http://tabs.ultimate-guitar.com/",
+        "http://www.ents24.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [
-        "http://www.edinburghlive.co.uk/",
-        "http://www.filmaffinity.com/",
-        "http://www.apkmirror.com/",
-        "http://www.plotaroute.com/",
-        "http://www.weather-forecast.com/"
+        "http://www.efestivals.co.uk/",
+        "http://www.fuel-finder.uk/",
+        "http://www.arrse.co.uk/",
+        "http://www.readytogo.net/",
+        "http://www.tide-forecast.com/"
       ],
       "errorSites": []
     },
     "US": {
-      "sites": 13,
+      "sites": 10,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
@@ -5116,22 +5166,23 @@
   },
   "real-cookie-banner": {
     "DE": {
-      "sites": 32,
+      "sites": 34,
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://hoehle-loewen.de/",
-        "http://bankinggeek.com/",
-        "http://www.photovoltaik.info/",
-        "http://fobizz.com/",
-        "http://vorunruhestand.de/"
+        "http://rentenbescheid24.de/",
+        "http://www.der-windows-papst.de/",
+        "http://www.windowspower.de/",
+        "http://www.heimhelden.de/",
+        "http://www.compact-online.de/"
       ],
       "failingSites": [
         "http://auswandern-info.com/"
       ],
       "unsuccessfulSites": [
-        "http://erp-up.de/",
+        "http://critviews.com/",
         "http://hoehle-loewen.de/",
+        "http://www.genussguide-hamburg.com/",
         "http://www.hausarztpraxis-am-romanplatz.de/",
         "http://www.tutonaut.de/"
       ],
@@ -5139,17 +5190,6 @@
     }
   },
   "ring": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://ring.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    },
     "GB": {
       "sites": 2,
       "errors": 0,
@@ -5255,13 +5295,38 @@
       "errorSites": []
     }
   },
-  "sandhills": {
+  "samsung.com": {
+    "US": {
+      "sites": 2,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://samsung.com/",
+        "http://www.samsung.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    }
+  },
+  "scmp": {
     "GB": {
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.farmmachinerylocator.co.uk/"
+        "http://www.scmp.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "US": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.scmp.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -5295,54 +5360,58 @@
   },
   "shopify": {
     "DE": {
-      "sites": 4,
+      "sites": 10,
       "errors": 0,
-      "selfTestFailures": 4,
+      "selfTestFailures": 10,
       "exampleSites": [
-        "http://kleineskraftwerk.de/",
-        "http://sonoff.tech/",
+        "http://www.gl-inet.com/",
+        "http://florage.de/",
         "http://stretta-music.de/",
-        "http://www.stretta-music.de/"
+        "http://kleineskraftwerk.de/",
+        "http://sonoff.tech/"
       ],
       "failingSites": [
-        "http://kleineskraftwerk.de/",
-        "http://sonoff.tech/",
+        "http://www.armedangels.com/",
+        "http://florage.de/",
         "http://stretta-music.de/",
-        "http://www.stretta-music.de/"
+        "http://kleineskraftwerk.de/",
+        "http://sonoff.tech/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 14,
+      "sites": 41,
       "errors": 0,
-      "selfTestFailures": 14,
+      "selfTestFailures": 41,
       "exampleSites": [
-        "http://afarley.co.uk/",
-        "http://www.e-bikeshop.co.uk/",
-        "http://ejbf.co.uk/",
-        "http://www.sarahraven.com/",
-        "http://www.bikeparts.co.uk/"
+        "http://www.thesoapery.co.uk/",
+        "http://www.rutlands.com/",
+        "http://www.tanks-direct.co.uk/",
+        "http://tufferman.co.uk/",
+        "http://hyundaipowerequipment.co.uk/"
       ],
       "failingSites": [
-        "http://www.e-bikeshop.co.uk/",
-        "http://labyrinthos.co/",
-        "http://ejbf.co.uk/",
-        "http://www.sarahraven.com/",
-        "http://hyundaipowerequipment.co.uk/"
+        "http://www.scarpa.co.uk/",
+        "http://www.the-home-brew-shop.co.uk/",
+        "http://supernote.com/",
+        "http://www.poundland.co.uk/",
+        "http://tufferman.co.uk/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 3,
+      "sites": 4,
       "errors": 0,
-      "selfTestFailures": 2,
+      "selfTestFailures": 3,
       "exampleSites": [
+        "http://www.bubsnaturals.com/",
         "http://www.goodandbeautiful.com/",
         "http://www.muji.us/"
       ],
       "failingSites": [
+        "http://www.bubsnaturals.com/",
         "http://www.goodandbeautiful.com/",
         "http://www.muji.us/"
       ],
@@ -5352,43 +5421,42 @@
   },
   "snigel": {
     "DE": {
-      "sites": 22,
+      "sites": 19,
       "errors": 0,
       "selfTestFailures": 5,
       "exampleSites": [
-        "http://www.ultimatespecs.com/",
-        "http://www.linguee.com/",
-        "http://www.trueachievements.com/",
-        "http://www.manualslib.tech/",
-        "http://www.dict.cc/"
+        "http://civitai.com/",
+        "http://www.notebookcheck.com/",
+        "http://www.rapidtables.com/",
+        "http://www.linguee.de/",
+        "http://www.buchstaben.com/"
       ],
       "failingSites": [
         "http://civitai.com/",
         "http://steamcharts.com/",
+        "http://www.blackdesertfoundry.com/",
         "http://www.dieblaue24.com/",
-        "http://www.geoguessr.com/",
-        "http://www.trueachievements.com/"
+        "http://www.geoguessr.com/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 20,
+      "sites": 18,
       "errors": 0,
-      "selfTestFailures": 5,
+      "selfTestFailures": 4,
       "exampleSites": [
-        "http://www.linguee.com/",
-        "http://www.linguee.fr/",
-        "http://www.manualslib.com/",
+        "http://www.holiday-weather.com/",
         "http://www.isitdownrightnow.com/",
-        "http://www.dict.cc/"
+        "http://www.linguee.fr/",
+        "http://www.crosswordsolver.org/",
+        "http://www.fmscout.com/"
       ],
       "failingSites": [
         "http://civitai.com/",
         "http://steamcharts.com/",
         "http://www.engineeringtoolbox.com/",
-        "http://www.geoguessr.com/",
-        "http://www.trueachievements.com/"
+        "http://www.geoguessr.com/"
       ],
       "unsuccessfulSites": [],
       "errorSites": []
@@ -5470,13 +5538,15 @@
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
-    },
+    }
+  },
+  "summitracing": {
     "US": {
       "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.thebulwark.com/"
+        "http://www.dxengineering.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -5528,6 +5598,17 @@
     }
   },
   "tagconcierge": {
+    "GB": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.classicstoday.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
     "US": {
       "sites": 1,
       "errors": 0,
@@ -5544,15 +5625,16 @@
     "DE": {
       "sites": 6,
       "errors": 0,
-      "selfTestFailures": 0,
+      "selfTestFailures": 1,
       "exampleSites": [
         "http://de.geneanet.org/",
-        "http://gw.geneanet.org/",
         "http://www.certificat-air.gouv.fr/",
-        "http://www.uni-osnabrueck.de/",
-        "http://www.visit.alsace/"
+        "http://www.ibantest.com/",
+        "http://www.uni-osnabrueck.de/"
       ],
-      "failingSites": [],
+      "failingSites": [
+        "http://www.feuerwerk-fanpage.de/"
+      ],
       "unsuccessfulSites": [],
       "errorSites": []
     },
@@ -5570,11 +5652,12 @@
       "errorSites": []
     },
     "US": {
-      "sites": 1,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://lingvanex.com/"
+        "http://lingvanex.com/",
+        "http://www.everquestlegends.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -5585,11 +5668,14 @@
     "DE": {
       "sites": 6,
       "errors": 0,
-      "selfTestFailures": 0,
+      "selfTestFailures": 1,
       "exampleSites": [
+        "http://www.feuerwerk-fanpage.de/",
         "http://www.stellenangebote.info/"
       ],
-      "failingSites": [],
+      "failingSites": [
+        "http://www.feuerwerk-fanpage.de/"
+      ],
       "unsuccessfulSites": [],
       "errorSites": []
     },
@@ -5603,7 +5689,7 @@
       "errorSites": []
     },
     "US": {
-      "sites": 1,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [],
@@ -5647,15 +5733,15 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 6,
+      "sites": 8,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.greeka.com/",
-        "http://www.leedsunited.com/",
-        "http://www.manchestertheatres.com/",
+        "http://concretecaptain.com/",
+        "http://www.useyourlocal.com/",
         "http://www.sabre-roads.org.uk/",
-        "http://www.tt2.co.uk/"
+        "http://www.travelsouthyorkshire.com/",
+        "http://www.manchestertheatres.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -5703,12 +5789,37 @@
   },
   "tesco": {
     "GB": {
-      "sites": 2,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://secure.tesco.com/",
         "http://tesco.com/",
         "http://www.tesco.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    }
+  },
+  "theguardian.com": {
+    "DE": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.theguardian.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.theguardian.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -5748,34 +5859,6 @@
       "errorSites": []
     }
   },
-  "toyota": {
-    "US": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 1,
-      "exampleSites": [
-        "http://autoparts.toyota.com/"
-      ],
-      "failingSites": [
-        "http://autoparts.toyota.com/"
-      ],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
-  "tplink": {
-    "DE": {
-      "sites": 1,
-      "errors": 0,
-      "selfTestFailures": 0,
-      "exampleSites": [
-        "http://www.tp-link.com/"
-      ],
-      "failingSites": [],
-      "unsuccessfulSites": [],
-      "errorSites": []
-    }
-  },
   "trader-joes-com": {
     "US": {
       "sites": 1,
@@ -5791,45 +5874,45 @@
   },
   "transcend": {
     "DE": {
-      "sites": 11,
+      "sites": 10,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://1password.com/",
-        "http://www.mozilla.org/",
-        "http://www.ralphlauren.de/",
-        "http://www.eventbrite.de/",
-        "http://www.grammarly.com/"
+        "http://www.notion.com/",
+        "http://www.kfc.de/",
+        "http://www.postman.com/",
+        "http://www.mozilla.org/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 17,
+      "sites": 16,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.eventbrite.com/",
-        "http://grammarly.com/",
-        "http://www.grammarly.com/",
-        "http://www.depop.com/",
-        "http://www.snapfish.co.uk/"
+        "http://www.ralphlauren.co.uk/",
+        "http://www.mozilla.org/",
+        "http://www.pizzahut.co.uk/",
+        "http://theordinary.com/",
+        "http://www.udiscovermusic.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 34,
+      "sites": 37,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://www.fubo.tv/",
-        "http://www.mayoclinichealthsystem.org/",
-        "http://www.pizzahut.com/",
-        "http://verizon.com/",
-        "http://www.hims.com/"
+        "http://www.taylorfrancis.com/",
+        "http://www.tacobell.com/",
+        "http://customerservice.costco.com/",
+        "http://www.verizonwireless.com/",
+        "http://www.hagerty.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -5838,7 +5921,7 @@
   },
   "truyo": {
     "US": {
-      "sites": 4,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
@@ -5961,10 +6044,11 @@
   },
   "ubuntu.com": {
     "DE": {
-      "sites": 2,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://discourse.ubuntu.com/",
         "http://snapcraft.io/",
         "http://ubuntu.com/"
       ],
@@ -5999,36 +6083,32 @@
   },
   "usercentrics-api": {
     "DE": {
-      "sites": 589,
-      "errors": 0,
-      "selfTestFailures": 2,
-      "exampleSites": [
-        "http://hrewards.com/",
-        "http://www.ullapopken.de/",
-        "http://betzold.de/",
-        "http://www.droemer-knaur.de/",
-        "http://www.radiobob.de/"
-      ],
-      "failingSites": [
-        "http://mytheresa.com/",
-        "http://www.mytheresa.com/"
-      ],
-      "unsuccessfulSites": [
-        "http://www.condor.com/",
-        "http://www.hood.de/"
-      ],
-      "errorSites": []
-    },
-    "GB": {
-      "sites": 74,
+      "sites": 603,
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://birkenstock.com/",
-        "http://www.iso.org/",
-        "http://www.myunidays.com/",
-        "http://flo.health/",
-        "http://notino.co.uk/"
+        "http://betzold.de/",
+        "http://www.capitalo.de/",
+        "http://www.carlsen.de/",
+        "http://www.kiwi-verlag.de/",
+        "http://www.aufbau-verlage.de/"
+      ],
+      "failingSites": [
+        "http://www.mytheresa.com/"
+      ],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 81,
+      "errors": 0,
+      "selfTestFailures": 1,
+      "exampleSites": [
+        "http://www.trivago.co.uk/",
+        "http://www.siemens.com/",
+        "http://parkhome-living.co.uk/",
+        "http://www.longines.com/",
+        "http://mytheresa.com/"
       ],
       "failingSites": [
         "http://mytheresa.com/"
@@ -6037,15 +6117,15 @@
       "errorSites": []
     },
     "US": {
-      "sites": 29,
+      "sites": 30,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://bibleproject.com/",
+        "http://www.fedex.com/",
         "http://fedex.com/",
-        "http://www.enbridgegas.com/",
-        "http://www.swansonvitamins.com/",
-        "http://preply.com/"
+        "http://www.massagebook.com/",
+        "http://www.office.fedex.com/",
+        "http://www.winnebago.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -6054,15 +6134,14 @@
   },
   "usercentrics-button": {
     "DE": {
-      "sites": 8,
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 1,
       "exampleSites": [
-        "http://bos-fahrzeuge.info/",
         "http://docs.typo3.org/",
-        "http://www.advocard.de/",
-        "http://www.studierendenwerk-aachen.de/",
-        "http://www.staerkergegenkrebs.de/"
+        "http://www.bsb.de/",
+        "http://www.staerkergegenkrebs.de/",
+        "http://www.wbs.legal/"
       ],
       "failingSites": [
         "http://docs.typo3.org/"
@@ -6101,15 +6180,15 @@
   },
   "web.de": {
     "DE": {
-      "sites": 7,
+      "sites": 6,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://anmelden.gmx.net/",
         "http://anmelden.web.de/",
-        "http://hilfe.gmx.net/",
+        "http://www.gmx.net/",
         "http://hilfe.web.de/",
-        "http://www.gmx.at/"
+        "http://web.de/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -6118,13 +6197,23 @@
   },
   "webflow": {
     "DE": {
-      "sites": 3,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://www.emobility.energy/",
-        "http://www.horoskop-paradies.ch/",
         "http://www.whk-controlling.de/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [],
+      "errorSites": []
+    },
+    "GB": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://www.ljmu.ac.uk/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -6133,29 +6222,29 @@
   },
   "wiki.gg": {
     "DE": {
-      "sites": 10,
+      "sites": 12,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://ark.wiki.gg/",
-        "http://pve.proxmox.com/",
+        "http://fieldsofmistria.wiki.gg/",
+        "http://calamitymod.wiki.gg/",
         "http://de.pornopedia.com/",
-        "http://de.wiki-aventurica.de/",
-        "http://satisfactory.wiki.gg/"
+        "http://palworld.wiki.gg/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "GB": {
-      "sites": 8,
+      "sites": 11,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://abioticfactor.wiki.gg/",
-        "http://pve.proxmox.com/",
+        "http://palia.wiki.gg/",
         "http://bindingofisaacrebirth.wiki.gg/",
-        "http://calamitymod.wiki.gg/",
+        "http://pve.proxmox.com/",
+        "http://fieldsofmistria.wiki.gg/",
         "http://limbuscompany.wiki.gg/"
       ],
       "failingSites": [],
@@ -6163,15 +6252,15 @@
       "errorSites": []
     },
     "US": {
-      "sites": 12,
+      "sites": 13,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://abioticfactor.wiki.gg/",
         "http://ark.wiki.gg/",
-        "http://arknights.wiki.gg/",
-        "http://calamitymod.wiki.gg/",
-        "http://palia.wiki.gg/"
+        "http://bindingofisaacrebirth.wiki.gg/",
+        "http://pve.proxmox.com/",
+        "http://eyewiki.org/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
@@ -6180,11 +6269,10 @@
   },
   "wix": {
     "DE": {
-      "sites": 2,
+      "sites": 1,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://de.wix.com/",
         "http://www.wix.com/"
       ],
       "failingSites": [],
@@ -6215,6 +6303,21 @@
       "errorSites": []
     }
   },
+  "woo-commerce-com": {
+    "GB": {
+      "sites": 1,
+      "errors": 0,
+      "selfTestFailures": 0,
+      "exampleSites": [
+        "http://woocommerce.com/"
+      ],
+      "failingSites": [],
+      "unsuccessfulSites": [
+        "http://woocommerce.com/"
+      ],
+      "errorSites": []
+    }
+  },
   "wpcc": {
     "DE": {
       "sites": 1,
@@ -6228,23 +6331,24 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 3,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://thisvid.com/",
-        "http://www.askmid.com/",
-        "http://www.thisvid.com/"
+        "http://www.askmid.com/"
       ],
       "failingSites": [],
       "unsuccessfulSites": [],
       "errorSites": []
     },
     "US": {
-      "sites": 1,
+      "sites": 3,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
+        "http://fr.thisvid.com/",
+        "http://thisvid.com/",
         "http://www.thisvid.com/"
       ],
       "failingSites": [],
@@ -6284,14 +6388,14 @@
   },
   "xhamster-eu": {
     "DE": {
-      "sites": 7,
+      "sites": 11,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://fra.xhamster.com/",
         "http://xhamster3.com/",
         "http://ge.xhamster3.com/",
-        "http://ita.xhamster.com/",
+        "http://id.xhamster.com/",
         "http://xhamster.com/"
       ],
       "failingSites": [],
@@ -6299,11 +6403,12 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 4,
+      "sites": 5,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://fra.xhamster.com/",
+        "http://ru.xhamster.com/",
         "http://xhamster.com/",
         "http://xhamster2.com/",
         "http://xhamster3.com/"
@@ -6315,14 +6420,14 @@
   },
   "xhamster-us": {
     "US": {
-      "sites": 7,
+      "sites": 6,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
-        "http://xhamster2.com/",
+        "http://es.xhamster.com/",
         "http://fra.xhamster.com/",
         "http://id.xhamster.com/",
-        "http://jp.xhamster.com/",
+        "http://xhamster.com/",
         "http://xhamster3.com/"
       ],
       "failingSites": [],
@@ -6332,16 +6437,19 @@
   },
   "xnxx-com": {
     "GB": {
-      "sites": 3,
+      "sites": 4,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://en.xnxx.place/",
+        "http://www.pornorama.com/",
         "http://www.xnxx.com/",
         "http://www.xvideos.tube/"
       ],
       "failingSites": [],
-      "unsuccessfulSites": [],
+      "unsuccessfulSites": [
+        "http://www.pornorama.com/"
+      ],
       "errorSites": []
     }
   },
@@ -6372,12 +6480,11 @@
       "errorSites": []
     },
     "GB": {
-      "sites": 3,
+      "sites": 2,
       "errors": 0,
       "selfTestFailures": 0,
       "exampleSites": [
         "http://uk.youtube.com/",
-        "http://www.youtube.co.uk/",
         "http://www.youtube.com/"
       ],
       "failingSites": [],


### PR DESCRIPTION
Rule coverage stats from the latest crawl.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only refresh of crawl statistics; no extension or rule logic changes.
> 
> **Overview**
> Refreshes **`data/coverage.json`** with the latest tracker-radar crawl stats (US, DE, GB top sites) so rule coverage, example URLs, and failure lists stay current for tests and rule maintenance.
> 
> Per-rule **`sites`** counts and **`exampleSites`** / **`failingSites`** / **`unsuccessfulSites`** lists shift across CMPs (e.g. Onetrust, Sourcepoint, consentmanager, HEURISTIC tiers, Shopify). Some rule keys are **added** (e.g. `gmx-permission`, `cookieacceptbar`, `pornhub-compact-cookie-banner`, `samsung.com`, `scmp`, `summitracing`, `theguardian.com`, `woo-commerce-com`) and **`WP DSGVO Tools`** is **removed**; a few regional entries move (e.g. `amex` US, `openai` DE→GB, `police-uk` / `sandhills` / `toyota` / `tplink` dropped from the snapshot).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d95e8fa6ab60d9f6adf895c43c1ad51c457deeb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->