### PR TITLE
Rule update: ddg_ios (ase) CPM magic report: www.ecb.europa.eu

### DIFF
--- a/lib/heuristic-patterns.ts
+++ b/lib/heuristic-patterns.ts
@@ -163,8 +163,8 @@ const REJECT_PATTERNS_ENGLISH = [
     // note that "reject and subscribe" and "reject and pay" are excluded via BUTTON_NEVER_MATCH_PATTERNS
     /^\s*(no,?\s*)?(i\s+)?(reject|deny|refuse|decline|disable)\s*(all)?\s*(but|except)?\s*(non[- ]?essential|un(necessary|required)|optional|additional|targeting|analytics|marketing|non[- ]?necessary|extra|tracking|advertising|necessary|essential)?\s*(cookies)?\s*(and\s+close)?\s*$/is,
 
-    // e.g. "i do not accept", "do not accept cookies"
-    /^\s*(i\s+)?do\s+not\s+accept\s*(cookies)?\s*$/is,
+    // e.g. "i do not accept", "do not accept cookies", "i do not accept the use of cookies"
+    /^\s*(no,?\s*)?(i\s+)?do\s+not\s+accept\s*(the\s+use\s+of\s+)?(any\s+)?(cookies)?\s*$/is,
 
     // e.g. "continue without accepting", "continue without agreeing", "continue without agreeing →"
     /^\s*(continue|proceed|continue\s+browsing)\s+without\s+(accepting|agreeing|consent|cookies|tracking)(\s*→)?\s*$/is,

--- a/tests-wtr/heuristics/heuristics-utils.test.ts
+++ b/tests-wtr/heuristics/heuristics-utils.test.ts
@@ -141,6 +141,12 @@ describe('classifyButtonTextRegex', () => {
         expect(classifyButtonTextRegex('Reject All (except Necessary)')).to.equal('reject');
     });
 
+    it('matches "do not accept" variants', () => {
+        expect(classifyButtonTextRegex('I do not accept')).to.equal('reject');
+        expect(classifyButtonTextRegex('Do not accept cookies')).to.equal('reject');
+        expect(classifyButtonTextRegex('I do not accept the use of cookies')).to.equal('reject');
+    });
+
     it('returns other for empty string', () => {
         expect(classifyButtonTextRegex('')).to.equal('other');
     });


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1216882346357771?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, anchored regex tweak plus tests. Risk is limited to heuristic misclassification of similar button text.
> 
> **Overview**
> Widens the English reject-button regex so phrases like **"I do not accept the use of cookies"** (and optional "no" / "any cookies") classify as reject, covering the ECB cookie banner.
> 
> Adds unit coverage for those variants in `classifyButtonTextRegex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7165fcf329d91c7ad5cc9dc8cca440b97a571795. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->