### PR TITLE
Rule update: Cookie popup on twitch.tv

### DIFF
--- a/rules/autoconsent/twitch.json
+++ b/rules/autoconsent/twitch.json
@@ -3,18 +3,33 @@
     "runContext": {
         "urlPattern": "^https?://([\\w-]+\\.)?twitch\\.tv"
     },
-    "prehideSelectors": [
-        "div:has(> .consent-banner .consent-banner__content--gdpr-v2),.ReactModalPortal:has([data-a-target=consent-modal-save])"
+    "prehideSelectors": ["[data-a-target=\"consent-banner\"],.ReactModalPortal:has([data-a-target=consent-modal-save])"],
+    "detectCmp": [{ "exists": "[data-a-target=\"consent-banner\"]" }],
+    "detectPopup": [{ "visible": "[data-a-target=\"consent-banner\"]" }],
+    "optIn": [
+        {
+            "if": { "exists": "[data-a-target=\"consent-banner-accept\"]" },
+            "then": [{ "click": "button[data-a-target=\"consent-banner-accept\"]" }],
+            "else": [{ "click": "[data-a-target=\"consent-banner\"] button:not([data-a-target])" }]
+        }
     ],
-    "detectCmp": [{ "exists": ".consent-banner .consent-banner__content--gdpr-v2" }],
-    "detectPopup": [{ "visible": ".consent-banner .consent-banner__content--gdpr-v2" }],
-    "optIn": [{ "click": "button[data-a-target=\"consent-banner-accept\"]" }],
     "optOut": [
-        { "hide": "div:has(> .consent-banner .consent-banner__content--gdpr-v2)" },
-        { "click": "button[data-a-target=\"consent-banner-manage-preferences\"]" },
-        { "waitFor": "input[type=checkbox][data-a-target=tw-checkbox]" },
-        { "click": "input[type=checkbox][data-a-target=tw-checkbox][checked]:not([disabled])", "all": true, "optional": true },
-        { "waitForThenClick": "[data-a-target=consent-modal-save]" },
-        { "waitForVisible": ".ReactModalPortal:has([data-a-target=consent-modal-save])", "check": "none" }
+        {
+            "if": { "exists": "[data-a-target=\"consent-banner-accept\"]" },
+            "then": [
+                { "click": "[data-a-target=\"consent-banner\"] button:not([data-a-target])" },
+                { "waitForVisible": "[data-a-target=\"consent-banner\"]", "check": "none" }
+            ],
+            "else": [
+                { "click": "button[data-a-target=\"consent-banner-manage-preferences\"]" },
+                { "waitFor": "input[type=checkbox][data-a-target=tw-checkbox]" },
+                {
+                    "click": "input[type=checkbox][data-a-target=tw-checkbox]:not(:checked):not([disabled])",
+                    "optional": true
+                },
+                { "waitForThenClick": "[data-a-target=consent-modal-save]" },
+                { "waitForVisible": ".ReactModalPortal:has([data-a-target=consent-modal-save])", "check": "none" }
+            ]
+        }
     ]
 }

--- a/rules/autoconsent/twitch.json
+++ b/rules/autoconsent/twitch.json
@@ -1,7 +1,7 @@
 {
     "name": "twitch.tv",
     "runContext": {
-        "urlPattern": "^https?://([\\w-]+\\.)?twitch\\.tv"
+        "urlPattern": "^https?://([\\w-]+\\.)?twitch\\.tv/"
     },
     "prehideSelectors": ["[data-a-target=\"consent-banner\"],.ReactModalPortal:has([data-a-target=consent-modal-save])"],
     "detectCmp": [{ "exists": "[data-a-target=\"consent-banner\"]" }],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217579659191994?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Site-specific cookie-banner selectors and click steps only; no auth, data handling, or engine changes.
> 
> **Overview**
> Updates the `twitch.tv` autoconsent rule to match the current consent banner.
> 
> Detection and prehide now target `[data-a-target="consent-banner"]`. Opt-in and opt-out branch on whether the Accept button exists: if it does, opt-in clicks Accept and opt-out clicks the unlabeled banner button; otherwise they fall back to the manage-preferences modal flow. Opt-out no longer hides the banner first, and checkbox clicks now target unchecked boxes instead of checked ones. The URL pattern also requires a trailing slash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 907f7c316a3e5a43d86e29eeebf19bd0dd08f6fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->