### PR TITLE
Rule update: xnxx.com (manual entry)

### DIFF
--- a/rules/autoconsent/xnxx-com.json
+++ b/rules/autoconsent/xnxx-com.json
@@ -15,14 +15,26 @@
     "optIn": [
         {
             "if": { "visible": ".disclaimer-opened #disclaimer-cookies" },
-            "then": [{ "waitForThenClick": "#disclaimer-accept_cookies" }],
+            "then": [
+                {
+                    "if": { "exists": "#disclaimer-accept_cookies" },
+                    "then": [{ "waitForThenClick": "#disclaimer-accept_cookies" }],
+                    "else": [{ "waitForThenClick": "#disclaimer_message .disclaimer-enter-btn" }]
+                }
+            ],
             "else": [{ "click": "#cookies-use-alert .close" }]
         }
     ],
     "optOut": [
         {
             "if": { "visible": ".disclaimer-opened #disclaimer-cookies" },
-            "then": [{ "waitForThenClick": "#disclaimer-reject_cookies" }],
+            "then": [
+                {
+                    "if": { "exists": "#disclaimer-reject_cookies" },
+                    "then": [{ "waitForThenClick": "#disclaimer-reject_cookies" }],
+                    "else": [{ "waitForThenClick": "#disclaimer_message .disclaimer-enter-btn" }]
+                }
+            ],
             "else": [{ "hide": "#cookies-use-alert" }]
         }
     ]

--- a/rules/autoconsent/xnxx-com.json
+++ b/rules/autoconsent/xnxx-com.json
@@ -4,7 +4,7 @@
     "prehideSelectors": ["#cookies-use-alert"],
     "detectCmp": [
         {
-            "any": [{ "exists": "#cookies-use-alert" }, { "exists": ".disclaimer-opened #disclaimer-cookies" }]
+            "any": [{ "exists": "#cookies-use-alert" }, { "exists": ".disclaimer-opened #disclaimer-reject_cookies" }]
         }
     ],
     "detectPopup": [
@@ -15,26 +15,14 @@
     "optIn": [
         {
             "if": { "visible": ".disclaimer-opened #disclaimer-cookies" },
-            "then": [
-                {
-                    "if": { "exists": "#disclaimer-accept_cookies" },
-                    "then": [{ "waitForThenClick": "#disclaimer-accept_cookies" }],
-                    "else": [{ "waitForThenClick": "#disclaimer_message .disclaimer-enter-btn" }]
-                }
-            ],
+            "then": [{ "waitForThenClick": "#disclaimer-accept_cookies" }],
             "else": [{ "click": "#cookies-use-alert .close" }]
         }
     ],
     "optOut": [
         {
             "if": { "visible": ".disclaimer-opened #disclaimer-cookies" },
-            "then": [
-                {
-                    "if": { "exists": "#disclaimer-reject_cookies" },
-                    "then": [{ "waitForThenClick": "#disclaimer-reject_cookies" }],
-                    "else": [{ "waitForThenClick": "#disclaimer_message .disclaimer-enter-btn" }]
-                }
-            ],
+            "then": [{ "waitForThenClick": "#disclaimer-reject_cookies" }],
             "else": [{ "hide": "#cookies-use-alert" }]
         }
     ]

--- a/rules/autoconsent/xvideos.json
+++ b/rules/autoconsent/xvideos.json
@@ -7,7 +7,7 @@
     "prehideSelectors": [],
     "detectCmp": [
         {
-            "exists": ".disclaimer-opened #disclaimer-cookies"
+            "exists": ".disclaimer-opened #disclaimer-reject_cookies"
         }
     ],
     "detectPopup": [

--- a/tests/xnxx.spec.ts
+++ b/tests/xnxx.spec.ts
@@ -1,6 +1,7 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('xnxx-com', ['https://www.xnxx.com/', 'https://www.pornorama.com/'], {
+// the disclaimer is only shown without a preceding age gate in the UK
+generateCMPTests('xnxx-com', ['https://www.xnxx.com/'], {
     onlyRegions: ['GB'],
 });
 

--- a/tests/xnxx.spec.ts
+++ b/tests/xnxx.spec.ts
@@ -1,5 +1,10 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('xnxx-com', ['https://xnxx.com/', 'https://xvideos.com/'], {
-    onlyRegions: ['US'],
+generateCMPTests('xnxx-com', ['https://www.xnxx.com/', 'https://www.pornorama.com/'], {
+    onlyRegions: ['GB'],
+});
+
+// the same rule also covers a bottom cookie bar used by an unrelated group of sites
+generateCMPTests('xnxx-com', ['https://newtabtvsearch.com/', 'https://socialnewpagessearch.com/'], {
+    onlyRegions: ['GB', 'DE'],
 });

--- a/tests/xvideos.spec.ts
+++ b/tests/xvideos.spec.ts
@@ -1,5 +1,5 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('xvideos', [
-    // 'https://www.xvideos.com/' // pop-up appears only after choosing the region
-]);
+generateCMPTests('xvideos', ['https://www.xvideos.com/'], {
+    onlyRegions: ['GB'],
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217866271421033?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic autoconsent rule and test-only changes with no auth, data, or core runtime logic impact.
> 
> **Overview**
> Updates **xnxx-com** and **xvideos** autoconsent rules so **`detectCmp`** looks for `.disclaimer-opened #disclaimer-reject_cookies` instead of `#disclaimer-cookies`, aligning CMP detection with the reject control while popup visibility and opt-in/opt-out flows still use the existing disclaimer and cookie-bar selectors.
> 
> **Playwright coverage** is tightened to match where disclaimers actually appear: **xnxx** tests target `www.xnxx.com` in **GB** only, with a second suite for **newtabtvsearch.com** and **socialnewpagessearch.com** in **GB** and **DE** (bottom cookie bar path). **xvideos** tests are enabled for **www.xvideos.com** in **GB**, and xvideos is no longer bundled under the xnxx-com test URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7401d867f3a79c7540b030bab8791084fd67be9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->