### PR TITLE
Rule update: kingrecords-co-jp

### DIFF
--- a/rules/autoconsent/kingrecords-co-jp.json
+++ b/rules/autoconsent/kingrecords-co-jp.json
@@ -1,0 +1,21 @@
+{
+    "name": "kingrecords-co-jp",
+    "vendorUrl": "https://www.kingrecords.co.jp/",
+    "runContext": {
+        "urlPattern": "^https?://(?:[^/]+\\.)?kingrecords\\.co\\.jp/"
+    },
+    "prehideSelectors": [".cookie:has(.cookie__inner .cookie__button)"],
+    "detectCmp": [{ "exists": ".cookie > .cookie__inner > .cookie__button > a" }],
+    "detectPopup": [{ "visible": ".cookie > .cookie__inner > .cookie__button > a" }],
+    "optIn": [
+        { "waitFor": "#loader.is--show", "timeout": 10000, "optional": true },
+        { "waitForThenClick": ".cookie > .cookie__inner > .cookie__button > a" }
+    ],
+    "optOut": [
+        { "waitFor": "#loader.is--show", "timeout": 10000, "optional": true },
+        { "waitForThenClick": ".cookie > .cookie__inner > .cookie__button > a" },
+        { "if": { "visible": ".cookie" }, "then": [{ "wait": 1000 }, { "click": ".cookie > .cookie__inner > .cookie__button > a" }] },
+        { "waitForVisible": ".cookie", "check": "none", "timeout": 5000 }
+    ],
+    "test": [{ "cookieContains": "cookiesubmit=1" }]
+}

--- a/tests/kingrecords-co-jp.spec.ts
+++ b/tests/kingrecords-co-jp.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('kingrecords-co-jp', ['https://www.kingrecords.co.jp/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217764864027240?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

Custom bottom cookie notice with a single accept-only button (承諾する) and no reject/settings option; not a shared CMP (PublicWWW searches for the copy text, cookie__inner/cookie__button markup and the cookiesubmit cookie name found no matching sites). Heuristics do not fire: no Japanese DETECT_PATTERNS exist and the popup has no reject-like button. Tracking is not gated by the notice (GTM/GA4 load before consent) and clicking only sets cookiesubmit=1, so the click is acknowledge-equivalent. Key gotcha: the banner is visible from first paint but its jQuery click handler binds ~5s later, so a plain waitForThenClick silently no-ops; the rule waits for the site's app-init marker (#loader.is--show, added right after the handler binds and never removed) and retries the click if the banner is still visible. Verified no false-positive reload loop: after dismissal the rule reports cmpDetected but no popupFound. Banner only exists on the homepage; subpages have no .cookie element. No exception exists in duckduckgo/privacy-configuration for this domain (features/autoconsent.json and all platform overrides checked). No expanded-region escalation: core results converged, the rule has no region-dependent logic and no language-dependent selectors, and it is site-scoped.

## Steps to test this PR:

- `npx playwright test tests/kingrecords-co-jp.spec.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Site-specific consent-banner automation only; no auth, data handling, or shared CMP changes.
> 
> **Overview**
> Adds a site-scoped autoconsent rule for kingrecords.co.jp’s custom accept-only cookie notice.
> 
> The rule waits for `#loader.is--show` (when the jQuery click handler binds) before clicking the banner, with a retry if it stays visible. Opt-in and opt-out both acknowledge the notice (no reject/settings). Includes a Playwright CMP test for the homepage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a77f595ae770bc2c67d15a76f02d2bdb75dcc0a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->