### PR TITLE
Rule update: Rule fix for Site Breakage: paypal.com (2026-08-15)

### DIFF
--- a/rules/autoconsent/paypal-us.json
+++ b/rules/autoconsent/paypal-us.json
@@ -27,16 +27,17 @@
                             "else": [
                                 { "waitForVisible": ".privacy-sheet-content #formContent" },
                                 {
-                                    "click": "#formContent .cookiepref-11m2iee-checkbox_base input:checked",
+                                    "click": "#formContent input[type='checkbox']:checked",
                                     "all": true,
                                     "optional": true
                                 },
-                                { "click": ".cookieAction.saveCookie,.confirmCookie #submitCookiesBtn" }
+                                { "click": ".cookieAction #submitCookiesBtn" }
                             ]
                         }
                     ]
                 }
             ]
         }
-    ]
+    ],
+    "test": [{ "wait": 1000 }, { "cookieContains": "type%3Dexplicit" }]
 }

--- a/tests/paypal-us.spec.ts
+++ b/tests/paypal-us.spec.ts
@@ -1,3 +1,7 @@
 import generateCMPTests from '../playwright/runner';
 
 generateCMPTests('paypal-us', ['https://www.paypal.com/us/home'], {});
+
+// This banner variant has no "Decline" button, so opting out goes through the cookie
+// preferences page, which navigates away and back, running the rule more than once.
+generateCMPTests('paypal-us', ['https://www.paypal.com/ca/home'], { expectedRuns: 3 });


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217705092861537?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small selector and test updates for a site-specific cookie-consent rule; no auth, security, or core infrastructure changes.
> 
> **Overview**
> Fixes the `paypal-us` autoconsent opt-out path for the privacy-sheet cookie preferences UI so it matches current PayPal markup.
> 
> The fallback branch now unchecks any checked `#formContent` checkboxes (instead of a brittle class-specific selector) and submits via `.cookieAction #submitCookiesBtn`. Adds a `test` step that waits then asserts the consent cookie contains `type%3Dexplicit`.
> 
> Also covers the Canada homepage variant (`paypal.com/ca/home`), which has no Decline button and navigates through preferences, so the rule is expected to run three times.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62578671b9b504a7edd241ee50b097c060b91818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->