### PR TITLE
Rule update: epaas

### DIFF
--- a/rules/autoconsent/epaas.json
+++ b/rules/autoconsent/epaas.json
@@ -1,0 +1,19 @@
+{
+    "name": "epaas",
+    "prehideSelectors": ["epaas-consent-drawer-shell"],
+    "detectCmp": [{ "exists": "epaas-consent-drawer-shell" }],
+    "detectPopup": [{ "visible": ["epaas-consent-drawer-shell", "section.consentDrawer"] }],
+    "optIn": [{ "waitForThenClick": ["epaas-consent-drawer-shell", "button.accept-button"] }],
+    "optOut": [
+        {
+            "if": { "exists": ["epaas-consent-drawer-shell", "button.reject-button"] },
+            "then": [{ "waitForThenClick": ["epaas-consent-drawer-shell", "button.reject-button"] }],
+            "else": [
+                { "waitForThenClick": ["epaas-consent-drawer-shell", "button.personalize-button"] },
+                { "waitFor": ["epaas-consent-drawer-shell", "epaas-policy-page-shell"] },
+                { "waitForThenClick": ["epaas-consent-drawer-shell", "button.save-button"] }
+            ]
+        }
+    ],
+    "test": [{ "cookieContains": "%22advertising%22%3A0" }]
+}

--- a/tests/epaas.spec.ts
+++ b/tests/epaas.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('epaas', ['https://www.bmw.de/de/index.html', 'https://www.mini.co.uk/en_GB/home.html']);
+
+// No explicit reject button outside the EEA: opt-out goes through the "customise" layer.
+generateCMPTests('epaas', ['https://www.mini.jp/ja_JP/home.html'], { testOptIn: false });


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217966590149649?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

The mini.jp banner is BMW's ePaaS consent controller, rendered in the shadow root of an epaas-consent-drawer-shell custom element. No rule existed and heuristics could not reach the buttons through the shadow root, so autoconsent reported NO CMP in every region before the change. PublicWWW shows the same epaas.js across the BMW/MINI network (mini.ca, bmwfs.co.uk, mini-paris.fr, bmw.com.cn, minidealer.it and many more), so the fix is a generic rule. Two variants: EEA/UK drawers expose button.reject-button (single click); elsewhere (incl. JP) opt-out goes personalize-button -> customise layer (all purposes default off) -> save-button. Both write cc_consentCookie containing "advertising":0, used as the self-test. Race condition found and fixed: clicking save-button immediately after personalize-button makes ePaaS show its 'cookie management tool is temporarily offline' fallback notice (reproduced 2/2 at a 0ms gap, 0/3 at >=500ms). Instead of an unconditional wait the rule waits for epaas-policy-page-shell, which replaces the layered-loading placeholder once the customise layer has loaded. Verified across the expanded region set plus a JP mobile check; reload after dismissal re-detects nothing. Generalisation spot checks on bmw.de (DE) and mini.co.uk (GB) pass. Note: bmw.com in US briefly exposes the host element without ever showing a drawer, so autoconsent detects the CMP and then correctly reports no popup. No autoconsent exception for mini.jp exists in duckduckgo/privacy-configuration (features/autoconsent.json fetched and searched directly). Regional proxies in this environment required Chromium's --ignore-certificate-errors flag to connect.

## Steps to test this PR:

- `npx playwright test tests/epaas.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New consent automation for a high-traffic automotive network; incorrect clicks or timing could mis-handle user consent, though the change follows existing rule patterns and adds targeted tests.
> 
> **Overview**
> Adds a new **epaas** autoconsent rule so DuckDuckGo can detect and dismiss BMW/MINI’s ePaaS consent drawer (`epaas-consent-drawer-shell`), which lives in a shadow root and was previously unreachable to heuristics.
> 
> **Accept** clicks `button.accept-button`; **reject** uses `button.reject-button` when present (EEA/UK), otherwise walks **personalize → wait for `epaas-policy-page-shell` → save** to avoid a race that triggers ePaaS’s offline fallback. Success is verified via `cc_consentCookie` containing `"advertising":0`.
> 
> Playwright coverage runs the rule against **bmw.de** and **mini.co.uk** (full opt-in/opt-out), and **mini.jp** with opt-in tests disabled because reject is only available through the customise flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2558d2f3a1ac7078332c60ccc4bee72ffa588bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->