### PR TITLE
Rule update: Cookie popup on youporn.com

### DIFF
--- a/rules/autoconsent/aylo-cookie-banner.json
+++ b/rules/autoconsent/aylo-cookie-banner.json
@@ -17,10 +17,6 @@
             "visible": "#cookie_consent_wrapper:not(.hideConsent)"
         },
         {
-            "visible": "#age_disclaimer_window,#ageDisclaimerWrapper",
-            "check": "none"
-        },
-        {
             "any": [
                 {
                     "visible": "#cookie_consent_wrapper.non_cookie_consent_wrapper #js_cookieBannerCloseBtn"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217579659445543?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small autoconsent JSON rule tweak with no auth, data, or engine changes. Worst case is a CMP detection miss or extra wait on Aylo sites.
> 
> **Overview**
> Updates the `aylo-cookie-banner` rule so popup detection no longer waits on the age-disclaimer overlay (`#age_disclaimer_window` / `#ageDisclaimerWrapper`).
> 
> Cookie-banner detection now depends only on the consent wrapper and cookie-manager readiness, which should fix false or delayed matches on sites like youporn.com.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 500cbd93f7b7e59e192266b511c3680481665013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->