### PR TITLE
Rule update: simplehuman-com

### DIFF
--- a/rules/autoconsent/simplehuman-com.json
+++ b/rules/autoconsent/simplehuman-com.json
@@ -1,0 +1,33 @@
+{
+    "name": "simplehuman-com",
+    "vendorUrl": "https://www.simplehuman.com/",
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(www\\.)?simplehuman\\.com/"
+    },
+    "prehideSelectors": ["custom-cookie-consent#cookieBubble.banner-show"],
+    "detectCmp": [
+        {
+            "exists": "custom-cookie-consent#cookieBubble #configureBtn"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "custom-cookie-consent#cookieBubble.banner-show #configureBtn"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "custom-cookie-consent#cookieBubble #cookieBubbleAcceptAll"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "custom-cookie-consent#cookieBubble #configureBtn"
+        },
+        {
+            "waitForThenClick": ".custom-cookie-modal #acceptNecessaryBtn"
+        }
+    ]
+}

--- a/tests/simplehuman-com.spec.ts
+++ b/tests/simplehuman-com.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('simplehuman-com', ['https://www.simplehuman.com/products/semi-round-open-can-80l']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217295906137035?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

No existing autoconsent exception was found in duckduckgo/privacy-configuration features or platform/browser overrides. PublicWWW did not show this exact Shopify custom-cookie-consent implementation as a common reusable CMP, so the fix is scoped to simplehuman.com. Validation commands passed: npm run build-rules, npm run rule-syntax-check, npx playwright test tests/simplehuman-com.spec.ts, npm run prepublish, and npm run lint. Draft PR creation was registered for approval by the environment; the pushed branch compare URL is provided.

## Steps to test this PR:

- `npx playwright test tests/simplehuman-com.spec.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new JSON rule and test only; no changes to shared runner logic or other rules.
> 
> **Overview**
> Introduces **autoconsent coverage for simplehuman.com**, scoped to that domain’s Shopify `custom-cookie-consent` banner.
> 
> The new rule **pre-hides** the cookie bubble, **detects** the CMP via `#configureBtn`, and defines **opt-in** (accept all) and **opt-out** (configure → accept necessary) click sequences. A **Playwright spec** runs the standard CMP test against a product URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdc8457bd996f23e5b89782404bf50b9302a4d82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->