### PR TITLE
Rule update: ddg_android (eun) CPM magic report: m.twitch.tv

### DIFF
--- a/rules/autoconsent/twitch.json
+++ b/rules/autoconsent/twitch.json
@@ -17,14 +17,19 @@
         {
             "if": { "exists": "[data-a-target=\"consent-banner-accept\"]" },
             "then": [
-                { "click": "[data-a-target=\"consent-banner\"] button:not([data-a-target])" },
+                {
+                    "waitForThenClick": "[data-a-target=\"consent-banner\"] button:not([data-a-target])",
+                    "retry": 3,
+                    "retryInterval": 1000
+                },
                 { "waitForVisible": "[data-a-target=\"consent-banner\"]", "check": "none" }
             ],
             "else": [
-                { "click": "button[data-a-target=\"consent-banner-manage-preferences\"]" },
-                { "waitFor": "input[type=checkbox][data-a-target=tw-checkbox]" },
+                { "waitForThenClick": "button[data-a-target=\"consent-banner-manage-preferences\"]" },
+                { "waitFor": "input[type=checkbox][data-a-target=tw-checkbox]:not([disabled])" },
                 {
                     "click": "input[type=checkbox][data-a-target=tw-checkbox]:not(:checked):not([disabled])",
+                    "all": true,
                     "optional": true
                 },
                 { "waitForThenClick": "[data-a-target=consent-modal-save]" },

--- a/tests/twitch.spec.ts
+++ b/tests/twitch.spec.ts
@@ -1,5 +1,5 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('twitch.tv', ['https://www.twitch.tv/'], {
+generateCMPTests('twitch.tv', ['https://www.twitch.tv/', 'https://m.twitch.tv/'], {
     skipRegions: ['US'],
 });


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217981965036730?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

## Steps to test this PR:

- Review the agent test evidence linked from the Asana task.
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only Twitch autoconsent steps and test URLs; no auth, data handling, or shared runtime logic.
> 
> **Overview**
> Updates the **Twitch** autoconsent rule so **opt-out** is more reliable on slower or mobile layouts (including **m.twitch.tv**), driven by CPM triage.
> 
> On the banner path that only shows a generic reject control, the reject action now uses **`waitForThenClick`** with **retries** instead of a bare **`click`**. The manage-preferences branch also waits before opening settings, waits for **enabled** checkboxes, toggles **all** unchecked optional boxes, then saves—matching patterns used in other rules.
> 
> Playwright CMP tests now run against **`https://m.twitch.tv/`** in addition to the www URL (still skipping US regions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 541d003a0002a9d645560269f6af7354e16c4345. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->