### PR TITLE
Add optional retry in waitForThenClick

### DIFF
--- a/docs/rule-syntax.md
+++ b/docs/rule-syntax.md
@@ -103,10 +103,21 @@ Click on an element returned by `selector`. If `all` is `true`, all matching ele
 {
   "waitForThenClick": ElementSelector,
   "timeout": 1000,
-  "all": true | false
+  "all": true | false,
+  "retry": 0,
+  "retryInterval": 300
 }
 ```
 Combines `waitFor` and `click`.
+
+`retry` is the number of extra click attempts if the element is still visible after the click, `0` by
+default. It works around CMPs that insert a button before its click handler is attached.
+Between attempts the step waits up to `retryInterval` ms (300 by default) for the element to
+disappear, and stops retrying as soon as it does. Prefer this over an unconditional `wait` before the
+click: nothing is added to the step's duration when the first click works.
+
+**Only use `retry` on elements that are expected to go away** once the click is handled — a button that
+stays visible (e.g. a toggle) would be clicked repeatedly.
 
 ## Unconditional wait
 ```javascript

--- a/lib/cmps/base.ts
+++ b/lib/cmps/base.ts
@@ -180,12 +180,12 @@ export default class AutoConsentCMPBase implements AutoCMP, DomActionsProvider {
         return this.autoconsent.domActions.waitForVisible(selector, timeout, check);
     }
 
