### PR TITLE
Rule update: Don't agree button on takahashikougei.com

### DIFF
--- a/lib/eval-snippets.ts
+++ b/lib/eval-snippets.ts
@@ -145,6 +145,7 @@ export const snippets = {
             if (x.checked) x.click();
         }) || true,
     EVAL_IUBENDA_1: () => !!document.cookie.match(/_iub_cs-\d+=/),
+    EVAL_KROWN_COOKIE_BANNER_TEST: () => localStorage.getItem('krown-cookie-banner') === 'true',
     EVAL_MICROSOFT_0: () =>
         Array.from(document.querySelectorAll('div > button'))
             .filter((el) => el.innerText.match('Reject|Ablehnen'))[0]

--- a/rules/autoconsent/krown-cookie-banner.json
+++ b/rules/autoconsent/krown-cookie-banner.json
@@ -1,0 +1,34 @@
+{
+    "name": "krown-cookie-banner",
+    "vendorUrl": "https://krownthemes.com/",
+    "cosmetic": false,
+    "prehideSelectors": ["modal-box[data-options*=\"cookies\"] .modal-object--cookie"],
+    "detectCmp": [
+        {
+            "exists": ".modal-object--cookie [data-js-cookies-decline]"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": ".modal-object--cookie [data-js-cookies-decline]"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": ".modal-object--cookie [data-js-cookies-accept]"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": ".modal-object--cookie [data-js-cookies-decline]"
+        }
+    ],
+    "test": [
+        {
+            "wait": 500
+        },
+        {
+            "eval": "EVAL_KROWN_COOKIE_BANNER_TEST"
+        }
+    ]
+}

--- a/tests/krown-cookie-banner.spec.ts
+++ b/tests/krown-cookie-banner.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('krown-cookie-banner', ['https://www.takahashikougei.com/', 'https://luxolor.com/', 'https://startmovin.com/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217404565866217?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated autoconsent rule and eval snippet with no auth, security, or sensitive data handling changes.
> 
> **Overview**
> Adds autoconsent support for **Krown Themes** cookie modals so sites like `takahashikougei.com` can **decline** cookies instead of being auto-accepted.
> 
> The new rule `krown-cookie-banner` detects the `.modal-object--cookie` UI, pre-hides the modal, clicks **accept** on opt-in and **decline** on opt-out, and verifies success via `localStorage` key `krown-cookie-banner` through `EVAL_KROWN_COOKIE_BANNER_TEST`. Playwright CMP tests cover three live URLs including takahashikougei.com.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1af9dae0fe7e872015d73e0716e16d2890c431a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->