### PR TITLE
Rule update: CPM crawl #222: pornpics.de

### DIFF
--- a/rules/autoconsent/pornpics-de.json
+++ b/rules/autoconsent/pornpics-de.json
@@ -1,0 +1,13 @@
+{
+    "name": "pornpics.de",
+    "runContext": {
+        "urlPattern": "^https?://(www\\.)?pornpics\\.de/"
+    },
+    "detectCmp": [{ "exists": "#cookie-form" }],
+    "detectPopup": [{ "visible": "#cookie-form" }],
+    "optIn": [{ "waitForThenClick": "#cookie-form .accept" }],
+    "optOut": [{ "waitForThenClick": "#cookie-form .reject" }],
+    "test": [
+        { "cookieContains": "_cookieNoticeSettings=%7B%22performance%22%3Afalse%2C%22targeting%22%3Afalse%2C%22analytic%22%3Afalse%7D" }
+    ]
+}

--- a/tests/pornpics-de.spec.ts
+++ b/tests/pornpics-de.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('pornpics.de', ['https://www.pornpics.de/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217309196855406?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated site rule and test file only; no changes to shared autoconsent or runner logic.
> 
> **Overview**
> Adds **autoconsent** coverage for **pornpics.de** via a new rule that targets `#cookie-form`, accepts with `.accept`, rejects with `.reject`, and validates opt-out via `_cookieNoticeSettings` in cookies.
> 
> A **Playwright** spec registers CMP tests against `https://www.pornpics.de/`, matching the usual pattern for site-specific rules in this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8030f053e095535aa5de2334ffd17331fa51131c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->