### PR TITLE
Rule update: CPM crawl cluster #415: landmarkcinemas.com (consentmanager.net|inert, 14 sites)

### DIFF
--- a/lib/cmps/consentmanager.ts
+++ b/lib/cmps/consentmanager.ts
@@ -5,11 +5,12 @@ import AutoConsentCMPBase from './base';
 export default class ConsentManager extends AutoConsentCMPBase {
     name = 'consentmanager.net';
 
-    prehideSelectors = ['#cmpbox,#cmpbox2'];
+    prehideSelectors = ['#cmpbox,#cmpbox2,#ncmp__tool .ncmp__banner'];
     apiAvailable = false;
+    ncmpAvailable = false;
 
     get hasSelfTest(): boolean {
-        return this.apiAvailable;
+        return this.apiAvailable || this.ncmpAvailable;
     }
 
     get isIntermediate(): boolean {
@@ -21,6 +22,11 @@ export default class ConsentManager extends AutoConsentCMPBase {
     }
 
     async detectCmp() {
+        this.ncmpAvailable = this.elementExists('#ncmp__tool .ncmp__banner.ncmp__active');
+        if (this.ncmpAvailable) {
+            return true;
+        }
+
         this.apiAvailable = await this.mainWorldEval('EVAL_CONSENTMANAGER_1');
         if (!this.apiAvailable) {
             return this.elementExists('#cmpbox');
@@ -30,6 +36,10 @@ export default class ConsentManager extends AutoConsentCMPBase {
     }
 
     async detectPopup() {
+        if (this.ncmpAvailable) {
+            return this.elementVisible('#ncmp__tool .ncmp__banner.ncmp__active', 'any');
+        }
+
         if (this.elementVisible('#cmpbox .cmpmore', 'any')) {
             return true;
         } else if (this.apiAvailable) {
@@ -43,6 +53,17 @@ export default class ConsentManager extends AutoConsentCMPBase {
 
     async optOut() {
         await this.wait(500);
+        if (this.ncmpAvailable || this.elementExists('#ncmp__tool .ncmp__banner')) {
+            if (await this.mainWorldEval('EVAL_CONSENTMANAGER_NCMP_REJECT')) {
+                return true;
+            }
+
+            if (!this.elementExists('button[onclick*="reject"].ncmp__btn-danger')) {
+                await this.waitForThenClick('button[onclick*="showModal"].ncmp__btn-border', 5000);
+            }
+            return await this.waitForThenClick('button[onclick*="reject"].ncmp__btn-danger', 5000);
+        }
+
         if (this.apiAvailable) {
             return await this.mainWorldEval('EVAL_CONSENTMANAGER_3');
         }
@@ -67,6 +88,14 @@ export default class ConsentManager extends AutoConsentCMPBase {
     }
 
     async optIn() {
+        if (this.ncmpAvailable || this.elementExists('#ncmp__tool .ncmp__banner')) {
+            if (await this.mainWorldEval('EVAL_CONSENTMANAGER_NCMP_ACCEPT')) {
+                return true;
+            }
+
+            return await this.waitForThenClick('button[onclick*="save"].ncmp__btn', 5000);
+        }
+
         if (this.apiAvailable) {
             return await this.mainWorldEval('EVAL_CONSENTMANAGER_4');
         }
@@ -74,6 +103,10 @@ export default class ConsentManager extends AutoConsentCMPBase {
     }
 
     async test() {
+        if (this.ncmpAvailable) {
+            return this.cookieContains('ncmp=');
+        }
+
         if (this.apiAvailable) {
             return await this.mainWorldEval('EVAL_CONSENTMANAGER_5');
         }

--- a/lib/cmps/consentmanager.ts
+++ b/lib/cmps/consentmanager.ts
@@ -5,12 +5,11 @@ import AutoConsentCMPBase from './base';
 export default class ConsentManager extends AutoConsentCMPBase {
     name = 'consentmanager.net';
 
-    prehideSelectors = ['#cmpbox,#cmpbox2,#ncmp__tool .ncmp__banner'];
+    prehideSelectors = ['#cmpbox,#cmpbox2'];
     apiAvailable = false;
-    ncmpAvailable = false;
 
     get hasSelfTest(): boolean {
-        return this.apiAvailable || this.ncmpAvailable;
+        return this.apiAvailable;
     }
 
     get isIntermediate(): boolean {
@@ -22,11 +21,6 @@ export default class ConsentManager extends AutoConsentCMPBase {
     }
 
     async detectCmp() {
-        this.ncmpAvailable = this.elementExists('#ncmp__tool .ncmp__banner.ncmp__active');
-        if (this.ncmpAvailable) {
-            return true;
-        }
-
         this.apiAvailable = await this.mainWorldEval('EVAL_CONSENTMANAGER_1');
         if (!this.apiAvailable) {
             return this.elementExists('#cmpbox');
@@ -36,10 +30,6 @@ export default class ConsentManager extends AutoConsentCMPBase {
     }
 
     async detectPopup() {
-        if (this.ncmpAvailable) {
-            return this.elementVisible('#ncmp__tool .ncmp__banner.ncmp__active', 'any');
-        }
-
         if (this.elementVisible('#cmpbox .cmpmore', 'any')) {
             return true;
         } else if (this.apiAvailable) {
@@ -53,17 +43,6 @@ export default class ConsentManager extends AutoConsentCMPBase {
 
     async optOut() {
         await this.wait(500);
-        if (this.ncmpAvailable || this.elementExists('#ncmp__tool .ncmp__banner')) {
-            if (await this.mainWorldEval('EVAL_CONSENTMANAGER_NCMP_REJECT')) {
-                return true;
-            }
-
-            if (!this.elementExists('button[onclick*="reject"].ncmp__btn-danger')) {
-                await this.waitForThenClick('button[onclick*="showModal"].ncmp__btn-border', 5000);
-            }
-            return await this.waitForThenClick('button[onclick*="reject"].ncmp__btn-danger', 5000);
-        }
-
         if (this.apiAvailable) {
             return await this.mainWorldEval('EVAL_CONSENTMANAGER_3');
         }
@@ -88,14 +67,6 @@ export default class ConsentManager extends AutoConsentCMPBase {
     }
 
     async optIn() {
-        if (this.ncmpAvailable || this.elementExists('#ncmp__tool .ncmp__banner')) {
-            if (await this.mainWorldEval('EVAL_CONSENTMANAGER_NCMP_ACCEPT')) {
-                return true;
-            }
-
-            return await this.waitForThenClick('button[onclick*="save"].ncmp__btn', 5000);
-        }
-
         if (this.apiAvailable) {
             return await this.mainWorldEval('EVAL_CONSENTMANAGER_4');
         }
@@ -103,10 +74,6 @@ export default class ConsentManager extends AutoConsentCMPBase {
     }
 
     async test() {
-        if (this.ncmpAvailable) {
-            return this.cookieContains('ncmp=');
-        }
-
         if (this.apiAvailable) {
             return await this.mainWorldEval('EVAL_CONSENTMANAGER_5');
         }

--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -22,11 +22,24 @@ export const snippets = {
         const disabled = window.Didomi?.getUserConsentStatusForAll?.()?.purposes?.disabled;
         return Array.isArray(disabled) && disabled.length > 0;
     },
-    EVAL_CONSENTMANAGER_1: () => window.__cmp && typeof __cmp('getCMPData') === 'object',
-    EVAL_CONSENTMANAGER_2: () => !__cmp('consentStatus').userChoiceExists,
+    EVAL_CONSENTMANAGER_1: () => {
+        const cmpData = window.__cmp?.('getCMPData');
+        return !!cmpData && typeof cmpData === 'object';
+    },
+    EVAL_CONSENTMANAGER_2: () => window.__cmp?.('consentStatus')?.userChoiceExists === false,
     EVAL_CONSENTMANAGER_3: () => __cmp('setConsent', 0),
     EVAL_CONSENTMANAGER_4: () => __cmp('setConsent', 1),
     EVAL_CONSENTMANAGER_5: () => __cmp('consentStatus').userChoiceExists,
+    EVAL_CONSENTMANAGER_NCMP_REJECT: () => {
+        if (typeof window.__npcmp !== 'function') return false;
+        window.__npcmp('reject');
+        return true;
+    },
+    EVAL_CONSENTMANAGER_NCMP_ACCEPT: () => {
+        if (typeof window.__npcmp !== 'function') return false;
+        window.__npcmp('save');
+        return true;
+    },
     EVAL_COOKIEBOT_1: () => !!window.Cookiebot,
     EVAL_COOKIEBOT_2: () => !window.Cookiebot.hasResponse && window.Cookiebot.dialog?.visible === true,
     EVAL_COOKIEBOT_3: () => window.Cookiebot.withdraw() || true,

--- a/rules/autoconsent/consentmanager-ncmp.json
+++ b/rules/autoconsent/consentmanager-ncmp.json
@@ -1,0 +1,34 @@
+{
+    "name": "consentmanager-ncmp",
+    "vendorUrl": "https://www.consentmanager.net/",
+    "prehideSelectors": ["#ncmp__tool .ncmp__banner"],
+    "detectCmp": [
+        {
+            "exists": "#ncmp__tool .ncmp__banner.ncmp__active"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#ncmp__tool .ncmp__banner.ncmp__active",
+            "check": "any"
+        }
+    ],
+    "optIn": [
+        {
+            "eval": "EVAL_CONSENTMANAGER_NCMP_ACCEPT"
+        }
+    ],
+    "optOut": [
+        {
+            "wait": 500
+        },
+        {
+            "eval": "EVAL_CONSENTMANAGER_NCMP_REJECT"
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "ncmp="
+        }
+    ]
+}

--- a/tests/consentmanager-ncmp.spec.ts
+++ b/tests/consentmanager-ncmp.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('consentmanager-ncmp', ['https://www.royalroad.com/', 'https://www.lolalytics.com/'], {
+    onlyRegions: ['DE'],
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217179883196513?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CMP detection/eval snippets and a new autoconsent rule; no auth, data, or core app logic. Slight behavior change on legacy `__cmp` detect when APIs are absent (false instead of errors).
> 
> **Overview**
> Adds autoconsent support for **consentmanager.net**’s NCMP banner (`#ncmp__tool`), using `__npcmp('reject')` / `__npcmp('save')` for opt-out and opt-in, with detection on the active banner and verification via an `ncmp=` cookie.
> 
> **Existing `__cmp` evals** (`EVAL_CONSENTMANAGER_1` / `2`) are tightened with optional chaining so missing `__cmp` or `consentStatus` no longer throws; `EVAL_CONSENTMANAGER_2` now explicitly checks `userChoiceExists === false`.
> 
> Playwright coverage runs the new rule against royalroad.com and lolalytics.com, **DE only**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9f5fb0280d650ce5b72c380c0571a925850034e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->