### PR TITLE
Fix cookie consent handling on twitch.tv and x.com, add primevideo.com rule

### DIFF
--- a/rules/autoconsent/primevideo.json
+++ b/rules/autoconsent/primevideo.json
@@ -4,18 +4,26 @@
     "runContext": {
         "urlPattern": "^https://(www\\.)?primevideo\\.com/"
     },
-    "prehideSelectors": [".DVWebNode-conditional-site-wide-wrapper:has([data-testid=critical-notification])"],
+    "prehideSelectors": [".DVWebNode-conditional-site-wide-wrapper:has([data-testid=critical-notification] a[href*=\"privacyprefs\"])"],
     "detectCmp": [
         { "exists": ".DVWebNode-conditional-site-wide-wrapper [data-testid=critical-notification]:has(a[href*=\"privacyprefs\"])" }
     ],
     "detectPopup": [
         { "visible": ".DVWebNode-conditional-site-wide-wrapper [data-testid=critical-notification]:has(a[href*=\"privacyprefs\"])" }
     ],
-    "optIn": [{ "waitForThenClick": "[data-testid=critical-notification] button[data-testid=critical-notification-v2-button-0]" }],
-    "optOut": [{ "waitForThenClick": "[data-testid=critical-notification] button[data-testid=critical-notification-v2-button-1]" }],
+    "optIn": [
+        {
+            "waitForThenClick": "[data-testid=critical-notification]:has(a[href*=\"privacyprefs\"]) button[data-testid=critical-notification-v2-button-0]"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "[data-testid=critical-notification]:has(a[href*=\"privacyprefs\"]) button[data-testid=critical-notification-v2-button-1]"
+        }
+    ],
     "test": [
         {
-            "waitForVisible": ".DVWebNode-conditional-site-wide-wrapper [data-testid=critical-notification]",
+            "waitForVisible": ".DVWebNode-conditional-site-wide-wrapper [data-testid=critical-notification]:has(a[href*=\"privacyprefs\"])",
             "timeout": 1000,
             "check": "none"
         }

--- a/rules/autoconsent/primevideo.json
+++ b/rules/autoconsent/primevideo.json
@@ -1,0 +1,23 @@
+{
+    "name": "primevideo.com",
+    "vendorUrl": "https://www.primevideo.com/",
+    "runContext": {
+        "urlPattern": "^https://(www\\.)?primevideo\\.com/"
+    },
+    "prehideSelectors": [".DVWebNode-conditional-site-wide-wrapper:has([data-testid=critical-notification])"],
+    "detectCmp": [
+        { "exists": ".DVWebNode-conditional-site-wide-wrapper [data-testid=critical-notification]:has(a[href*=\"privacyprefs\"])" }
+    ],
+    "detectPopup": [
+        { "visible": ".DVWebNode-conditional-site-wide-wrapper [data-testid=critical-notification]:has(a[href*=\"privacyprefs\"])" }
+    ],
+    "optIn": [{ "waitForThenClick": "[data-testid=critical-notification] button[data-testid=critical-notification-v2-button-0]" }],
+    "optOut": [{ "waitForThenClick": "[data-testid=critical-notification] button[data-testid=critical-notification-v2-button-1]" }],
+    "test": [
+        {
+            "waitForVisible": ".DVWebNode-conditional-site-wide-wrapper [data-testid=critical-notification]",
+            "timeout": 1000,
+            "check": "none"
+        }
+    ]
+}

--- a/rules/autoconsent/twitch.json
+++ b/rules/autoconsent/twitch.json
@@ -12,8 +12,8 @@
     "optOut": [
         { "hide": "div:has(> .consent-banner .consent-banner__content--gdpr-v2)" },
         { "click": "button[data-a-target=\"consent-banner-manage-preferences\"]" },
-        { "waitFor": "input[type=checkbox][data-a-target=tw-checkbox]" },
-        { "click": "input[type=checkbox][data-a-target=tw-checkbox][checked]:not([disabled])", "all": true, "optional": true },
+        { "waitFor": "input[type=checkbox][data-a-target=tw-toggle]" },
+        { "click": "input[type=checkbox][data-a-target=tw-toggle][checked]:not([disabled])", "all": true, "optional": true },
         { "waitForThenClick": "[data-a-target=consent-modal-save]" },
         { "waitForVisible": ".ReactModalPortal:has([data-a-target=consent-modal-save])", "check": "none" }
     ]

--- a/rules/autoconsent/twitter.json
+++ b/rules/autoconsent/twitter.json
@@ -3,30 +3,22 @@
     "runContext": {
         "urlPattern": "^https://([a-z0-9-]+\\.)?(twitter|x)\\.com/"
     },
-    "prehideSelectors": ["[data-testid=\"BottomBar\"]"],
-    "detectCmp": [
-        {
-            "exists": "body > div#react-root > div:not([id]) > div:not([id]) > div:nth-child(1)#layers > div:not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:not([id])[data-testid=BottomBar] > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])"
-        }
-    ],
-    "detectPopup": [
-        {
-            "visible": "body > div#react-root > div:not([id]) > div:not([id]) > div:nth-child(1)#layers > div:not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:not([id])[data-testid=BottomBar] > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])"
-        }
-    ],
+    "prehideSelectors": ["body > div[role=region][aria-label]:has(> div:last-child > button:first-child + button:last-child)"],
+    "detectCmp": [{ "exists": "body > div[role=region][aria-label]:has(> div:last-child > button:first-child + button:last-child)" }],
+    "detectPopup": [{ "visible": "body > div[role=region][aria-label]:has(> div:last-child > button:first-child + button:last-child)" }],
     "optIn": [
         {
-            "waitForThenClick": "[data-testid=\"BottomBar\"] > div:has(>div:first-child>div:last-child>button[role=button]>span) > div:last-child > button[role=button]:first-child"
+            "waitForThenClick": "body > div[role=region][aria-label]:has(> div:last-child > button:first-child + button:last-child) > div:last-child > button:first-child"
         }
     ],
     "optOut": [
         {
-            "waitForThenClick": "body > div#react-root > div:not([id]) > div:not([id]) > div:nth-child(1)#layers > div:not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:not([id])[data-testid=BottomBar] > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])"
+            "waitForThenClick": "body > div[role=region][aria-label]:has(> div:last-child > button:first-child + button:last-child) > div:last-child > button:last-child"
         }
     ],
     "test": [
         {
-            "waitForVisible": "body > div#react-root > div:not([id]) > div:not([id]) > div:nth-child(1)#layers > div:not([id]) > div:nth-child(2):not([id]) > div:not([id]) > div:not([id])[data-testid=BottomBar] > div:not([id]) > div:nth-child(2):not([id]) > button:nth-child(2):not([id])",
+            "waitForVisible": "body > div[role=region][aria-label]:has(> div:last-child > button:first-child + button:last-child)",
             "timeout": 1000,
             "check": "none"
         }

--- a/tests/primevideo.spec.ts
+++ b/tests/primevideo.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('primevideo.com', ['https://www.primevideo.com/'], {
+    skipRegions: ['US'],
+});

--- a/tests/twitter.spec.ts
+++ b/tests/twitter.spec.ts
@@ -1,10 +1,10 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('twitter', ['https://mobile.twitter.com/', 'https://twitter.com/'], {
+generateCMPTests('twitter', ['https://x.com/'], {
     skipRegions: ['US'],
 });
 
-generateCMPTests('twitter', ['https://mobile.twitter.com/', 'https://twitter.com/'], {
+generateCMPTests('twitter', ['https://x.com/'], {
     skipRegions: ['US'],
     mobile: true,
 });


### PR DESCRIPTION
Task/Issue URL:

## Description:

- twitch.tv: the preference toggles were renamed from `tw-checkbox` to `tw-toggle`, so opt-out aborted and left the preferences modal open
- twitter/x.com: the banner was rebuilt as a `div[role=region]` bottom bar without `data-testid=BottomBar`; rule rewritten for the new markup. Note: x.com does not persist refusal for logged-out users (verified with a manual click), so the banner is re-dismissed on each visit
- primevideo.com: new rule for the cookie banner, previously not covered

## Steps to test this PR:

- From an EU location, open https://www.twitch.tv/, https://x.com/ and https://www.primevideo.com/ and verify the cookie popups are rejected automatically

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Declarative autoconsent CSS/click rules and Playwright tests only; no auth, data handling, or runtime logic changes.
> 
> **Overview**
> Fixes broken cookie-banner handling on Twitch and X, and adds coverage for Prime Video.
> 
> Twitch opt-out now targets `tw-toggle` instead of `tw-checkbox`, so preference toggles are actually clicked and the modal can close.
> 
> X/Twitter selectors are rewritten for the new `role=region` bottom bar (no `BottomBar` test id). Tests now hit `https://x.com/` only.
> 
> Adds a new `primevideo.com` rule (and Playwright test, US skipped) that detects the critical-notification banner and clicks accept/reject buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aebb193ac340ae6c9343a3554c835432a24a3a26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->