### PR TITLE
Rule update: postnl

### DIFF
--- a/rules/autoconsent/postnl.json
+++ b/rules/autoconsent/postnl.json
@@ -6,6 +6,7 @@
         "urlPattern": "^https://([a-z]*\\.)?postnl\\.nl/"
     },
     "prehideSelectors": ["pnl-cookie-wall-widget"],
+    "minimumRuleStepVersion": 2,
     "detectCmp": [
         {
             "exists": "pnl-cookie-wall-widget"
@@ -13,17 +14,41 @@
     ],
     "detectPopup": [
         {
-            "visible": "pnl-cookie-wall-widget"
+            "visible": ["pnl-cookie-wall-widget", ".pnl-cookie-wall"]
         }
     ],
     "optIn": [
         {
-            "waitForThenClick": ["pnl-cookie-wall-widget", "button.pci-button--primary"]
+            "waitForThenClick": ["pnl-cookie-wall-widget", ".cookie-overview__footer button.stamp-button--variant-primary"]
+        },
+        {
+            "waitForVisible": ["pnl-cookie-wall-widget", ".pnl-cookie-wall"],
+            "check": "none",
+            "timeout": 3000,
+            "optional": true
+        },
+        {
+            "comment": "the wall locks and dims body via inline styles, and sometimes fails to restore them",
+            "setStyle": "",
+            "selector": "body",
+            "optional": true
         }
     ],
     "optOut": [
         {
-            "waitForThenClick": ["pnl-cookie-wall-widget", "button.pci-button--secondary"]
+            "waitForThenClick": ["pnl-cookie-wall-widget", ".cookie-overview__footer button.stamp-button--variant-secondary:last-child"]
+        },
+        {
+            "waitForVisible": ["pnl-cookie-wall-widget", ".pnl-cookie-wall"],
+            "check": "none",
+            "timeout": 3000,
+            "optional": true
+        },
+        {
+            "comment": "the wall locks and dims body via inline styles, and sometimes fails to restore them",
+            "setStyle": "",
+            "selector": "body",
+            "optional": true
         }
     ],
     "test": [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217942569159958?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Bug in existing rule

No autoconsent exception exists for postnl.nl in duckduckgo/privacy-configuration (features/autoconsent.json fetched directly and its 250 exceptions checked; no platform override match), so a rule fix was made. Root cause: PostNL rebuilt the cookie wall, renaming footer buttons from pci-button--primary/secondary to stamp-button--variant-primary/secondary, so the rule's optOut selector matched nothing and opt-out failed in all regions while the CMP was still detected. The footer now holds three buttons (Accept All primary, Adjust Settings and Reject All both secondary), so optOut targets the last secondary footer button and optIn the primary one; if the order ever changed the worst case is clicking Adjust Settings, which opens the settings pane rather than accepting. Two additional defects were fixed: (1) detectPopup checked visibility of the pnl-cookie-wall-widget host, which remains in the DOM after consent is stored and still passes isElementVisible because an empty custom element has a non-null offsetParent, causing a popup detection and opt-out failure on every subsequent load; it is now gated on .pnl-cookie-wall inside the shadow root. (2) The wall sets 'position: fixed; overflow: hidden; width: 100vw; height: 100vh; background-color: rgba(0,0,0,0.5)' as an inline style on body and its teardown is racy, leaving the page dimmed and unscrollable in roughly 1 of 5 runs; optOut and optIn now wait for the wall to disappear and clear body's inline style via optional steps (minimumRuleStepVersion 2). Breakage verdicts after the fix: leftover overlay none (no viewport-covering tinted element, no open dialog, no injected styles remaining); blocked scrolling none (body inline style empty, position static, overflow visible, programmatic scroll moved 500px); blocked interaction none (elementFromPoint at viewport centre returns page content ARTICLE.ptt-collo-details); reload loop none (popup not detected on a second visit in all 18 region/device combinations). Not a cosmetic rule. The regional proxies required --ignore-certificate-errors in this environment because the proxy endpoint's TLS certificate is expired relative to the VM clock; this affects only the local test harness, not the shipped rule. GDPR regions ch, no, it, es, se and dk were skipped as optional under the proxy-testing policy, since the popup and markup were identical in all nine tested regions with no divergence.

## Steps to test this PR:

- `npx playwright test tests/postnl.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the PostNL autoconsent rule JSON; no application or security-sensitive runtime code is modified.
> 
> **Overview**
> Updates the **postnl** autoconsent rule for PostNL’s rebuilt cookie wall: **optIn** and **optOut** now click the new footer buttons (`stamp-button--variant-primary` / last secondary) instead of the removed `pci-button` classes.
> 
> **detectPopup** now requires `.pnl-cookie-wall` inside the widget so the empty host element no longer counts as a visible popup after consent.
> 
> Both consent paths add optional **minimumRuleStepVersion 2** steps: wait for the wall to hide, then clear inline `body` styles when the overlay fails to tear down (dimmed / no scroll).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb5d7b2d8e47f6eef6ae1f712fcaa94a67865a5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->