### PR TITLE
Rule update: CPM feedback: justwatch.com

### DIFF
--- a/rules/autoconsent/justwatch-com.json
+++ b/rules/autoconsent/justwatch-com.json
@@ -7,7 +7,7 @@
     "optOut": [
         { "click": ".consent-banner__actions button.basic-button.secondary" },
         { "waitForThenClick": ".consent-modal__footer button.basic-button.secondary" },
-        { "waitForThenClick": ".consent-modal ion-content > div > a:nth-child(9)" },
+        { "waitForThenClick": ".consent-modal .base-modal__body a", "all": true },
         { "click": "label.consent-switch input[type=checkbox]:checked", "all": true, "optional": true },
         { "waitForVisible": ".consent-modal__footer button.basic-button.primary" },
         { "click": ".consent-modal__footer button.basic-button.primary" }

--- a/tests/justwatch-com.spec.ts
+++ b/tests/justwatch-com.spec.ts
@@ -1,3 +1,3 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('justwatch.com', ['https://www.justwatch.com/'], {});
+generateCMPTests('justwatch.com', ['https://www.justwatch.com/', 'https://www.justwatch.com/us/movie/a-knights-tale'], {});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217623048091140?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only autoconsent rule selectors and test URLs for justwatch.com; no auth, data handling, or shared runtime logic.
> 
> **Overview**
> Updates the **justwatch.com** autoconsent **optOut** flow after a CMP/layout change on the consent modal.
> 
> The step that opens or navigates consent settings no longer uses `.consent-modal ion-content > div > a:nth-child(9)`. It now **`waitForThenClick`s** `.consent-modal .base-modal__body a` with **`all: true`**, so every matching link in the modal body is clicked instead of relying on a fixed child index.
> 
> Playwright coverage adds **`https://www.justwatch.com/us/movie/a-knights-tale`** alongside the homepage so the rule is exercised on a content URL, not only the root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7eed82cef4623e73e0dc673009f9bd45bd99460. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->