### PR TITLE
Rule update: rule34-xxx

### DIFF
--- a/rules/autoconsent/rule34-xxx.json
+++ b/rules/autoconsent/rule34-xxx.json
@@ -1,0 +1,12 @@
+{
+    "name": "rule34-xxx",
+    "runContext": {
+        "urlPattern": "^https?://(www\\.)?rule34\\.xxx/"
+    },
+    "prehideSelectors": ["#gdprconsent.gdprcontainer"],
+    "detectCmp": [{ "exists": "#gdprconsent.gdprcontainer" }],
+    "detectPopup": [{ "visible": "#gdprconsent.gdprcontainer" }],
+    "optIn": [{ "waitForThenClick": "#gdprconsent .gdprbutton button" }],
+    "optOut": [{ "waitForThenClick": "#gdprconsent .gdprbutton a" }],
+    "test": [{ "cookieContains": "gdpr-consent=0" }]
+}

--- a/tests/rule34-xxx.spec.ts
+++ b/tests/rule34-xxx.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('rule34-xxx', ['https://rule34.xxx/index.php?page=post&s=list&tags=all'], {
+    onlyRegions: ['DE'],
+    testOptIn: false,
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217579678480749?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

No rule34.xxx autoconsent exception was found in duckduckgo/privacy-configuration features/autoconsent.json or platform overrides. Added rules/autoconsent/rule34-xxx.json and tests/rule34-xxx.spec.ts. Ran npm run build-rules && npm run rule-syntax-check, focused DE proxy spec, npm run prepublish, and npm run lint. Expanded regional validation was run because core-region behavior diverged: US/GB/AU showed CAPTCHA or age-verification pages, CA/JP showed no cookie banner, and DE/FR/NL/PL plus DE mobile showed the GDPR banner handled successfully after the fix.

## Steps to test this PR:

- `REGION=DE npx playwright test tests/rule34-xxx.spec.ts --project chrome --config playwright.regional.config.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New isolated autoconsent rule and DE-only test; no changes to shared consent infrastructure or security-sensitive paths.
> 
> **Overview**
> Adds a new **site-specific autoconsent rule** for `rule34.xxx` so the GDPR cookie banner can be detected and handled in regions where it appears (notably DE).
> 
> The rule targets `#gdprconsent.gdprcontainer`, pre-hides it, uses **opt-out** via the link in `.gdprbutton` and **opt-in** via the button, and verifies success with a `gdpr-consent=0` cookie check.
> 
> A Playwright spec runs against a list URL with **`onlyRegions: ['DE']`** and **`testOptIn: false`**, matching triage where US/GB/AU showed CAPTCHA/age gates and other regions did not show the same banner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96f4b957f0952eccd1d65916d87a98abcbc35664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->