### PR TITLE
Rule update: CPM crawl #1635: darty.com

### DIFF
--- a/rules/autoconsent/appconsent-legacy.json
+++ b/rules/autoconsent/appconsent-legacy.json
@@ -1,0 +1,31 @@
+{
+    "name": "AppConsent legacy",
+    "prehideSelectors": ["iframe[srcdoc*='frame-root']"],
+    "detectCmp": [
+        {
+            "exists": "script[src*='cdn.appconsent.io/tcf2/'][src*='core.bundle.js']"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "iframe[srcdoc*='frame-root']"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": ["iframe[srcdoc*='frame-root']", ".button__acceptAll"]
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": ["iframe[srcdoc*='frame-root']", ".button__skip"]
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "iframe[srcdoc*='frame-root']",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/rules/autoconsent/appconsent.json
+++ b/rules/autoconsent/appconsent.json
@@ -1,36 +1,29 @@
 {
     "name": "AppConsent",
-    "prehideSelectors": ["iframe[title='Consent window']", "iframe[srcdoc*='frame-root']"],
+    "prehideSelectors": ["iframe[title='Consent window']"],
     "detectCmp": [
         {
-            "exists": "script[src*='cdn.appconsent.io'][src*='core.bundle.js']"
+            "exists": "script[src*='cdn.appconsent.io/tcf2-clear/'][src*='core.bundle.js']"
         }
     ],
     "detectPopup": [
         {
-            "visible": "iframe[title='Consent window'], iframe[srcdoc*='frame-root']"
+            "visible": "iframe[title='Consent window']"
         }
     ],
     "optIn": [
         {
-            "waitForThenClick": ["iframe[title='Consent window'], iframe[srcdoc*='frame-root']", ".button__acceptAll"]
+            "waitForThenClick": ["iframe[title='Consent window']", ".button__acceptAll"]
         }
     ],
     "optOut": [
         {
-            "any": [
-                {
-                    "waitForThenClick": ["iframe[title='Consent window'], iframe[srcdoc*='frame-root']", ".button__skip"]
-                },
-                {
-                    "waitForThenClick": ["iframe[title='Consent window'], iframe[srcdoc*='frame-root']", ".button__refuseAll"]
-                }
-            ]
+            "waitForThenClick": ["iframe[title='Consent window']", ".button__refuseAll"]
         }
     ],
     "test": [
         {
-            "waitForVisible": "iframe[title='Consent window'], iframe[srcdoc*='frame-root']",
+            "waitForVisible": "iframe[title='Consent window']",
             "timeout": 1000,
             "check": "none"
         }

--- a/rules/autoconsent/appconsent.json
+++ b/rules/autoconsent/appconsent.json
@@ -1,6 +1,6 @@
 {
     "name": "AppConsent",
-    "prehideSelectors": ["iframe[title='Consent window']"],
+    "prehideSelectors": ["iframe[title='Consent window']", "iframe[srcdoc*='frame-root']"],
     "detectCmp": [
         {
             "exists": "script[src*='cdn.appconsent.io'][src*='core.bundle.js']"
@@ -8,22 +8,29 @@
     ],
     "detectPopup": [
         {
-            "visible": "iframe[title='Consent window']"
+            "visible": "iframe[title='Consent window'], iframe[srcdoc*='frame-root']"
         }
     ],
     "optIn": [
         {
-            "waitForThenClick": ["iframe[title='Consent window']", ".button__acceptAll"]
+            "waitForThenClick": ["iframe[title='Consent window'], iframe[srcdoc*='frame-root']", ".button__acceptAll"]
         }
     ],
     "optOut": [
         {
-            "waitForThenClick": ["iframe[title='Consent window']", ".button__refuseAll"]
+            "any": [
+                {
+                    "waitForThenClick": ["iframe[title='Consent window'], iframe[srcdoc*='frame-root']", ".button__skip"]
+                },
+                {
+                    "waitForThenClick": ["iframe[title='Consent window'], iframe[srcdoc*='frame-root']", ".button__refuseAll"]
+                }
+            ]
         }
     ],
     "test": [
         {
-            "waitForVisible": "iframe[title='Consent window']",
+            "waitForVisible": "iframe[title='Consent window'], iframe[srcdoc*='frame-root']",
             "timeout": 1000,
             "check": "none"
         }

--- a/rules/autoconsent/appconsent.json
+++ b/rules/autoconsent/appconsent.json
@@ -1,0 +1,31 @@
+{
+    "name": "AppConsent",
+    "prehideSelectors": ["iframe[title='Consent window']"],
+    "detectCmp": [
+        {
+            "exists": "script[src*='cdn.appconsent.io'][src*='core.bundle.js']"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "iframe[title='Consent window']"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": ["iframe[title='Consent window']", ".button__acceptAll"]
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": ["iframe[title='Consent window']", ".button__refuseAll"]
+        }
+    ],
+    "test": [
+        {
+            "waitForVisible": "iframe[title='Consent window']",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/tests/appconsent-legacy.spec.ts
+++ b/tests/appconsent-legacy.spec.ts
@@ -1,6 +1,6 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('AppConsent', ['https://magasin.darty.com/'], {
+generateCMPTests('AppConsent legacy', ['https://www.meteociel.fr/'], {
     testOptIn: false,
     testOptOut: true,
     onlyRegions: ['US', 'FR'],

--- a/tests/appconsent.spec.ts
+++ b/tests/appconsent.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('AppConsent', ['https://magasin.darty.com/', 'https://www.meteociel.fr/']);

--- a/tests/appconsent.spec.ts
+++ b/tests/appconsent.spec.ts
@@ -3,5 +3,5 @@ import generateCMPTests from '../playwright/runner';
 generateCMPTests('AppConsent', ['https://magasin.darty.com/', 'https://www.meteociel.fr/'], {
     testOptIn: false,
     testOptOut: true,
-    onlyRegions: ['US', 'FR']
+    onlyRegions: ['US', 'FR'],
 });

--- a/tests/appconsent.spec.ts
+++ b/tests/appconsent.spec.ts
@@ -2,6 +2,6 @@ import generateCMPTests from '../playwright/runner';
 
 generateCMPTests('AppConsent', ['https://magasin.darty.com/', 'https://www.meteociel.fr/'], {
     testOptIn: false,
-    testOptOut: false,
-    expectPopupOpen: false,
+    testOptOut: true,
+    onlyRegions: ['US', 'FR']
 });

--- a/tests/appconsent.spec.ts
+++ b/tests/appconsent.spec.ts
@@ -1,3 +1,7 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('AppConsent', ['https://magasin.darty.com/', 'https://www.meteociel.fr/']);
+generateCMPTests('AppConsent', ['https://magasin.darty.com/', 'https://www.meteociel.fr/'], {
+    testOptIn: false,
+    testOptOut: false,
+    expectPopupOpen: false,
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217312076587151?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New CMP detection/click rules and test URLs only; no changes to core extension logic or shared infrastructure.
> 
> **Overview**
> Adds **autoconsent** coverage for AppConsent’s two embed variants so opt-out can run on sites like Darty from the CPM crawl.
> 
> A new **`AppConsent`** rule targets the `tcf2-clear` script bundle and a consent iframe titled `Consent window`, with **opt-out** via `.button__refuseAll` inside that iframe (opt-in paths exist but tests skip opt-in). A separate **`AppConsent legacy`** rule covers the older `tcf2/` bundle and an iframe whose `srcdoc` contains `frame-root`, with legacy opt-out on `.button__skip`.
> 
> Playwright specs register **`magasin.darty.com`** for the modern rule and **`meteociel.fr`** for legacy, both **US/FR** regions and **opt-out-only** tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79567f4f938a38becc5ad315447f5fb57e680298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->