### PR TITLE
Rule update: bankmillennium.pl

### DIFF
--- a/rules/autoconsent/bankmillennium-pl.json
+++ b/rules/autoconsent/bankmillennium-pl.json
@@ -1,0 +1,26 @@
+{
+    "name": "bankmillennium.pl",
+    "runContext": {
+        "urlPattern": "^https?://(www\\.)?bankmillennium\\.pl/"
+    },
+    "prehideSelectors": ["#cookie_modal_placeholder dialog.bm-modal--cookie"],
+    "detectCmp": [{ "exists": "#cookie_modal_placeholder dialog.bm-modal--cookie" }],
+    "detectPopup": [{ "visible": "#cookie_modal_placeholder dialog.bm-modal--cookie" }],
+    "optIn": [
+        {
+            "waitForThenClick": [
+                "#cookie_modal_placeholder dialog.bm-modal--cookie",
+                "xpath///button[contains(normalize-space(.), 'Potwierd')]"
+            ]
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": [
+                "#cookie_modal_placeholder dialog.bm-modal--cookie",
+                "xpath///button[contains(normalize-space(.), 'Odrzu')]"
+            ]
+        }
+    ],
+    "test": [{ "cookieContains": "Analytics_consent=2" }, { "cookieContains": "Marketing_consent=2" }]
+}

--- a/tests/bankmillennium-pl.spec.ts
+++ b/tests/bankmillennium-pl.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('bankmillennium.pl', ['https://www.bankmillennium.pl/'], {
+    testOptIn: false,
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217263682859808?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

No matching autoconsent exception was found in duckduckgo/privacy-configuration features/autoconsent.json or overrides, and no matching privacy-configuration PR was found, so no Asana task was applicable. The reported HTTP URL was blocked by the PL proxy, but the canonical HTTPS URL loaded and reproduced the cookie dialog. PublicWWW did not show broad prevalence for the distinctive Bank Millennium cookie modal selectors/script, so the fix is a narrow site-specific JSON rule. Core regions plus reported PL were consistent, so expanded regional testing was skipped under policy. PL mobile sanity also passed visually and via API.

## Steps to test this PR:

- `npx playwright test tests/bankmillennium-pl.spec.ts --project chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated site JSON rule and test only; no changes to shared autoconsent engine or security-sensitive paths.
> 
> **Overview**
> Adds a **site-specific autoconsent rule** for Bank Millennium (`bankmillennium.pl`) so DuckDuckGo can handle their custom cookie dialog on `www.bankmillennium.pl`.
> 
> The rule **pre-hides** `#cookie_modal_placeholder dialog.bm-modal--cookie`, detects the same modal for CMP/popup checks, and uses **Polish button labels** via XPath: **Potwierd** for opt-in and **Odrzu** for opt-out. Success is verified with cookies `Analytics_consent=2` and `Marketing_consent=2`.
> 
> A Playwright spec runs CMP tests against `https://www.bankmillennium.pl/` with **`testOptIn: false`** (opt-out–focused coverage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74a71eec0886c62c1bfbea82631744e73de5882f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->