### PR TITLE
Rule update: mensaje-cookies

### DIFF
--- a/rules/autoconsent/mensaje-cookies.json
+++ b/rules/autoconsent/mensaje-cookies.json
@@ -1,0 +1,24 @@
+{
+    "name": "mensaje-cookies",
+    "prehideSelectors": ["#mensajeCookies", "#divConfigCookies"],
+    "detectCmp": [
+        { "exists": "#mensajeCookies .cajaCookies #btnAcceptAll" },
+        {
+            "any": [{ "exists": "#mensajeCookies #btnAcceptNoAllCookies" }, { "exists": "#divConfigCookies #btnAcceptNoCookies" }]
+        }
+    ],
+    "detectPopup": [{ "visible": "#mensajeCookies .cajaCookies" }],
+    "optIn": [{ "waitForThenClick": "#mensajeCookies #btnAcceptAll" }],
+    "optOut": [
+        {
+            "if": { "exists": "#mensajeCookies #btnAcceptNoAllCookies" },
+            "then": [{ "waitForThenClick": "#mensajeCookies #btnAcceptNoAllCookies" }],
+            "else": [
+                { "waitForThenClick": "#mensajeCookies #btnConfigCookies" },
+                { "waitForThenClick": "#divConfigCookies #btnAcceptNoCookies" }
+            ]
+        },
+        { "waitForVisible": "#mensajeCookies .cajaCookies", "check": "none", "timeout": 3000 }
+    ],
+    "test": [{ "visible": "#mensajeCookies .cajaCookies", "check": "none" }]
+}

--- a/tests/mensaje-cookies.spec.ts
+++ b/tests/mensaje-cookies.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('mensaje-cookies', ['https://www.poderjudicial.es/', 'https://www.idepa.es/'], {
+    testOptIn: false,
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1218084152920019?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

The 'Uso de cookies' modal on poderjudicial.es is a self-hosted a11y-dialog widget (/recursos_web/rwd/js/cookies.js) shared by Spanish public-sector portals, not a third-party CMP. idepa.es uses the same markup and the same aceptarTodas()/rechazarTodas()/configurarCookies() handlers, so a generic rule (no urlPattern) was added instead of a site-specific one. Two layouts are handled: reject directly in the notice (#mensajeCookies #btnAcceptNoAllCookies, poderjudicial.es) and reject only inside the settings dialog (#divConfigCookies #btnAcceptNoCookies, idepa.es); optOut branches between them so no Accept button is ever clicked. With heuristics enabled the popup was already handled as HEURISTIC-REJECT, but heuristics are off in the default config (lib/utils.ts sets heuristicMode 'off'), and all before/after regional runs were therefore done with heuristics disabled to match the report. No privacy-configuration exception exists for the domain (checked features/autoconsent.json, the five platform overrides, and all nine browser overrides). No stale rules or coverage entries referenced poderjudicial.es or idepa.es. Reload check: poderjudicial.es no longer detects the CMP after opt-out (_visited_v3 cookie), idepa.es still matches detectCmp on the retained hidden markup but detectPopup is false so nothing is clicked and there is no reload loop. Expanded-set regions were skipped because all four core results agreed, the rule has no region-dependent logic, and its selectors are stable element IDs rather than language-dependent text.

## Steps to test this PR:

- `npx playwright test tests/mensaje-cookies.spec.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated autoconsent rule and tests; no changes to auth, data handling, or core extension infrastructure.
> 
> **Overview**
> Adds a new **mensaje-cookies** autoconsent rule for the shared self-hosted cookie notice used on Spanish public-sector sites (e.g. poderjudicial.es and idepa.es), replacing reliance on heuristics that are off in the default config.
> 
> **Opt-out** branches on layout: one-click reject via `#btnAcceptNoAllCookies` when present, otherwise opens settings (`#btnConfigCookies`) and clicks reject in `#divConfigCookies`. Detection uses stable ID selectors with no `urlPattern`, so the same rule covers portals that share the markup.
> 
> Playwright coverage registers both URLs with `testOptIn: false`, exercising reject-only behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cddbfb4123ab654034dd01a64e761fc3cc8a6fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->