### PR TITLE
Rule update: bbva

### DIFF
--- a/rules/autoconsent/bbva.json
+++ b/rules/autoconsent/bbva.json
@@ -1,0 +1,12 @@
+{
+    "name": "bbva",
+    "prehideSelectors": [".cookiesgdpr__base:has(.cookiesgdpr__rejectbtn)"],
+    "detectCmp": [{ "exists": ".cookiesgdpr__base .cookiesgdpr__rejectbtn" }],
+    "detectPopup": [{ "visible": ".cookiesgdpr__base .cookiesgdpr__rejectbtn" }],
+    "optIn": [{ "waitForThenClick": ".cookiesgdpr__base .cookiesgdpr__acceptbtn" }],
+    "optOut": [
+        { "waitForThenClick": ".cookiesgdpr__base .cookiesgdpr__rejectbtn" },
+        { "waitForVisible": ".cookiesgdpr__base .cookiesgdpr__wrapper", "check": "none" }
+    ],
+    "test": [{ "cookieContains": "\"analitica\":false" }]
+}

--- a/tests/bbva.spec.ts
+++ b/tests/bbva.spec.ts
@@ -1,0 +1,4 @@
+import generateCMPTests from '../playwright/runner';
+
+// bbva.es uses the same banner, but its bot protection blocks datacenter IPs, so it is not listed here.
+generateCMPTests('bbva', ['https://www.bbvauk.com/', 'https://www.bbva.be/'], {});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217814051600992?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

No autoconsent exception exists for bbva.es in duckduckgo/privacy-configuration (checked features/autoconsent.json and the android/ios/macos/windows/extension override files). Root cause: BBVA renders its own AEM consent dialog (.cookiesgdpr__base with Aceptar/Declinar/Configurar) while also loading the OneTrust SDK, whose #onetrust-banner-sdk element is present but permanently display:none. Onetrust.detectCmp() only checks element existence, so the generic stage matched OneTrust and ended rule detection before the heuristic stage could run; autoconsent then waited forever for a OneTrust popup that never appears. Heuristics would otherwise have handled the dialog ('Declinar' matches the existing Spanish reject pattern). I did not change the OneTrust rule: requiring visibility in its detectCmp would risk breaking the many sites where OneTrust reveals its banner after the detection retries are exhausted. Instead added a generic rules/autoconsent/bbva.json that runs alongside OneTrust in the generic stage, so detectPopups() resolves on whichever popup actually shows. Selectors are anchored on .cookiesgdpr__rejectbtn/.cookiesgdpr__wrapper, which PublicWWW shows are BBVA-only (bbva.es, bbvauk.com, bbva.be, bbva.fr); a different flavour of the same cookiesgdpr component used by Spanish sites such as cata.com (.cookiesgdpr__rejectallbtn) is deliberately not matched, and cata.com was re-tested to confirm it still opts out via HEURISTIC-REJECT. Opting out writes aceptarCookies with all optional categories false; after consent the banner markup is absent on reload, so there is no false-positive re-detection (verified with a second page load in the same context). Spot checks: bbvauk.com (gb) and bbva.be (nl) both PASS with self-test true. No region escalation: the rule has no region-dependent logic and no language-dependent selectors, and the four core-set regions behaved identically before and after. Related site bundesliga.com shows a Contentpass pay-or-consent wall, which is out of scope and unaffected by this change. npm run lint, npm run rule-syntax-check and npm run test:lib (838 unit tests) all pass.

## Steps to test this PR:

- `npx playwright test tests/bbva.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds site-specific autoconsent selectors and tests only; no auth, secrets, or shared infrastructure changes.
> 
> **Overview**
> Adds a new **bbva** autoconsent rule so BBVA’s visible AEM cookie dialog (`.cookiesgdpr__*`) can be detected and handled instead of stalling on a hidden OneTrust banner.
> 
> The rule **pre-hides** the BBVA banner when a reject button is present, **detects** the popup via the reject button visibility, **opts in** via accept and **opts out** via reject (then confirms the wrapper is gone). Self-test checks consent cookie content for `"analitica":false`.
> 
> Playwright coverage runs the rule against `bbvauk.com` and `bbva.be`; `bbva.es` is omitted from the test list because datacenter IPs are blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a83f3f4e6738705a6354715b1862fce4f2665546. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->