### PR TITLE
Rule update: ibanez

### DIFF
--- a/rules/autoconsent/ibanez.json
+++ b/rules/autoconsent/ibanez.json
@@ -1,0 +1,13 @@
+{
+    "name": "ibanez",
+    "vendorUrl": "https://www.ibanez.com/",
+    "runContext": {
+        "urlPattern": "^https?://www\\.ibanez\\.com/"
+    },
+    "prehideSelectors": ["#header-gdpr"],
+    "detectCmp": [{ "exists": "#header-gdpr #header-gdpr-in-btn button" }],
+    "detectPopup": [{ "visible": "#header-gdpr.is-active" }],
+    "optOut": [{ "waitForThenClick": "#header-gdpr #header-gdpr-in-btn button" }],
+    "optIn": [{ "waitForThenClick": "#header-gdpr #header-gdpr-in-btn button" }],
+    "test": [{ "cookieContains": "gdprCookieData=ok" }]
+}

--- a/tests/ibanez.spec.ts
+++ b/tests/ibanez.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('ibanez', ['https://www.ibanez.com/jp/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217451338790955?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

No existing autoconsent exception for ibanez.com was found in duckduckgo/privacy-configuration features/autoconsent.json or overrides. The popup is an in-scope custom cookie notice using #header-gdpr and /common/js/gdpr.js; PublicWWW did not identify a useful shared CMP pattern. Added a site-specific rule that clicks OK and self-tests gdprCookieData=ok. Reload verification confirmed the banner remains hidden and the rule does not act again after dismissal.

## Steps to test this PR:

- `npx playwright test tests/ibanez.spec.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive site-specific autoconsent rule and test only; no changes to shared consent logic or security-sensitive code.
> 
> **Overview**
> Adds **autoconsent coverage for ibanez.com** via a new `ibanez` rule and matching Playwright spec.
> 
> The rule targets the site’s custom GDPR header (`#header-gdpr`): it **pre-hides** the banner, detects the active popup and OK button, **clicks OK** for both opt-out and opt-in paths, and **verifies** dismissal with `gdprCookieData=ok`. URL scope is `www.ibanez.com`. Tests run against `https://www.ibanez.com/jp/` through the shared `generateCMPTests` runner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e05f4b4d74df79e65dca0760a654b2dcb6b70b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->