### PR TITLE
Rule update: Proactive CPM check: paypal.com

### DIFF
--- a/rules/autoconsent/paypal-us.json
+++ b/rules/autoconsent/paypal-us.json
@@ -1,8 +1,8 @@
 {
     "name": "paypal-us",
-    "prehideSelectors": ["#ccpaCookieContent_wrapper, article.ppvx_modal--overpanel"],
-    "detectCmp": [{ "exists": "#ccpaCookieBanner, .privacy-sheet-content" }],
-    "detectPopup": [{ "visible": "#ccpaCookieBanner, .privacy-sheet-content" }],
+    "prehideSelectors": ["#ccpaCookieContent_wrapper, article.ppvx_modal--overpanel, #cookiePrefsModal"],
+    "detectCmp": [{ "exists": "#ccpaCookieBanner, .privacy-sheet-content, #cookiePrefsModal" }],
+    "detectPopup": [{ "visible": "#ccpaCookieBanner, .privacy-sheet-content, #cookiePrefsModal" }],
     "optIn": [{ "click": "#acceptAllButton" }],
     "optOut": [
         {
@@ -13,13 +13,27 @@
                     "if": { "exists": "a#manageCookiesLink" },
                     "then": [{ "click": "a#manageCookiesLink" }],
                     "else": [
-                        { "waitForVisible": ".privacy-sheet-content #formContent" },
                         {
-                            "click": "#formContent .cookiepref-11m2iee-checkbox_base input:checked",
-                            "all": true,
-                            "optional": true
-                        },
-                        { "click": ".cookieAction.saveCookie,.confirmCookie #submitCookiesBtn" }
+                            "if": { "exists": "#cookiePrefsModal" },
+                            "then": [
+                                { "waitForVisible": "#cookiePrefsModal #submitCookiesBtn, .confirmCookie #submitCookiesBtn" },
+                                {
+                                    "click": "#cookiePrefsModal input[type='checkbox']:checked",
+                                    "all": true,
+                                    "optional": true
+                                },
+                                { "click": "#cookiePrefsModal #submitCookiesBtn, .confirmCookie #submitCookiesBtn" }
+                            ],
+                            "else": [
+                                { "waitForVisible": ".privacy-sheet-content #formContent" },
+                                {
+                                    "click": "#formContent .cookiepref-11m2iee-checkbox_base input:checked",
+                                    "all": true,
+                                    "optional": true
+                                },
+                                { "click": ".cookieAction.saveCookie,.confirmCookie #submitCookiesBtn" }
+                            ]
+                        }
                     ]
                 }
             ]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217480710971045?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON rule change for cookie-banner automation with no auth, data, or core app logic impact.
> 
> **Overview**
> Updates the **paypal-us** autoconsent rule so PayPal’s cookie UI can be detected and opted out when the site shows **`#cookiePrefsModal`** instead of only the banner or privacy sheet.
> 
> **Detection and prehide** now include `#cookiePrefsModal` alongside the existing selectors. On **opt-out**, when there is no decline button and no manage-cookies link path, the rule **branches**: if the modal exists, it waits for the submit control, optionally unchecks checked boxes inside the modal, and clicks submit; otherwise it keeps the prior **privacy-sheet** flow (`#formContent` checkboxes and save).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8026c894225197e1854105abe5519dadb328ed9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->