### PR TITLE
Rule update: fever

### DIFF
--- a/rules/autoconsent/fever.json
+++ b/rules/autoconsent/fever.json
@@ -1,0 +1,42 @@
+{
+    "name": "fever",
+    "prehideSelectors": ["astro-island[component-url*=\"CookiesBanner\"] .cookies"],
+    "detectCmp": [
+        {
+            "exists": "astro-island[component-url*=\"CookiesBanner\"] .cookies button.cookies__buttons--settings"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "astro-island[component-url*=\"CookiesBanner\"] .cookies"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "astro-island[component-url*=\"CookiesBanner\"] .cookies button.cookies__buttons--accept"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "astro-island[component-url*=\"CookiesBanner\"] .cookies button.cookies__buttons--settings"
+        },
+        {
+            "if": {
+                "exists": "astro-island[component-url*=\"CookiesBanner\"] .cookies input[name=\"targeting\"]:checked"
+            },
+            "then": [
+                {
+                    "click": "astro-island[component-url*=\"CookiesBanner\"] .cookies input[name=\"targeting\"]"
+                }
+            ]
+        },
+        {
+            "waitForThenClick": "astro-island[component-url*=\"CookiesBanner\"] .cookies button.cookies__buttons--accept"
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "cookiesPreferences=[%22necessary%22]"
+        }
+    ]
+}

--- a/tests/fever.spec.ts
+++ b/tests/fever.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('fever', ['https://nimrodsmovie2026.com/', 'https://kaleidoentertainment.com/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217183683897068?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

No existing privacy-configuration autoconsent exception or related PR was found for nimrodsmovie2026.com. PublicWWW found many Fever/Astro cookie banner matches, so a narrow generic Fever rule was added. The rule opens Settings, keeps only Necessary selected, saves, sets cookiesPreferences=[%22necessary%22], removes the banner, passes self-test, and does not re-detect after reload. Reported region value 'use' was treated as US.

## Steps to test this PR:

- `npx playwright test tests/fever.spec.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated autoconsent rule and tests only; no changes to shared runner logic or security-sensitive code.
> 
> **Overview**
> Adds a new **fever** autoconsent rule for Fever’s Astro `CookiesBanner` component, targeting sites such as nimrodsmovie2026.com and kaleidoentertainment.com.
> 
> The rule pre-hides the banner, detects it via the settings button, **opt-in** accepts all cookies, and **opt-out** opens Settings, unchecks targeting when needed, then saves so `cookiesPreferences` contains only necessary cookies. Self-test checks that cookie value.
> 
> Playwright coverage is added via `tests/fever.spec.ts` against the two example URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 266ea25b6a051036b0de5677dbe9f6cea1e0144f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->