### PR TITLE
Rule update: Cookie Popup on pay.amazon.co.jp

### DIFF
--- a/rules/autoconsent/amazon-pay.json
+++ b/rules/autoconsent/amazon-pay.json
@@ -1,0 +1,13 @@
+{
+    "name": "amazon-pay",
+    "vendorUrl": "https://pay.amazon.com/",
+    "runContext": {
+        "urlPattern": "^https?://pay\\.amazon\\."
+    },
+    "prehideSelectors": [".cookie-menu.js-cookie-banner"],
+    "detectCmp": [{ "exists": ".cookie-menu.js-cookie-banner .js-cookie-banner-close" }],
+    "detectPopup": [{ "visible": ".cookie-menu.js-cookie-banner" }],
+    "optIn": [{ "click": ".cookie-menu.js-cookie-banner .js-cookie-banner-close" }],
+    "optOut": [{ "click": ".cookie-menu.js-cookie-banner .js-cookie-banner-close" }],
+    "test": [{ "cookieContains": "apaycnst-mktg=true" }]
+}

--- a/tests/amazon-pay.spec.ts
+++ b/tests/amazon-pay.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('amazon-pay', ['https://pay.amazon.co.jp/', 'https://pay.amazon.co.uk/', 'https://pay.amazon.de/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217812414655823?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated autoconsent rule and tests only; no changes to shared runner or security-sensitive code paths.
> 
> **Overview**
> Adds a new **autoconsent** rule for Amazon Pay (`pay.amazon.*`) so the extension can detect and dismiss the marketing cookie banner (`.cookie-menu.js-cookie-banner`).
> 
> **Opt-in** and **opt-out** both click the banner close control, and success is verified via the `apaycnst-mktg=true` cookie. Playwright CMP tests cover **Japan**, **UK**, and **Germany** regional pay sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79499cf28f57334a8204a32df148ae24eb7ec19a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->