### PR TITLE
Rule update: ddg_android (eun) CPM magic report: www.thefoxandpheasant.com

### DIFF
--- a/rules/autoconsent/complianz-opt-out.json
+++ b/rules/autoconsent/complianz-opt-out.json
@@ -27,6 +27,12 @@
     ],
     "optOut": [
         {
+            "comment": "the popup markup exists before the library opens it; clicking too early gets undone by the pending open",
+            "waitFor": "[aria-describedby=\"cookieconsent:desc\"].cc-type-opt-out:not(.cc-invisible)",
+            "timeout": 2000,
+            "optional": true
+        },
+        {
             "if": {
                 "exists": ".cc-deny"
             },

--- a/tests/complianz-opt-out.spec.ts
+++ b/tests/complianz-opt-out.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('Complianz opt-out', ['https://www.thefoxandpheasant.com/food-menu/', 'https://www.museum.de/', 'https://www.dtv.de/'], {
+    testOptIn: false,
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1216848184558040?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small autoconsent rule timing tweak and tests only; no auth, data, or core engine changes.
> 
> **Overview**
> Fixes a race in the **Complianz opt-out** rule: the banner markup can exist before CookieConsent actually opens it, so an early `.cc-deny` click was being undone.
> 
> `optOut` now optionally waits up to 2s for `[aria-describedby="cookieconsent:desc"].cc-type-opt-out:not(.cc-invisible)` before the existing deny/preferences flow.
> 
> Adds Playwright coverage for `thefoxandpheasant.com`, `museum.de`, and `dtv.de` (opt-in tests disabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17530706d95fc9588bb8f1019f1bebbc1f528961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->