-    async waitForThenClick(selector: ElementSelector, timeout?: number, all?: boolean) {
+    async waitForThenClick(selector: ElementSelector, timeout?: number, all?: boolean, retries?: number, retryInterval?: number) {
         if (this.autoconsent.config.visualTest) {
             await this.highlightElements(this.elementSelector(selector), all);
         }
         this.autoconsent.updateState({ clicks: this.autoconsent.state.clicks + 1 });
-        return this.autoconsent.domActions.waitForThenClick(selector, timeout, all);
+        return this.autoconsent.domActions.waitForThenClick(selector, timeout, all, retries, retryInterval);
     }
 
     wait(ms: number) {
@@ -336,7 +336,7 @@ export class AutoConsentCMP extends AutoConsentCMPBase {
             results.push(this.click(rule.click, rule.all));
         }
         if (rule.waitForThenClick) {
-            results.push(this.waitForThenClick(rule.waitForThenClick, rule.timeout, rule.all));
+            results.push(this.waitForThenClick(rule.waitForThenClick, rule.timeout, rule.all, rule.retry, rule.retryInterval));
         }
         if (rule.wait) {
             results.push(this.wait(rule.wait));

--- a/lib/dom-actions.ts
+++ b/lib/dom-actions.ts
@@ -3,6 +3,11 @@ import { DomActionsProvider } from './types';
 import { getStyleElement, hideElements, appendStylesheetRule, isElementVisible, waitFor } from './utils';
 import AutoConsent from './web';
 
+// Default for the `retryInterval` option of `waitForThenClick`.
+export const DEFAULT_CLICK_RETRY_INTERVAL = 300;
+// How often we check if the element is gone while waiting out a `retryInterval`.
+const CLICK_RETRY_POLL_INTERVAL = 50;
+
 export class DomActions implements DomActionsProvider {
     constructor(public autoconsentInstance: AutoConsent) {}
 
@@ -66,9 +71,28 @@ export class DomActions implements DomActionsProvider {
         return waitFor(() => this.elementVisible(selector, check), times, interval);
     }
 
-    async waitForThenClick(selector: ElementSelector, timeout = 10000, all = false): Promise<boolean> {
+    async waitForThenClick(
+        selector: ElementSelector,
+        timeout = 10000,
+        all = false,
+        retries = 0,
+        retryInterval = DEFAULT_CLICK_RETRY_INTERVAL,
+    ): Promise<boolean> {
         await this.waitForElement(selector, timeout);
-        return await this.click(selector, all);
+        let clicked = await this.click(selector, all);
+        // Some CMPs insert the button before its click handler is attached, so the first click is
+        // silently dropped. There is usually no DOM signal for this, but a click that was handled
+        // makes the element go away: if it is still visible, we assume the click was lost and repeat it.
+        for (let attempt = 0; clicked && attempt < retries; attempt++) {
+            const pollTimes = Math.ceil(retryInterval / CLICK_RETRY_POLL_INTERVAL);
+            const isGone = await waitFor(() => !this.elementVisible(selector, 'any'), pollTimes, CLICK_RETRY_POLL_INTERVAL);
+            if (isGone) {
+                break;
+            }
+            this.autoconsentInstance.config.logs.rulesteps && console.log('[waitForThenClick] retrying click', selector);
+            clicked = await this.click(selector, all);
+        }
+        return clicked;
     }
 
     wait(ms: number): Promise<true> {

--- a/lib/rules.ts
+++ b/lib/rules.ts
@@ -99,6 +99,16 @@ export type WaitForThenClickRule = {
     waitForThenClick: ElementSelector;
     timeout?: number;
     all?: boolean;
+    /**
+     * Number of additional click attempts if the element is still visible after the first click.
+     * Defaults to 0 (no retries). Only use this on elements that are expected to disappear once the
+     * click is handled, otherwise the extra clicks are wasted (or harmful).
+     */
+    retry?: number;
+    /**
+     * How long to wait (in ms) for the element to disappear before clicking it again.
+     */
+    retryInterval?: number;
 };
 
 export type WaitRule = {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -29,7 +29,13 @@ export interface DomActionsProvider {
     elementVisible(selector: ElementSelector, check: VisibilityCheck): boolean;
     waitForElement(selector: ElementSelector, timeout?: number): Promise<boolean>;
     waitForVisible(selector: ElementSelector, timeout?: number, check?: VisibilityCheck): Promise<boolean>;
-    waitForThenClick(selector: ElementSelector, timeout?: number, all?: boolean): Promise<boolean>;
+    waitForThenClick(
+        selector: ElementSelector,
+        timeout?: number,
+        all?: boolean,
+        retries?: number,
+        retryInterval?: number,
+    ): Promise<boolean>;
     wait(ms: number): Promise<true>;
     hide(selector: string, method: HideMethod): boolean;
     removeClass(selector: ElementSelector, className: string): boolean;

--- a/tests-wtr/dom-actions/dom-actions.wait-for-then-click.html
+++ b/tests-wtr/dom-actions/dom-actions.wait-for-then-click.html
@@ -1,0 +1,14 @@
+<html>
+    <body>
+        <script type="module">
+            import { runTests } from '@web/test-runner-mocha';
+
+            runTests(async () => {
+                await import('./dom-actions.wait-for-then-click');
+            });
+        </script>
+
+        <h1>Hello test</h1>
+        <div id="container"></div>
+    </body>
+</html>

--- a/tests-wtr/dom-actions/dom-actions.wait-for-then-click.ts
+++ b/tests-wtr/dom-actions/dom-actions.wait-for-then-click.ts
@@ -1,0 +1,106 @@
+import { expect } from '@esm-bundle/chai';
+import { instantiateDomActions } from './utils';
+
+// A short interval keeps the tests fast; the retry loop polls every 50ms regardless.
+const RETRY_INTERVAL = 50;
+
+// must be run from dom-actions.wait-for-then-click.html
+describe('waitForThenClick', () => {
+    let clicks: number;
+
+    /**
+     * Adds a button that hides itself once it has been clicked `handledAfterClicks` times.
+     * `handledAfterClicks: 0` simulates a button whose click handler is never effective.
+     */
+    function addButton(handledAfterClicks: number): HTMLElement {
+        const button = document.createElement('button');
+        button.id = 'target';
+        button.innerText = 'Click me';
+        button.addEventListener('click', () => {
+            clicks++;
+            if (handledAfterClicks > 0 && clicks >= handledAfterClicks) {
+                button.style.display = 'none';
+            }
+        });
+        document.getElementById('container')!.appendChild(button);
+        return button;
+    }
+
+    beforeEach(() => {
+        clicks = 0;
+    });
+
+    afterEach(() => {
+        document.getElementById('container')!.innerHTML = '';
+    });
+
+    it('should click once and not retry by default', async () => {
+        const domActions = instantiateDomActions();
+        addButton(0);
+
+        const result = await domActions.waitForThenClick('#target');
+
+        expect(result).to.be.true;
+        expect(clicks).to.equal(1);
+    });
+
+    it('should retry while the element is still visible', async () => {
+        const domActions = instantiateDomActions();
+        addButton(0);
+
+        const result = await domActions.waitForThenClick('#target', 10000, false, 2, RETRY_INTERVAL);
+
+        expect(result).to.be.true;
+        expect(clicks).to.equal(3); // the first click plus two retries
+    });
+
+    it('should stop retrying as soon as the click is handled', async () => {
+        const domActions = instantiateDomActions();
+        addButton(2); // the first click is dropped, the second one hides the button
+
+        const result = await domActions.waitForThenClick('#target', 10000, false, 5, RETRY_INTERVAL);
+
+        expect(result).to.be.true;
+        expect(clicks).to.equal(2);
+    });
+
+    it('should not retry if the element disappears on the first click', async () => {
+        const domActions = instantiateDomActions();
+        addButton(1);
+
+        const result = await domActions.waitForThenClick('#target', 10000, false, 5, RETRY_INTERVAL);
+
+        expect(result).to.be.true;
+        expect(clicks).to.equal(1);
+    });
+
+    it('should not retry when retries is 0', async () => {
+        const domActions = instantiateDomActions();
+        addButton(0);
+
+        const result = await domActions.waitForThenClick('#target', 10000, false, 0, RETRY_INTERVAL);
+
+        expect(result).to.be.true;
+        expect(clicks).to.equal(1);
+    });
+
+    it('should not retry if the element never appeared', async () => {
+        const domActions = instantiateDomActions();
+
+        const result = await domActions.waitForThenClick('#nonexistent', 100, false, 5, RETRY_INTERVAL);
+
+        expect(result).to.be.false;
+        expect(clicks).to.equal(0);
+    });
+
+    it('should retry all matching elements when all is true', async () => {
+        const domActions = instantiateDomActions();
+        addButton(0);
+        addButton(0);
+
+        const result = await domActions.waitForThenClick('#target', 10000, true, 1, RETRY_INTERVAL);
+
+        expect(result).to.be.true;
+        expect(clicks).to.equal(4); // two elements, clicked twice each
+    });
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201844467387842/task/1217816336077843?focus=true

## Description:

<!--
Don't forget to label the PR.

Version labels use the `version:` prefix, for example `version: patch`.
Category labels use the `category:` prefix, for example `category: rules`.
Details: https://github.com/duckduckgo/autoconsent/blob/main/docs/release-notes.md
-->

## Steps to test this PR:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core opt-out click timing and can issue multiple clicks on the same selector; misconfigured rules on persistent controls could click more than intended, though defaults preserve prior behavior.
> 
> **Overview**
> Extends the **`waitForThenClick`** rule step with optional **`retry`** and **`retryInterval`** so CMP rules can re-click when the first click is ignored (e.g. button in the DOM before its handler is attached).
> 
> After the initial wait and click, the engine polls for the target to become **not visible**; if it stays visible within **`retryInterval`** (default 300ms), it clicks again, up to **`retry`** extra attempts (default 0). Behavior is unchanged when those fields are omitted.
> 
> **`DomActions`**, **`DomActionsProvider`**, and JSON rule evaluation in **`base.ts`** pass the new options through. **`docs/rule-syntax.md`** documents usage and warns to use **`retry`** only on elements that should disappear after a successful click.
> 
> Adds Web Test Runner coverage for default single-click behavior, retry limits, early stop when the element hides, and **`all: true`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3f10fbc73998cdcc906ca9efd9c13ef21c2562e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->