### PR TITLE
Rule update: CPM feedback: paypal.com

### DIFF
--- a/rules/autoconsent/paypal-cookieprefs.json
+++ b/rules/autoconsent/paypal-cookieprefs.json
@@ -1,0 +1,29 @@
+{
+    "name": "paypal-cookieprefs",
+    "comment": "Cookie preferences page (.privacy-sheet-content on desktop, #cookiePrefsModal on mobile). Only automate it when we got here from the banner's \"Manage your cookies\" link, which appends a query string; a user who opens the page themselves lands on it without one and must be left free to edit their own preferences.",
+    "runContext": { "urlPattern": "^https://www\\.paypal\\.com/myaccount/privacy/cookiePrefs\\?" },
+    "prehideSelectors": ["#cookiePrefsModal, .privacy-sheet-content"],
+    "detectCmp": [{ "exists": "#cookiePrefsModal #formContent, .privacy-sheet-content #formContent" }],
+    "detectPopup": [{ "visible": "#cookiePrefsModal #formContent, .privacy-sheet-content #formContent" }],
+    "optIn": [
+        {
+            "click": "#formContent input[type='checkbox']:not(:checked)",
+            "all": true,
+            "optional": true
+        },
+        { "waitForThenClick": ".cookieAction #submitCookiesBtn", "timeout": 15000 }
+    ],
+    "optOut": [
+        {
+            "click": "#formContent input[type='checkbox']:checked",
+            "all": true,
+            "optional": true
+        },
+        {
+            "comment": "In \"manage\" mode the submit button is present but its sticky bar stays hidden, so wait for existence rather than visibility.",
+            "waitForThenClick": ".cookieAction #submitCookiesBtn",
+            "timeout": 15000
+        }
+    ],
+    "test": [{ "wait": 1000 }, { "cookieContains": "type%3Dexplicit" }]
+}

--- a/rules/autoconsent/paypal-us.json
+++ b/rules/autoconsent/paypal-us.json
@@ -1,42 +1,15 @@
 {
     "name": "paypal-us",
-    "prehideSelectors": ["#ccpaCookieContent_wrapper, article.ppvx_modal--overpanel, #cookiePrefsModal"],
-    "detectCmp": [{ "exists": "#ccpaCookieBanner, .privacy-sheet-content, #cookiePrefsModal" }],
-    "detectPopup": [{ "visible": "#ccpaCookieBanner, .privacy-sheet-content, #cookiePrefsModal" }],
+    "prehideSelectors": ["#ccpaCookieContent_wrapper"],
+    "detectCmp": [{ "exists": "#ccpaCookieBanner" }],
+    "detectPopup": [{ "visible": "#ccpaCookieBanner" }],
     "optIn": [{ "click": "#acceptAllButton" }],
     "optOut": [
         {
             "if": { "exists": "#bannerDeclineButton" },
             "then": [{ "click": "#bannerDeclineButton" }],
-            "else": [
-                {
-                    "if": { "exists": "a#manageCookiesLink" },
-                    "then": [{ "click": "a#manageCookiesLink" }],
-                    "else": [
-                        {
-                            "if": { "exists": "#cookiePrefsModal" },
-                            "then": [
-                                { "waitForVisible": "#cookiePrefsModal #submitCookiesBtn, .confirmCookie #submitCookiesBtn" },
-                                {
-                                    "click": "#cookiePrefsModal input[type='checkbox']:checked",
-                                    "all": true,
-                                    "optional": true
-                                },
-                                { "click": "#cookiePrefsModal #submitCookiesBtn, .confirmCookie #submitCookiesBtn" }
-                            ],
-                            "else": [
-                                { "waitForVisible": ".privacy-sheet-content #formContent" },
-                                {
-                                    "click": "#formContent input[type='checkbox']:checked",
-                                    "all": true,
-                                    "optional": true
-                                },
-                                { "click": ".cookieAction #submitCookiesBtn" }
-                            ]
-                        }
-                    ]
-                }
-            ]
+            "comment": "Without a decline button the only way out is the banner's link to the cookie preferences page, which paypal-cookieprefs submits after the navigation.",
+            "else": [{ "click": "a#manageCookiesLink" }]
         }
     ],
     "test": [{ "wait": 1000 }, { "cookieContains": "type%3Dexplicit" }]

--- a/tests/paypal-cookieprefs.spec.ts
+++ b/tests/paypal-cookieprefs.spec.ts
@@ -1,0 +1,7 @@
+import generateCMPTests from '../playwright/runner';
+
+// Only the banner's "Manage your cookies" link (which appends a locale query string) should be
+// automated. Opening the same page without a query string is a deliberate user visit and is left
+// untouched, so it is not covered here.
+generateCMPTests('paypal-cookieprefs', ['https://www.paypal.com/myaccount/privacy/cookiePrefs?locale=en_US'], {});
+generateCMPTests('paypal-cookieprefs', ['https://www.paypal.com/myaccount/privacy/cookiePrefs?locale=en_US'], { mobile: true });


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217937163730372?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only autoconsent rule JSON and CMP tests; the query-string guard limits risk of overriding user-initiated cookie preference edits.
> 
> **Overview**
> Updates PayPal autoconsent after CPM feedback by **splitting cookie-preferences handling out of `paypal-us`** into a new **`paypal-cookieprefs`** rule.
> 
> **`paypal-us`** now targets only the CCPA banner (`#ccpaCookieBanner`): accept-all on opt-in, and on opt-out either the decline button or a click on **Manage your cookies**—no more inline modal/sheet checkbox flows or extra prehide targets.
> 
> **`paypal-cookieprefs`** runs only when the prefs URL has a **query string** (banner navigation), so direct visits to the same path without `?` are not automated. It handles desktop `.privacy-sheet-content` and mobile `#cookiePrefsModal`, toggles checkboxes for opt-in/opt-out, and submits via `#submitCookiesBtn` (with longer wait for the sticky submit bar).
> 
> Playwright coverage adds **`paypal-cookieprefs`** tests for desktop and mobile with `?locale=en_US`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2549fb4ab94770c54c8d6e820731b8613d0b223d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->