### PR TITLE
Rule update: CPM crawl #37: pornpics.com

### DIFF
--- a/rules/autoconsent/pornpics-de.json
+++ b/rules/autoconsent/pornpics-de.json
@@ -1,7 +1,7 @@
 {
     "name": "pornpics.de",
     "runContext": {
-        "urlPattern": "^https?://(www\\.)?pornpics\\.de/"
+        "urlPattern": "^https?://(www\\.)?pornpics\\.(com|de)/"
     },
     "detectCmp": [{ "exists": "#cookie-form" }],
     "detectPopup": [{ "visible": "#cookie-form" }],

--- a/tests/pornpics-de.spec.ts
+++ b/tests/pornpics-de.spec.ts
@@ -1,3 +1,3 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('pornpics.de', ['https://www.pornpics.de/']);
+generateCMPTests('pornpics.de', ['https://www.pornpics.de/', 'https://www.pornpics.com/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217262897359683?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small URL-pattern and test-site expansion for an existing consent rule; no logic or selector changes.
> 
> **Overview**
> Extends the existing `pornpics.de` autoconsent rule so it also matches **pornpics.com**. The CMP selectors and opt-in/opt-out clicks are unchanged.
> 
> The Playwright test now covers both `https://www.pornpics.de/` and `https://www.pornpics.com/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b7ff3cbf7204da5141db3fed413c7780917772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->