### PR TITLE
Rule update: porngameshub

### DIFF
--- a/rules/autoconsent/porngameshub.json
+++ b/rules/autoconsent/porngameshub.json
@@ -1,0 +1,33 @@
+{
+    "name": "porngameshub",
+    "runContext": {
+        "urlPattern": "^https?://(\\w+\\.)?porngameshub\\.com/"
+    },
+    "comment": "notice-only cookie banner without a reject option; the heuristic skips it because of the adult-content disclaimer in the same banner",
+    "prehideSelectors": ["aside[aria-label='Cookie Notification']"],
+    "detectCmp": [
+        {
+            "exists": "aside[aria-label='Cookie Notification'] button[aria-label='Accept Cookies']"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "aside[aria-label='Cookie Notification']"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "aside[aria-label='Cookie Notification'] button[aria-label='Accept Cookies']"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "aside[aria-label='Cookie Notification'] button[aria-label='Accept Cookies']"
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "gdpr_consent="
+        }
+    ]
+}

--- a/tests/porngameshub.spec.ts
+++ b/tests/porngameshub.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('porngameshub', ['https://porngameshub.com/'], {});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217743526538786?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

The banner is a notice-only cookie bar (fixed bottom aside, single 'Got it' button) that sets gdpr_consent=accepted. Heuristic detection failed because the same aside element also contains the adult-content disclaimer 'you confirm that you are 18 years of age or older', which matches DETECT_NEVER_MATCH_PATTERNS in lib/heuristic-patterns.ts, so isExcludedPopup discarded the popup despite the body text matching the cookie DETECT pattern /(?:this|our) (?:web)?site.{0,100}cookies/. I did not relax the exclusion patterns because that would re-enable heuristic clicking on genuine age gates site-wide; a scoped rule is the lower-risk fix. This is not an age gate: no reject/leave path exists, page content renders behind the bar, and the button is aria-label='Accept Cookies' inside aside[aria-label='Cookie Notification']. Rule uses those ARIA labels rather than Tailwind utility classes. optOut acknowledges since there is no reject option. No exception exists for this domain in duckduckgo/privacy-configuration (checked features/autoconsent.json and the android/ios/macos/windows/extension overrides). PublicWWW found no other sites with this markup (banner is client-rendered and absent from server HTML), so a generic rule was not justified. Verified no false re-detection: reloading in the same context after dismissal yields cmpsDetected=[] and zero banner elements. Stayed on the core region set per policy since results were consistent, the rule has no region-dependent logic, and it is site-scoped rather than a widely-used generic rule.

## Steps to test this PR:

- `npx playwright test tests/porngameshub.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Site-specific cookie-banner rule and test only; no shared heuristic or core consent logic changes.
> 
> **Overview**
> Adds a site-scoped autoconsent rule for porngameshub.com so the notice-only cookie bar is dismissed. Heuristics skip it because the same banner includes an adult-content disclaimer.
> 
> The rule prehides and clicks `Accept Cookies` for both opt-in and opt-out (no reject path), then checks for a `gdpr_consent=` cookie. Includes a Playwright CMP test for the homepage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de37950957bbfe907161fe6cd064820452ef239f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->