### PR TITLE
Rule update: cookie-banner-element

### DIFF
--- a/rules/autoconsent/cookie-banner-element.json
+++ b/rules/autoconsent/cookie-banner-element.json
@@ -1,0 +1,8 @@
+{
+    "name": "cookie-banner-element",
+    "prehideSelectors": ["cookie-banner-element#ckb"],
+    "detectCmp": [{ "exists": "cookie-banner-element#ckb" }],
+    "detectPopup": [{ "visible": ["cookie-banner-element#ckb", "#ckb[role=\"dialog\"]"] }],
+    "optIn": [{ "waitForThenClick": ["cookie-banner-element#ckb", "#cky"] }],
+    "optOut": [{ "waitForThenClick": ["cookie-banner-element#ckb", "#ckn"] }]
+}

--- a/tests/cookie-banner-element.spec.ts
+++ b/tests/cookie-banner-element.spec.ts
@@ -1,0 +1,7 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('cookie-banner-element', [
+    'https://asteriskmag.com/issues/15/why-we-like-things',
+    'https://turnerinsurance.es/',
+    'https://www.zorgvoorlater.nl/',
+]);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217447775528136?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

No existing privacy-configuration exception was found. Added a generic rule for the shared cookie-banner-element#ckb custom element, with PublicWWW showing the CookieBannerConfig pattern on multiple sites. npm run lint and npm run prepublish passed. Regional validation showed the banner in every control/before screenshot and removed after opt-out in every tested region/device; reload validation did not redetect the popup.

## Steps to test this PR:

- `npm run build-rules && npm run rule-syntax-check && npx playwright test tests/cookie-banner-element.spec.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new autoconsent rule and tests only; no changes to auth, data handling, or core runtime logic.
> 
> **Overview**
> Adds autoconsent support for sites using the shared **`cookie-banner-element#ckb`** custom element (CookieBannerConfig pattern).
> 
> The new rule **`cookie-banner-element`** pre-hides and detects that element, dismisses via **`#cky`** (opt-in) or **`#ckn`** (opt-out), and includes Playwright coverage on three live URLs (asteriskmag.com, turnerinsurance.es, zorgvoorlater.nl).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1535a69637ea2e78dc600513d90f2908a62dea1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->