### PR TITLE
Rule update: CPM crawl #28: walmart.ca

### DIFF
--- a/rules/autoconsent/walmart-ca.json
+++ b/rules/autoconsent/walmart-ca.json
@@ -26,10 +26,9 @@
     ],
     "optOut": [
         {
-            "waitForThenClick": "button[data-dca-intent=\"open\"][role=\"link\"]"
-        },
-        {
-            "wait": 2000
+            "waitForThenClick": "button[data-dca-intent=\"open\"][role=\"link\"]",
+            "retry": 5,
+            "retryInterval": 500
         },
         {
             "waitForThenClick": "xpath///button[contains(., 'Save settings') or contains(., 'Enregistrer les paramètres')]",

--- a/rules/autoconsent/walmart-ca.json
+++ b/rules/autoconsent/walmart-ca.json
@@ -1,0 +1,29 @@
+{
+    "name": "walmart-ca",
+    "vendorUrl": "https://www.walmart.ca/",
+    "cosmetic": true,
+    "runContext": {
+        "urlPattern": "^https?://(www\\.)?walmart\\.ca/"
+    },
+    "prehideSelectors": [],
+    "detectCmp": [
+        {
+            "exists": "#third-party-cookie-detection"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "a[href=\"https://www.walmartcanada.ca/cookie-notice\"]"
+        }
+    ],
+    "optIn": [
+        {
+            "hide": "section[role=\"banner\"]:has(a[href=\"https://www.walmartcanada.ca/cookie-notice\"]), div[role=\"dialog\"]:has(a[href=\"https://www.walmartcanada.ca/cookie-notice\"])"
+        }
+    ],
+    "optOut": [
+        {
+            "hide": "section[role=\"banner\"]:has(a[href=\"https://www.walmartcanada.ca/cookie-notice\"]), div[role=\"dialog\"]:has(a[href=\"https://www.walmartcanada.ca/cookie-notice\"])"
+        }
+    ]
+}

--- a/rules/autoconsent/walmart-ca.json
+++ b/rules/autoconsent/walmart-ca.json
@@ -31,8 +31,7 @@
             "retryInterval": 500
         },
         {
-            "waitForThenClick": "xpath///button[contains(., 'Save settings') or contains(., 'Enregistrer les paramètres')]",
-            "optional": true
+            "waitForThenClick": "xpath///button[contains(., 'Save settings') or contains(., 'Enregistrer les paramètres')]"
         },
         {
             "waitForVisible": "a[href=\"https://www.walmartcanada.ca/cookie-notice\"]",

--- a/rules/autoconsent/walmart-ca.json
+++ b/rules/autoconsent/walmart-ca.json
@@ -1,14 +1,14 @@
 {
     "name": "walmart-ca",
     "vendorUrl": "https://www.walmart.ca/",
-    "cosmetic": true,
+    "cosmetic": false,
     "runContext": {
         "urlPattern": "^https?://(www\\.)?walmart\\.ca/"
     },
     "prehideSelectors": [],
     "detectCmp": [
         {
-            "exists": "#third-party-cookie-detection"
+            "exists": "a[href=\"https://www.walmartcanada.ca/cookie-notice\"]"
         }
     ],
     "detectPopup": [
@@ -18,12 +18,21 @@
     ],
     "optIn": [
         {
-            "hide": "section[role=\"banner\"]:has(a[href=\"https://www.walmartcanada.ca/cookie-notice\"]), div[role=\"dialog\"]:has(a[href=\"https://www.walmartcanada.ca/cookie-notice\"])"
+            "waitForThenClick": "xpath///button[contains(., 'Manage cookie settings')]"
+        },
+        {
+            "waitForThenClick": "button[aria-label=\"acceptAll button\"]"
         }
     ],
     "optOut": [
         {
-            "hide": "section[role=\"banner\"]:has(a[href=\"https://www.walmartcanada.ca/cookie-notice\"]), div[role=\"dialog\"]:has(a[href=\"https://www.walmartcanada.ca/cookie-notice\"])"
+            "waitForThenClick": "xpath///button[contains(., 'Manage cookie settings')]"
+        },
+        {
+            "wait": 2000
+        },
+        {
+            "waitForThenClick": "button[aria-label=\"Save settings button\"]"
         }
     ]
 }

--- a/rules/autoconsent/walmart-ca.json
+++ b/rules/autoconsent/walmart-ca.json
@@ -18,7 +18,7 @@
     ],
     "optIn": [
         {
-            "waitForThenClick": "xpath///button[contains(., 'Manage cookie settings')]"
+            "waitForThenClick": "button[data-dca-intent=\"open\"][role=\"link\"]"
         },
         {
             "waitForThenClick": "button[aria-label=\"acceptAll button\"]"
@@ -26,13 +26,19 @@
     ],
     "optOut": [
         {
-            "waitForThenClick": "xpath///button[contains(., 'Manage cookie settings')]"
+            "waitForThenClick": "button[data-dca-intent=\"open\"][role=\"link\"]"
         },
         {
             "wait": 2000
         },
         {
-            "waitForThenClick": "button[aria-label=\"Save settings button\"]"
+            "waitForThenClick": "xpath///button[contains(., 'Save settings') or contains(., 'Enregistrer les paramètres')]",
+            "optional": true
+        },
+        {
+            "waitForVisible": "a[href=\"https://www.walmartcanada.ca/cookie-notice\"]",
+            "check": "none",
+            "timeout": 5000
         }
     ]
 }

--- a/rules/autoconsent/walmart-ca.json
+++ b/rules/autoconsent/walmart-ca.json
@@ -32,7 +32,9 @@
         },
         {
             "waitForThenClick": "xpath///button[contains(., 'Save settings') or contains(., 'Enregistrer les paramètres')]"
-        },
+        }
+    ],
+    "test": [
         {
             "waitForVisible": "a[href=\"https://www.walmartcanada.ca/cookie-notice\"]",
             "check": "none",

--- a/tests/walmart-ca.spec.ts
+++ b/tests/walmart-ca.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('walmart-ca', ['https://www.walmart.ca/en'], { testOptIn: false, testSelfTest: false });

--- a/tests/walmart-ca.spec.ts
+++ b/tests/walmart-ca.spec.ts
@@ -1,3 +1,3 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('walmart-ca', ['https://www.walmart.ca/en'], { testOptIn: false, testSelfTest: false });
+generateCMPTests('walmart-ca', ['https://www.walmart.ca/en', 'https://www.walmart.ca/fr'], { testOptIn: false, testSelfTest: false });

--- a/tests/walmart-ca.spec.ts
+++ b/tests/walmart-ca.spec.ts
@@ -1,3 +1,3 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('walmart-ca', ['https://www.walmart.ca/en', 'https://www.walmart.ca/fr'], { testOptIn: false, testSelfTest: false });
+generateCMPTests('walmart-ca', ['https://www.walmart.ca/en', 'https://www.walmart.ca/fr'], { testOptIn: false });


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217262863106572?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new site-specific JSON rule and test file only; no changes to shared autoconsent or runner logic.
> 
> **Overview**
> Adds **autoconsent coverage for walmart.ca** via a new `walmart-ca` rule and matching Playwright spec.
> 
> The rule targets `walmart.ca` URLs, detects the cookie UI via the walmartcanada cookie-notice link, and defines **opt-in** (open preferences, accept all) and **opt-out** (open preferences, save settings with English/French button text) click sequences. Post-opt-out verification waits for that notice link to disappear.
> 
> **Tests** run the shared CMP runner against `https://www.walmart.ca/en` and `/fr` with `testOptIn: false`, consistent with other opt-out-focused CMP specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0ee8a6610b73a7a4e129d9a4505757580b3f16b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->