### PR TITLE
Rule update: Cookie popup on sqe.sra.org.uk

### DIFF
--- a/rules/autoconsent/cookiefirst.json
+++ b/rules/autoconsent/cookiefirst.json
@@ -24,7 +24,7 @@
                     "if": {
                         "exists": "#btnRejectAllCookies"
                     },
-                    "then": [{ "wait": 2500 }, { "click": "#btnRejectAllCookies" }, { "wait": 1500 }],
+                    "then": [{ "wait": 1500 }, { "click": "#btnRejectAllCookies" }, { "wait": 1500 }],
                     "else": [
                         {
                             "if": {

--- a/rules/autoconsent/cookiefirst.json
+++ b/rules/autoconsent/cookiefirst.json
@@ -24,7 +24,11 @@
                     "if": {
                         "exists": "#btnRejectAllCookies"
                     },
-                    "then": [{ "wait": 1500 }, { "click": "#btnRejectAllCookies" }, { "wait": 1500 }],
+                    "then": [
+                        { "waitForVisible": "#btnRejectAllCookies", "timeout": 5000 },
+                        { "click": "#btnRejectAllCookies" },
+                        { "wait": 1500 }
+                    ],
                     "else": [
                         {
                             "if": {

--- a/rules/autoconsent/cookiefirst.json
+++ b/rules/autoconsent/cookiefirst.json
@@ -3,31 +3,51 @@
     "prehideSelectors": ["#cookiefirst-root,.cookiefirst-root,[aria-labelledby=cookie-preference-panel-title]"],
     "detectCmp": [{ "exists": "#cookiefirst-root,.cookiefirst-root" }],
     "detectPopup": [{ "visible": "#cookiefirst-root,.cookiefirst-root" }],
-    "optIn": [{ "click": "button[data-cookiefirst-action=accept]" }],
+    "optIn": [
+        {
+            "any": [{ "click": "button[data-cookiefirst-action=accept]" }, { "click": "#btnAcceptAllCookies" }]
+        }
+    ],
     "optOut": [
         {
             "if": {
-                "exists": "button[data-cookiefirst-action=adjust]"
+                "exists": "button[data-cookiefirst-action=reject]"
             },
-            "then": [
+            "then": [{ "click": "button[data-cookiefirst-action=reject]" }],
+            "else": [
                 {
-                    "click": "button[data-cookiefirst-action=adjust]"
-                },
-                {
-                    "waitForVisible": "[data-cookiefirst-widget=modal]",
-                    "timeout": 1000
-                },
-                {
-                    "eval": "EVAL_COOKIEFIRST_1"
-                },
-                {
-                    "wait": 1000
-                },
-                {
-                    "click": "button[data-cookiefirst-action=save]"
+                    "if": {
+                        "exists": "#btnRejectAllCookies"
+                    },
+                    "then": [{ "wait": 2500 }, { "click": "#btnRejectAllCookies" }, { "wait": 1500 }],
+                    "else": [
+                        {
+                            "if": {
+                                "exists": "button[data-cookiefirst-action=adjust]"
+                            },
+                            "then": [
+                                {
+                                    "click": "button[data-cookiefirst-action=adjust]"
+                                },
+                                {
+                                    "waitForVisible": "[data-cookiefirst-widget=modal]",
+                                    "timeout": 1000
+                                },
+                                {
+                                    "eval": "EVAL_COOKIEFIRST_1"
+                                },
+                                {
+                                    "wait": 1000
+                                },
+                                {
+                                    "click": "button[data-cookiefirst-action=save]"
+                                }
+                            ],
+                            "else": [{ "click": "button[data-cookiefirst-action=reject]" }]
+                        }
+                    ]
                 }
-            ],
-            "else": [{ "click": "button[data-cookiefirst-action=reject]" }]
+            ]
         }
     ],
     "test": [

--- a/rules/autoconsent/cookiefirst.json
+++ b/rules/autoconsent/cookiefirst.json
@@ -2,7 +2,12 @@
     "name": "cookiefirst.com",
     "prehideSelectors": ["#cookiefirst-root,.cookiefirst-root,[aria-labelledby=cookie-preference-panel-title]"],
     "detectCmp": [{ "exists": "#cookiefirst-root,.cookiefirst-root" }],
-    "detectPopup": [{ "visible": "#cookiefirst-root,.cookiefirst-root" }],
+    "detectPopup": [
+        {
+            "visible": "#cookiefirst-root button[data-cookiefirst-action],.cookiefirst-root button[data-cookiefirst-action],#btnAcceptAllCookies,#btnRejectAllCookies,#btnAdjustSettings,[aria-labelledby=cookie-preference-panel-title] button",
+            "check": "any"
+        }
+    ],
     "optIn": [
         {
             "any": [{ "click": "button[data-cookiefirst-action=accept]" }, { "click": "#btnAcceptAllCookies" }]

--- a/tests/cookiefirst.spec.ts
+++ b/tests/cookiefirst.spec.ts
@@ -1,3 +1,7 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('cookiefirst.com', ['https://targetjobs.co.uk/', 'https://www.pensador.com/', 'https://grupovaughan.com/'], {});
+generateCMPTests(
+    'cookiefirst.com',
+    ['https://targetjobs.co.uk/', 'https://www.pensador.com/', 'https://grupovaughan.com/', 'https://sqe.sra.org.uk/'],
+    {},
+);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217579226547601?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Declarative CMP rule and test-site list only; no auth, data handling, or runtime engine changes.
> 
> **Overview**
> Updates the CookieFirst autoconsent rule so it can detect and handle an alternate banner layout (used on `sqe.sra.org.uk`) in addition to the existing `data-cookiefirst-action` UI.
> 
> Popup detection now looks for any of several action buttons, including `#btnAcceptAllCookies` / `#btnRejectAllCookies`. Opt-in can click either the standard accept control or `#btnAcceptAllCookies`. Opt-out prefers a direct reject (`data-cookiefirst-action=reject` or `#btnRejectAllCookies`) before falling back to the adjust-preferences flow.
> 
> Adds `https://sqe.sra.org.uk/` to the CookieFirst Playwright coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a84ee70d888accc3794204182ffb1acb8aa4b59f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->