### PR TITLE
Rule update: check24

### DIFF
--- a/rules/autoconsent/check24.json
+++ b/rules/autoconsent/check24.json
@@ -1,0 +1,30 @@
+{
+    "name": "check24",
+    "prehideSelectors": [".c24-cookie-consent-wrapper"],
+    "detectCmp": [
+        {
+            "exists": ".c24-cookie-consent-wrapper .c24-cookie-consent-functional"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": ".c24-cookie-consent-notice"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": ".c24-cookie-consent-notice .c24-cookie-consent-button:not(.c24-cookie-consent-button-secondary)"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": ".c24-cookie-consent-wrapper .c24-cookie-consent-functional"
+        }
+    ],
+    "test": [
+        {
+            "visible": ".c24-cookie-consent-wrapper",
+            "check": "none"
+        }
+    ]
+}

--- a/tests/check24.spec.ts
+++ b/tests/check24.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('check24', ['https://www.check24.de/', 'https://www.check24.es/'], {});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217515433530989?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

No privacy-configuration autoconsent exception was found for check24.de; only an unrelated check24-partnerprogramm-de entry exists. Added a generic CHECK24 rule after PublicWWW showed the same c24-cookie-consent selector family on multiple CHECK24-owned hosts. Regional proxy validation passed for DE, GB, and US desktop plus DE mobile; reload checks after opt-out showed no repeat detection.

## Steps to test this PR:

- `npx playwright test tests/check24.spec.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new autoconsent rule and tests only; no changes to core consent logic or shared infrastructure.
> 
> **Overview**
> Adds autoconsent support for CHECK24 sites using the shared `c24-cookie-consent` DOM (wrapper, notice, functional toggle, and primary button selectors).
> 
> The rule **pre-hides** the consent wrapper, **detects** the CMP and visible notice, **opts in** via the non-secondary button, **opts out** via the functional control, and validates with a visibility check on the wrapper.
> 
> A new Playwright spec runs the standard CMP test harness against `check24.de` and `check24.es`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a27a140146afa46d938edaff07df5faa28241c93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->