### PR TITLE
Rule update: popup on deliveroo.co.uk

### DIFF
--- a/rules/autoconsent/deliveroo.json
+++ b/rules/autoconsent/deliveroo.json
@@ -1,7 +1,7 @@
 {
     "name": "deliveroo",
     "runContext": {
-        "urlPattern": "^https?://(\\w+\\.)?deliveroo\\."
+        "urlPattern": "^https?://(\\w+\\.)?deliveroo\\.(co\\.uk|\\w+)/"
     },
     "prehideSelectors": ["div[role=\"dialog\"][class*=\"CustomCookieBanner\"]"],
     "detectCmp": [{ "exists": "div[role=\"dialog\"][class*=\"CustomCookieBanner\"]" }],

--- a/rules/autoconsent/deliveroo.json
+++ b/rules/autoconsent/deliveroo.json
@@ -1,0 +1,15 @@
+{
+    "name": "deliveroo",
+    "runContext": {
+        "urlPattern": "^https?://(\\w+\\.)?deliveroo\\."
+    },
+    "prehideSelectors": ["div[role=\"dialog\"][class*=\"CustomCookieBanner\"]"],
+    "detectCmp": [{ "exists": "div[role=\"dialog\"][class*=\"CustomCookieBanner\"]" }],
+    "detectPopup": [{ "visible": "div[role=\"dialog\"][class*=\"CustomCookieBanner\"]" }],
+    "optIn": [{ "waitForThenClick": "#onetrust-consent-sdk #accept-recommended-btn-handler" }],
+    "optOut": [
+        { "waitForThenClick": "#onetrust-consent-sdk .ot-pc-refuse-all-handler" },
+        { "waitForVisible": "div[role=\"dialog\"][class*=\"CustomCookieBanner\"]", "check": "none" }
+    ],
+    "test": [{ "cookieContains": "OptanonAlertBoxClosed" }]
+}

--- a/tests/deliveroo.spec.ts
+++ b/tests/deliveroo.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('deliveroo', ['https://deliveroo.co.uk/', 'https://deliveroo.fr/', 'https://deliveroo.it/', 'https://deliveroo.ie/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217798857562742?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds site-specific autoconsent JSON and tests only; no changes to shared runner or consent logic.
> 
> **Overview**
> Adds a new **autoconsent rule** for Deliveroo regional sites so the extension can detect and handle their cookie UI.
> 
> The rule matches Deliveroo URLs (`deliveroo.co.uk` and other TLDs), targets the **CustomCookieBanner** dialog for detection/prehide, and uses **OneTrust** handlers for accept (`#accept-recommended-btn-handler`) and refuse-all (`ot-pc-refuse-all-handler`). Opt-out also waits until the banner is no longer visible. Success is verified via the **`OptanonAlertBoxClosed`** cookie.
> 
> A **Playwright CMP test** (`deliveroo.spec.ts`) runs the rule against UK, France, Italy, and Ireland homepages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81783397e2ed67583079bb1754c468b5a53d154e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->