### PR TITLE
massage xhamster rule

### DIFF
--- a/rules/autoconsent/xhamster-eu.json
+++ b/rules/autoconsent/xhamster-eu.json
@@ -8,6 +8,7 @@
     "detectPopup": [{ "visible": "[data-role=\"cookies-modal\"] [data-opt-hydration=\"cookies-dialog-eu\"]" }],
     "optIn": [{ "waitForThenClick": "[data-role=\"cookies-modal\"] [class*=experimentalButtons] button:nth-of-type(1)" }],
     "optOut": [
+        { "waitForVisible": "[data-role=\"cookies-modal\"] [class*=experimentalButtons] button:nth-of-type(2)" },
         { "waitForThenClick": "[data-role=\"cookies-modal\"] [class*=experimentalButtons] button:nth-of-type(2)" },
         { "hide": "[data-role=\"cookies-modal\"] [class*=container]", "optional": true }
     ]

--- a/rules/autoconsent/xhamster-eu.json
+++ b/rules/autoconsent/xhamster-eu.json
@@ -9,7 +9,8 @@
     "optIn": [{ "waitForThenClick": "[data-role=\"cookies-modal\"] [class*=experimentalButtons] button:nth-of-type(1)" }],
     "optOut": [
         { "waitForVisible": "[data-role=\"cookies-modal\"] [class*=experimentalButtons] button:nth-of-type(2)" },
-        { "waitForThenClick": "[data-role=\"cookies-modal\"] [class*=experimentalButtons] button:nth-of-type(2)" },
+        { "wait": 500 },
+        { "click": "[data-role=\"cookies-modal\"] [class*=experimentalButtons] button:nth-of-type(2)" },
         { "hide": "[data-role=\"cookies-modal\"] [class*=container]", "optional": true }
     ]
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217579246546562?focus=true

## Description:

<!--
Don't forget to label the PR.

Version labels use the `version:` prefix, for example `version: patch`.
Category labels use the `category:` prefix, for example `category: rules`.
Details: https://github.com/duckduckgo/autoconsent/blob/main/docs/release-notes.md
-->

## Steps to test this PR:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Site-specific autoconsent rule tweak only; no engine, auth, or data-handling changes.
> 
> **Overview**
> Makes the xhamster EU cookie-banner **opt-out** more reliable by waiting for the reject button to be visible, pausing 500ms, then clicking it instead of using a single `waitForThenClick`.
> 
> The optional hide of the modal container is unchanged. Opt-in is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8f235a61e7d4c21064f51fbd08f7b3d57e839bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->