### PR TITLE
Rule update: ccm-net

### DIFF
--- a/rules/autoconsent/ccm-net.json
+++ b/rules/autoconsent/ccm-net.json
@@ -1,0 +1,34 @@
+{
+    "name": "ccm-net",
+    "vendorUrl": "https://www.ccm.net/",
+    "cosmetic": true,
+    "runContext": {
+        "urlPattern": "^https?://([\\w-]+\\.)?ccm\\.net/"
+    },
+    "prehideSelectors": ["iframe[srcdoc*='frame-root']", ".incentive-banner"],
+    "detectCmp": [
+        {
+            "any": [{ "exists": "script[src*='cdn.appconsent.io/tcf2/'][src*='core.bundle.js']" }, { "exists": ".incentive-banner" }]
+        }
+    ],
+    "detectPopup": [
+        {
+            "any": [{ "visible": "iframe[srcdoc*='frame-root']" }, { "visible": ".incentive-banner" }]
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": ["iframe[srcdoc*='frame-root']", ".button__acceptAll"],
+            "optional": true
+        }
+    ],
+    "optOut": [
+        {
+            "hide": ".incentive-banner"
+        },
+        {
+            "if": { "visible": "iframe[srcdoc*='frame-root']" },
+            "then": [{ "waitForThenClick": ["iframe[srcdoc*='frame-root']", ".button__skip"] }]
+        }
+    ]
+}

--- a/tests/ccm-net.spec.ts
+++ b/tests/ccm-net.spec.ts
@@ -1,0 +1,7 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('ccm-net', ['https://es.ccm.net/', 'https://de.ccm.net/', 'https://it.ccm.net/'], {
+    testOptIn: false,
+    testSelfTest: false,
+    skipRegions: ['US'],
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217967352650665?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

No autoconsent exception exists for ccm.net in duckduckgo/privacy-configuration (checked features/autoconsent.json and the android/ios/macos/windows/extension overrides), so there was no prior PR or Asana task to reference. The reported popup is the AppConsent legacy dialog, which autoconsent already opts out of successfully; the real defect is that ccm.net's GTM container (GTM-N4SNZN) then injects a persistent .incentive-banner bar ('You have chosen to reject advertising cookies... Change your choice') with no dismiss control, 178px tall on desktop and 206px on mobile, which reappears on every subsequent page load. Kept as a site-specific cosmetic rule because the banner appears on all ccm.net locale subdomains (es/de/it/www) but not on sibling CCM Benchmark sites (commentcamarche.net, linternaute.com, journaldunet.com, journaldesfemmes.fr) nor on other AppConsent sites, and '.incentive-banner' is too generic to add to the widely-used AppConsent legacy rule. The rule installs the hide stylesheet rule before clicking reject so the later-injected bar never renders, and handles repeat visits where only the bar (not the dialog) is present. cosmetic: true also gives a graceful fallback: when cosmetic rules are disabled the rule is filtered out and AppConsent legacy handles the dialog exactly as before. Testing note: the regional proxies required --ignore-certificate-errors in Chromium; a local unauthenticated CONNECT relay was used to route the Playwright spec through the ES/FR proxies.

## Steps to test this PR:

- `PROXY_SERVER=http://127.0.0.1:8899 REGION=ES npx playwright test tests/ccm-net.spec.ts --project=chrome --project=webkit`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New site-scoped CMP/cosmetic hiding rule and tests only; no changes to shared auth or core extension logic.
> 
> **Overview**
> Adds a **site-specific cosmetic** autoconsent rule for `ccm.net` locale subdomains so users aren’t stuck with a persistent **`.incentive-banner`** bar after rejecting cookies via AppConsent legacy.
> 
> The rule **pre-hides** the AppConsent iframe and the incentive banner, **detects** either the AppConsent script or the banner alone (repeat visits), and on **opt-out** hides the banner and clicks **skip** in the consent iframe when it’s visible. **`cosmetic: true`** keeps the generic AppConsent legacy rule as fallback when cosmetic rules are off. A Playwright spec runs against **es/de/it** `ccm.net` URLs with opt-in and self-test disabled and **US** skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a566cd8385f21fbff7b72659ac15fb8f34b2fef4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->