### PR TITLE
Rule update: Cookie popup on alexjoneslive.com

### DIFF
--- a/rules/autoconsent/wpconsent.json
+++ b/rules/autoconsent/wpconsent.json
@@ -1,0 +1,30 @@
+{
+    "name": "WPConsent",
+    "vendorUrl": "https://wordpress.org/plugins/wpconsent-cookies-banner-privacy-suite/",
+    "prehideSelectors": ["#wpconsent-root"],
+    "detectCmp": [
+        {
+            "exists": "#wpconsent-container"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": ["#wpconsent-container", "#wpconsent-banner-holder.wpconsent-banner-visible"]
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": ["#wpconsent-container", "#wpconsent-accept-all"]
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": ["#wpconsent-container", "#wpconsent-cancel-all"]
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "wpconsent_preferences="
+        }
+    ]
+}

--- a/tests/wpconsent.spec.ts
+++ b/tests/wpconsent.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('WPConsent', ['https://www.allthebestfights.com/', 'https://usatourist.com/'], {
+    testSelfTest: false,
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217579659452221?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new isolated CMP rule and tests only; no changes to shared autoconsent infrastructure or existing rules.
> 
> **Overview**
> Adds autoconsent support for the **WPConsent** WordPress plugin via a new `rules/autoconsent/wpconsent.json` rule.
> 
> Detection targets `#wpconsent-container` and visible banner state; **opt-in** clicks `#wpconsent-accept-all` and **opt-out** clicks `#wpconsent-cancel-all`, with `#wpconsent-root` prehidden. Consent is verified with a `wpconsent_preferences=` cookie check.
> 
> Playwright coverage is added in `tests/wpconsent.spec.ts` against `allthebestfights.com` and `usatourist.com`, with `testSelfTest: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6e966823493c6aae0dc3e1c44866184de643550. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->