### PR TITLE
Rule update: Cookie popup shown on ebay.com

### DIFF
--- a/rules/autoconsent/ebay.json
+++ b/rules/autoconsent/ebay.json
@@ -21,11 +21,45 @@
     "optIn": [
         {
             "waitForThenClick": "#gdpr-banner-accept"
+        },
+        {
+            "waitForVisible": "#gdpr-banner",
+            "check": "none",
+            "timeout": 2000,
+            "optional": true
+        },
+        {
+            "if": {
+                "visible": "#gdpr-banner"
+            },
+            "then": [
+                {
+                    "waitForThenClick": "#gdpr-banner-accept",
+                    "timeout": 2000
+                }
+            ]
         }
     ],
     "optOut": [
         {
             "waitForThenClick": "#gdpr-banner-decline"
+        },
+        {
+            "waitForVisible": "#gdpr-banner",
+            "check": "none",
+            "timeout": 2000,
+            "optional": true
+        },
+        {
+            "if": {
+                "visible": "#gdpr-banner"
+            },
+            "then": [
+                {
+                    "waitForThenClick": "#gdpr-banner-decline",
+                    "timeout": 2000
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217738149270197?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes ebay cookie-banner automation JSON; no app logic, auth, or data handling.
> 
> **Overview**
> Updates the **ebay** autoconsent rule so accept and decline flows handle the `#gdpr-banner` appearing late or needing a second attempt.
> 
> After the existing immediate click on `#gdpr-banner-accept` / `#gdpr-banner-decline`, the rule now **optionally waits** (2s) for the banner with `check: "none"`, then **conditionally retries** the same click if the banner is still visible. **optIn** and **optOut** mirror the same structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28493e5f90fc7a2f524bbf29768ee60c6701a994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->