### PR TITLE
Rule update: appconsent

### DIFF
--- a/rules/autoconsent/appconsent.json
+++ b/rules/autoconsent/appconsent.json
@@ -1,0 +1,17 @@
+{
+    "name": "appconsent",
+    "prehideSelectors": ["iframe[style*=\"2147483647\"]"],
+    "detectCmp": [{ "exists": "script[src*=\"appconsent.io/tcf2/\"]" }],
+    "detectPopup": [{ "visible": ["iframe[style*=\"2147483647\"]", ".banner"] }],
+    "optIn": [{ "waitForThenClick": ["iframe[style*=\"2147483647\"]", ".button__acceptAll:not(.button__save)"] }],
+    "optOut": [
+        {
+            "if": { "exists": ["iframe[style*=\"2147483647\"]", ".button__skip"] },
+            "then": [{ "waitForThenClick": ["iframe[style*=\"2147483647\"]", ".button__skip"] }],
+            "else": [
+                { "waitForThenClick": ["iframe[style*=\"2147483647\"]", ".button__openPrivacyCenter"] },
+                { "waitForThenClick": ["iframe[style*=\"2147483647\"]", ".button__refuseAll"] }
+            ]
+        }
+    ]
+}

--- a/tests/appconsent.spec.ts
+++ b/tests/appconsent.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('appconsent', ['https://www.meteociel.fr/', 'https://www.maxifoot.fr/'], { expectPopupOpen: false });


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217482257603225?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

No privacy-configuration autoconsent exception was found for meteociel.fr. PublicWWW showed AppConsent usage on multiple sites, so a generic AppConsent JSON rule was added. The reported HTTP URL was blocked by the regional proxy, so validation used the canonical HTTPS site, which redirects to https://www.meteociel.fr/. The popup was reproduced and fixed in US, GB, DE, FR, NL, and PL. AU, CA, and JP loaded the AppConsent script but showed no visible popup in control/before/after screenshots. FR mobile also reproduced and was fixed. Additional spot checks confirmed AppConsent opt-in on Meteociel and opt-out on maxifoot.fr.

## Steps to test this PR:

- `npx playwright test tests/appconsent.spec.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new CMP rule and tests only; no changes to core autoconsent infrastructure or security-sensitive paths.
> 
> **Overview**
> Adds support for the **AppConsent** CMP (detected via `appconsent.io/tcf2/` scripts) with a new `rules/autoconsent/appconsent.json` rule.
> 
> The rule targets the high z-index iframe and `.banner`, pre-hides that iframe, and drives **opt-in** via **Accept all** and **opt-out** via **Skip** when present or **Privacy center → Refuse all** otherwise.
> 
> Playwright coverage runs against **meteociel.fr** and **maxifoot.fr** with `expectPopupOpen: false` (popup should be closed after autoconsent).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 968ac9358c9f21d79c9671f51c65a489575ac3a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->