### PR TITLE
Rule update: ecbeing

### DIFF
--- a/rules/autoconsent/ecbeing.json
+++ b/rules/autoconsent/ecbeing.json
@@ -1,0 +1,10 @@
+{
+    "name": "ecbeing",
+    "vendorUrl": "https://www.ecbeing.net/",
+    "cosmetic": true,
+    "prehideSelectors": ["#cookieBox .block-cookie-consent"],
+    "detectCmp": [{ "exists": "#cookieBox #consentButton.block-cookie-consent--btn" }],
+    "detectPopup": [{ "visible": "#cookieBox" }],
+    "optIn": [{ "waitForThenClick": "#cookieBox #consentButton" }],
+    "optOut": [{ "hide": "#cookieBox" }]
+}

--- a/tests/ecbeing.spec.ts
+++ b/tests/ecbeing.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('ecbeing', ['https://store.kadokawa.co.jp/shop/default.aspx', 'https://www.iodata.jp/shop/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217819494397339?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

The reported banner is the ecbeing e-commerce platform's cookie notice (/js/sys/cookie_policy.js, #cookieBox + #consentButton.block-cookie-consent--btn, cookieconsent cookie), widely deployed across Japanese online shops per PublicWWW, so a generic cosmetic rule was added instead of a site-specific one. The banner has no reject or dismiss control, only an accept button, which is why the heuristic rule did not fire and why optOut hides the banner. Detection combines the generic #cookieBox id with the platform-specific consent button class to avoid false positives. Re-detection check after opting in: kadokawa removes #cookieBox from the DOM on reload and iodata keeps it hidden, so detectPopup is false in both cases and no reload loop occurs. No pre-existing autoconsent exception for kadokawa exists in duckduckgo/privacy-configuration (features/autoconsent.json plus all platform and browser override files checked).

## Steps to test this PR:

- `npx playwright test tests/ecbeing.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New site-pattern rule and tests only; no changes to core consent engine or security-sensitive paths. Detection uses a combined selector to limit false positives on generic `#cookieBox` ids.
> 
> **Overview**
> Adds a new **cosmetic** autoconsent rule for the ecbeing e-commerce platform cookie banner (`#cookieBox`, accept-only `#consentButton`), which is common on Japanese online shops.
> 
> The rule **pre-hides** the consent block, **detects** via the platform-specific button class, **opts in** by clicking accept, and **opts out** by hiding `#cookieBox` because there is no reject/dismiss control. Playwright coverage registers **kadokawa** and **iodata** shop URLs via `generateCMPTests('ecbeing', ...)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5507983b94a070fbafcfee125404982b41dc87a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->