### PR TITLE
Rule update: stright

### DIFF
--- a/rules/autoconsent/stright.json
+++ b/rules/autoconsent/stright.json
@@ -1,0 +1,29 @@
+{
+    "name": "stright",
+    "prehideSelectors": ["#controlled_banner-cookie_consent-consent_banner", "#controlled_banner-cookie_consent-privacy_setting_banner"],
+    "detectCmp": [{ "exists": "#controlled_banner-cookie_consent-consent_banner" }],
+    "detectPopup": [{ "visible": "#controlled_banner-cookie_consent-consent_banner" }],
+    "optIn": [{ "waitForThenClick": "#controlled_submit-cookie_consent-consent_banner-accept_all" }],
+    "optOut": [
+        {
+            "if": {
+                "visible": "#controlled_banner-cookie_consent-consent_banner [data-search-key-button=reject_all_text]"
+            },
+            "then": [
+                {
+                    "waitForThenClick": "#controlled_banner-cookie_consent-consent_banner [data-search-key-button=reject_all_text]"
+                }
+            ],
+            "else": [
+                {
+                    "waitForThenClick": "#controlled_submit-cookie_consent-consent_banner-privacy_setting_banner_link"
+                },
+                {
+                    "waitForThenClick": "#controlled_banner-cookie_consent-privacy_setting_banner [data-search-key-button=reject_all_text]"
+                }
+            ]
+        },
+        { "waitForVisible": "#controlled_banner-cookie_consent-consent_banner", "check": "none" }
+    ],
+    "test": [{ "visible": "#controlled_banner-cookie_consent-consent_banner", "check": "none" }]
+}

--- a/tests/stright.spec.ts
+++ b/tests/stright.spec.ts
@@ -1,0 +1,8 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('stright', [
+    // 'https://www.kadokawa.co.jp/', // does not serve the banner to CI egress IPs, only reproducible via a regional proxy
+    'https://www.toei-anim.co.jp/',
+    'https://www.makita.co.jp/',
+    'https://www.yamada-denki.jp/',
+]);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217820004091365?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

The popup is served by STRIGHT, a consent management platform from Internet Initiative Japan (IIJ), loaded from cdn01.stright.bizris.com and previously unsupported by autoconsent. It is region-aware: under GDPR the first-layer banner exposes a Reject All button (which the existing heuristic rule already handled), while in jp/us/au/ca the first layer only offers Privacy Settings, OK and a close icon, leaving the banner unhandled. The new generic rule rules/autoconsent/stright.json clicks the banner-level reject button when present and otherwise opens the privacy-settings dialog and clicks Reject All there, using the CMP's locale-independent data-search-key-button attributes rather than visible text. PublicWWW shows the CMP on 100+ mostly Japanese sites (makita.co.jp, toei-anim.co.jp, yamada-denki.jp, tsukumo.co.jp, jprs.jp, nhk-p.co.jp), which justified a generic rule over a site-specific one. Escalated to the expanded region set because the rule has region-dependent branching. Reload-after-dismissal check: the CMP does not render the banner again, so the rule stops matching and there is no reload loop. No autoconsent exception exists for kadokawa.co.jp in duckduckgo/privacy-configuration (checked features/autoconsent.json and the android/ios/macos/windows/extension overrides).

## Steps to test this PR:

- `npx playwright test tests/stright.spec.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated new CMP rule and tests only; no changes to core extension logic, though live-site opt-out flows depend on stable STRIGHT DOM selectors.
> 
> **Overview**
> Adds support for the **STRIGHT** consent platform (IIJ) via a new `rules/autoconsent/stright.json` rule keyed on `#controlled_banner-cookie_consent-consent_banner`, with prehide selectors for the main and privacy-settings banners.
> 
> **Opt-out** branches on region: if a first-layer `[data-search-key-button=reject_all_text]` is visible it clicks it; otherwise it opens privacy settings and rejects there, then verifies the banner is gone. **Opt-in** accepts via the accept-all submit control; **test** asserts the banner is not visible after dismissal.
> 
> Adds `tests/stright.spec.ts` running the shared CMP runner against Toei Animation, Makita, and Yamada Denki (Kadokawa left commented because the banner does not appear from CI egress IPs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abaa5da6f1adeb39cf2d082d8da5acb41282ee89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->