### PR TITLE
Rule update: Cookie prompt on chatgpt.com

### DIFF
--- a/rules/autoconsent/chatgpt.json
+++ b/rules/autoconsent/chatgpt.json
@@ -7,34 +7,33 @@
     "runContext": {
         "main": true,
         "frame": false,
-        "urlPattern": "^https://(www\\.)?chatgpt\\.com/"
+        "urlPattern": "^https?://(\\w+\\.)?chatgpt\\.com/"
     },
-    "prehideSelectors": [],
+    "comment": "Covers the server-rendered consent dialog. Once the app hydrates it swaps in a banner whose buttons are only distinguishable by text, which the heuristic rule handles better.",
+    "prehideSelectors": ["dialog[data-cookie-consent]:has(form[data-privacy-consent-form])"],
     "detectCmp": [
         {
-            "exists": "body > div:not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])"
+            "exists": "dialog[data-cookie-consent] form[data-privacy-consent-form] input[name=\"action\"][value=\"reject\"]"
         }
     ],
     "detectPopup": [
         {
-            "visible": "body > div:not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])"
+            "visible": "dialog[data-cookie-consent]:has(form[data-privacy-consent-form])"
         }
     ],
     "optIn": [
         {
-            "waitForThenClick": "body > div:not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(3):not([id])"
+            "waitForThenClick": "dialog[data-cookie-consent] form[data-privacy-consent-form]:has(input[name=\"action\"][value=\"accept\"]) button[type=\"submit\"]"
         }
     ],
     "optOut": [
-        { "wait": 500 },
         {
-            "waitForThenClick": "body > div:not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
-            "comment": "Reject non-essential"
+            "waitForThenClick": "dialog[data-cookie-consent] form[data-privacy-consent-form]:has(input[name=\"action\"][value=\"reject\"]) button[type=\"submit\"]"
         }
     ],
     "test": [
         {
-            "waitForVisible": "body > div:not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:nth-child(2):not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
+            "waitForVisible": "dialog[data-cookie-consent]",
             "timeout": 1000,
             "check": "none"
         }

--- a/rules/autoconsent/holidaymedia.json
+++ b/rules/autoconsent/holidaymedia.json
@@ -1,9 +1,9 @@
 {
     "name": "holidaymedia",
     "vendorUrl": "https://holidaymedia.nl/",
-    "prehideSelectors": ["dialog[data-cookie-consent]"],
-    "detectCmp": [{ "exists": "dialog[data-cookie-consent]" }],
-    "detectPopup": [{ "visible": "dialog[data-cookie-consent]" }],
+    "prehideSelectors": ["dialog[data-cookie-consent]:has([data-cookie-accept])"],
+    "detectCmp": [{ "exists": "dialog[data-cookie-consent] [data-cookie-accept]" }],
+    "detectPopup": [{ "visible": "dialog[data-cookie-consent]:has([data-cookie-accept])" }],
     "optIn": [{ "waitForThenClick": "button.cookie-consent__button--accept-all" }],
     "optOut": [{ "waitForThenClick": "a[data-cookie-accept=\"functional\"]", "timeout": 2000 }]
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1211382979490769?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Site-specific autoconsent selector updates only; no auth, data handling, or core engine changes. Wrong selectors could miss or mis-click a cookie banner on those sites.
> 
> **Overview**
> Updates the ChatGPT autoconsent rule to match the server-rendered `dialog[data-cookie-consent]` form instead of brittle nested `body > div` button paths. Accept/reject now click the form submit buttons keyed by `action=accept|reject`, prehide is scoped to that dialog, and the URL pattern also allows http and extra subdomains.
> 
> The holidaymedia rule is tightened so it only matches dialogs that contain `[data-cookie-accept]`, avoiding overlap with ChatGPT’s same `dialog[data-cookie-consent]` markup. Hydrated ChatGPT banners remain for the heuristic rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 952fba5c5679bb090e0975d32bd5d88beaa4430f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->