### PR TITLE
Rule update: regression on www.wohnen.de

### DIFF
--- a/lib/cmps/cookiebot.ts
+++ b/lib/cmps/cookiebot.ts
@@ -30,14 +30,14 @@ export default class Cookiebot extends AutoConsentCMPBase {
         if (this.elementVisible('#CybotCookiebotDialogBodyLevelButtonLevelOptinDeclineAll')) {
             return await this.click('#CybotCookiebotDialogBodyLevelButtonLevelOptinDeclineAll');
         }
-        // Custom dialog templates reuse Cookiebot button ids but aren't closed by Cookiebot.hide().
-        if (this.elementVisible('#CybotCookiebotDialogBodyButtonDecline')) {
-            return await this.click('#CybotCookiebotDialogBodyButtonDecline');
-        }
         await this.wait(500);
         let res = await this.mainWorldEval('EVAL_COOKIEBOT_3'); // withdraw
         await this.wait(1000); // prevent race conditions
         res = res && (await this.mainWorldEval('EVAL_COOKIEBOT_4')); // hide
+        // Custom dialog templates reuse Cookiebot button ids but aren't closed by Cookiebot.hide().
+        if (this.elementVisible('#CybotCookiebotDialogBodyButtonDecline')) {
+            return await this.click('#CybotCookiebotDialogBodyButtonDecline');
+        }
         return res;
     }
 

--- a/lib/cmps/cookiebot.ts
+++ b/lib/cmps/cookiebot.ts
@@ -30,6 +30,10 @@ export default class Cookiebot extends AutoConsentCMPBase {
         if (this.elementVisible('#CybotCookiebotDialogBodyLevelButtonLevelOptinDeclineAll')) {
             return await this.click('#CybotCookiebotDialogBodyLevelButtonLevelOptinDeclineAll');
         }
+        // Custom dialog templates reuse Cookiebot button ids but aren't closed by Cookiebot.hide().
+        if (this.elementVisible('#CybotCookiebotDialogBodyButtonDecline')) {
+            return await this.click('#CybotCookiebotDialogBodyButtonDecline');
+        }
         await this.wait(500);
         let res = await this.mainWorldEval('EVAL_COOKIEBOT_3'); // withdraw
         await this.wait(1000); // prevent race conditions

--- a/tests/cookiebot.spec.ts
+++ b/tests/cookiebot.spec.ts
@@ -10,7 +10,7 @@ generateCMPTests(
         // "https://www.ab-in-den-urlaub.de/", // often blocked by botwall
         'https://www.vatera.hu/',
         'https://www.bax-shop.nl/',
-        // Dialogs whose only decline button is CybotCookiebotDialogBodyButtonDecline
+        // Dialogs whose only decline control is CybotCookiebotDialogBodyButtonDecline
         'https://www.drukwerkdeal.nl/',
         'https://www.freelance.de/',
         'https://www.printdeal.be/',

--- a/tests/cookiebot.spec.ts
+++ b/tests/cookiebot.spec.ts
@@ -10,6 +10,10 @@ generateCMPTests(
         // "https://www.ab-in-den-urlaub.de/", // often blocked by botwall
         'https://www.vatera.hu/',
         'https://www.bax-shop.nl/',
+        // Dialogs whose only decline button is CybotCookiebotDialogBodyButtonDecline
+        'https://www.drukwerkdeal.nl/',
+        'https://www.freelance.de/',
+        'https://www.printdeal.be/',
     ],
     {
         skipRegions: ['US'],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217866271421027?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow fallback in Cookiebot opt-out and added test URLs; no auth or data-handling changes.
> 
> **Overview**
> Fixes **Cookiebot** opt-out regressions on sites that use **custom dialog templates** that reuse standard Cybot button IDs but are **not dismissed** by `Cookiebot.hide()`.
> 
> After the existing withdraw/hide path in `optOut()`, the rule now **clicks `#CybotCookiebotDialogBodyButtonDecline`** when that control is still visible. CMP tests add **drukwerkdeal.nl**, **freelance.de**, and **printdeal.be** as coverage for dialogs where that button is the only decline path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 651b6b7901cc7adab64893ff10f4128ef3660f6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->