### PR TITLE
Rule update: doordash-storefront

### DIFF
--- a/rules/autoconsent/doordash-storefront.json
+++ b/rules/autoconsent/doordash-storefront.json
@@ -1,0 +1,34 @@
+{
+    "name": "doordash-storefront",
+    "vendorUrl": "https://www.doordash.com/",
+    "prehideSelectors": ["[data-testid=\"cookie-banner\"][class*=\"cookie-banner-styles__StyledCookieBanner\"]"],
+    "detectCmp": [
+        {
+            "exists": "[data-testid=\"cookie-banner\"][class*=\"cookie-banner-styles__StyledCookieBanner\"]"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "[data-testid=\"cookie-banner\"][class*=\"cookie-banner-styles__StyledCookieBanner\"]"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "[data-testid=\"cookie-banner\"] button[kind=\"BUTTON/TERTIARY\"]",
+            "retry": 15,
+            "retryInterval": 300
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "[data-testid=\"cookie-banner\"] button[kind=\"BUTTON/FLAT_SECONDARY\"]",
+            "retry": 15,
+            "retryInterval": 300
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "cookie_tracking_enabled"
+        }
+    ]
+}

--- a/tests/doordash-storefront.spec.ts
+++ b/tests/doordash-storefront.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../playwright/runner';
+
+// DoorDash only serves the banner in some markets; Canada is the one covered by the test regions.
+generateCMPTests('doordash-storefront', ['https://order.online/store/25309440', 'https://earlsca.order.online/store/-98335/'], {
+    onlyRegions: ['CA'],
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217939889694388?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

The reported checkout URL returns a 404 (session-specific cart id), so reproduction used store pages on the same DoorDash storefront: https://order.online/store/25309440 (the reported business 11688470) and https://earlsca.order.online/store/-98335/. The DoorDash storefront banner is server-rendered and visible ~1s after navigation, but React hydration attaches the click handler only at 4.2-4.5s (measured over three runs), so the heuristic's single click on 'Essential only' was dropped while still reporting optOut success; the sticky banner then stayed over the bottom of the page, where the checkout controls are. Fix is a new JSON rule scoped by DoorDash's own cookie-banner class, clicking 'Essential only' with retry:15 / retryInterval:300 so the click repeats until the banner is gone. A heuristic-level retry was rejected because covering this race globally would add ~3.5s of retries to every popup. The banner is only served in Canada: us, gb, de, fr, nl, pl, au and jp show no CMP at all, before and after the change. No exception exists for order.online or doordash in duckduckgo/privacy-configuration features/autoconsent.json, and none is needed.

## Steps to test this PR:

- `REGION=CA xvfb-run -a npx playwright test --config tmp-playwright.ca.config.ts tests/doordash-storefront.spec.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated autoconsent rule and regional Playwright coverage; no changes to shared heuristics or auth/data paths.
> 
> **Overview**
> Adds a new **doordash-storefront** autoconsent rule for DoorDash `order.online` store pages where a server-rendered cookie banner appears before React attaches click handlers (~4s), which caused one-shot opt-out clicks to fail while still reporting success and leaving the banner over checkout UI.
> 
> The rule targets DoorDash’s styled cookie banner via `data-testid` and class selectors, **pre-hides** it during detection, and uses **opt-in/opt-out** `waitForThenClick` on the tertiary and flat-secondary buttons with **15 retries at 300ms** so dismissal waits for hydration instead of adding global heuristic delay. Verification checks the **`cookie_tracking_enabled`** cookie.
> 
> A Playwright spec runs the rule against two Canadian store URLs with **`onlyRegions: ['CA']`**, matching markets where the banner is actually served.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4c696d13eea9e7a667ef38cb4023151269313bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->