### PR TITLE
Rule update: sex.com

### DIFF
--- a/rules/autoconsent/sex.com.json
+++ b/rules/autoconsent/sex.com.json
@@ -1,0 +1,45 @@
+{
+    "name": "sex.com",
+    "runContext": {
+        "urlPattern": "^https?://(\\w+\\.)?sex\\.com/"
+    },
+    "prehideSelectors": ["[class*=\"cookie-consent-required\"]"],
+    "detectCmp": [
+        {
+            "comment": "the flag is cleared once consent is stored, so it prevents re-detecting the leftover markup",
+            "exists": "html[data-cookie-consent-required] [data-testid=\"accept-all-cookie-button\"]"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "[data-testid=\"accept-all-cookie-button\"]"
+        }
+    ],
+    "optIn": [
+        {
+            "comment": "the modal is server-rendered, buttons only respond once the dialog is hydrated and locks scrolling",
+            "waitFor": "body[data-scroll-locked]"
+        },
+        {
+            "waitForThenClick": "[data-testid=\"accept-all-cookie-button\"]"
+        }
+    ],
+    "optOut": [
+        {
+            "comment": "the modal is server-rendered, buttons only respond once the dialog is hydrated and locks scrolling",
+            "waitFor": "body[data-scroll-locked]"
+        },
+        {
+            "comment": "optional categories default to off, so confirming the defaults rejects them",
+            "waitForThenClick": "[data-testid=\"customize-cookie-button\"]"
+        },
+        {
+            "waitForThenClick": "[data-testid=\"confirm-settings-cookie-button\"]"
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "%22analytics%22%3Afalse"
+        }
+    ]
+}

--- a/tests/sex.com.spec.ts
+++ b/tests/sex.com.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('sex.com', ['https://www.sex.com/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217764122639837?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

No autoconsent exception exists for sex.com in duckduckgo/privacy-configuration (checked features/autoconsent.json and the android/ios/macos/windows/extension overrides), so this is not a duplicate fix. The reported dialog is a genuine cookie consent modal ('We care about your privacy' with 'Accept All' and 'Manage or reject Cookies'). Heuristics did not handle it for two reasons: the dialog embeds an 18+ disclaimer whose text matches DETECT_NEVER_MATCH_PATTERNS and suppresses heuristic detection, and the first layer offers no direct reject button. I deliberately did not relax the never-match patterns, since that suppression exists to protect real age gates. PublicWWW searches for accept-all-cookie-button, customize-cookie-button, confirm-settings-cookie-button and the site CDN sxccdn.com returned no other sites with this markup, so a site-specific rule is appropriate. Two implementation details: the modal is server-rendered and its buttons are no-ops for roughly two seconds until React hydrates, so both flows wait for body[data-scroll-locked] (set by the dialog's scroll lock exactly at hydration) rather than using a blind wait; and detectCmp is gated on html[data-cookie-consent-required], without which the rule kept re-detecting leftover markup after consent was already stored. Opt-out opens the preference center and confirms the defaults (optional categories default to off), storing privacy-preferences={"essential":true,"analytics":false}. A reload after opt-out produced no further cmpDetected or popupFound, so there is no re-detection loop. sex.com also shows an age-verification gate in some regions (visible behind the cookie modal in gb and de after opt-out); that is out of scope and the rule leaves it untouched. Escalation to the expanded region set was not required: the rule is site-specific, contains no region-dependent logic, and uses locale-independent data-testid selectors, and the four tested regions behaved identically.

## Steps to test this PR:

- `npx playwright test tests/sex.com.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated site-specific consent rule and test; no shared heuristics, auth, or core infrastructure changes.
> 
> **Overview**
> Adds a site-specific autoconsent rule for sex.com so the cookie modal can be handled without relaxing global age-gate heuristics.
> 
> Detection is gated on `html[data-cookie-consent-required]` to avoid re-matching leftover markup after consent is stored. Opt-in/opt-out wait for `body[data-scroll-locked]` so clicks run only after the server-rendered dialog hydrates. Opt-out opens customize and confirms defaults (optional categories off). Includes a Playwright CMP test for `https://www.sex.com/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe504948d034a494c5525ccaccf7f094430a6f15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->