### PR TITLE
Rule update: xe.com

### DIFF
--- a/rules/autoconsent/xe.com.json
+++ b/rules/autoconsent/xe.com.json
@@ -2,38 +2,40 @@
     "name": "xe.com",
     "vendorUrl": "https://www.xe.com/",
     "runContext": {
-        "urlPattern": "^https://www\\.xe\\.com/"
+        "urlPattern": "^https?://(www\\.)?xe\\.com/"
     },
-    "prehideSelectors": ["[class*=ConsentBanner]"],
+    "prehideSelectors": ["dialog[aria-labelledby=\"consent-title\"]", "div.animate-slideFromLeft.fixed.bottom-0.z-50"],
     "detectCmp": [
         {
-            "exists": "[class*=ConsentBanner]"
+            "exists": "dialog[aria-labelledby=\"consent-title\"], div.animate-slideFromLeft.fixed.bottom-0.z-50"
         }
     ],
     "detectPopup": [
         {
-            "visible": "[class*=ConsentBanner]"
+            "visible": "dialog[aria-labelledby=\"consent-title\"], div.animate-slideFromLeft.fixed.bottom-0.z-50"
         }
     ],
     "optIn": [
         {
-            "waitForThenClick": "[class*=ConsentBanner] .egnScw"
+            "waitForThenClick": "dialog[aria-labelledby=\"consent-title\"] button.bg-xe-primary-500, div.animate-slideFromLeft button.bg-xe-primary-500"
         }
     ],
     "optOut": [
         {
-            "wait": 1000
+            "waitForThenClick": "dialog[aria-labelledby=\"consent-title\"] button.border-xe-primary-500, div.animate-slideFromLeft button.border-xe-primary-500",
+            "retry": 3,
+            "retryInterval": 500
         },
         {
-            "waitForThenClick": "[class*=ConsentBanner] .frDWEu"
+            "waitForVisible": "[data-testid=\"performance-toggle\"]"
         },
         {
-            "waitForThenClick": "[class*=ConsentBanner] .hXIpFU"
+            "waitForThenClick": "dialog[aria-labelledby=\"consent-title\"] button.bg-xe-primary-500, div.animate-slideFromLeft button.bg-xe-primary-500"
         }
     ],
     "test": [
         {
-            "cookieContains": "xeConsentState={%22performance%22:false%2C%22marketing%22:false%2C%22compliance%22:false}"
+            "cookieContains": "xeConsentState={%22performance%22:false%2C%22marketing%22:false"
         }
     ]
 }

--- a/tests/xe.com.spec.ts
+++ b/tests/xe.com.spec.ts
@@ -1,3 +1,3 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('xe.com', ['https://www.xe.com/']);
+generateCMPTests('xe.com', ['https://www.xe.com/', 'https://www.xe.com/en-gb/currencyconverter/convert/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1218140565176956?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Bug in existing rule

No autoconsent exception exists for xe.com in duckduckgo/privacy-configuration. The single 'xe.com' hit in features/autoconsent.json is inside settings.compactRuleList (the bundled rule), not the exceptions array, and none of the platform overrides mention the domain. No related sites were listed in the task, so none were skipped. Key reproduction detail: xe.com sets window.inEU from the browser timezone (Intl.DateTimeFormat().resolvedOptions().timeZone containing 'Europe'), not from the IP, so a regional proxy alone is not enough — the browser context needs a matching timezoneId or the banner never renders. Consent is only required when inEU is true or the server-side userCountry is US, which is why au, ca and jp legitimately show no banner. The rule stays site-specific (urlPattern) because this is xe.com's own in-house consent manager (window.ConsentManager, xeConsentState cookie), not a third-party CMP. The optOut Confirm selector (button.bg-xe-primary-500) would also match the simple prompt's Accept button, so the step is gated behind waitForVisible on [data-testid="performance-toggle"]; if the Customize click ever fails the rule fails safe rather than opting in. Optional EEA regions ch, no, it, es, se and dk were skipped per the proxy-testing policy since de, fr, nl and pl already represent the GDPR cluster and all behaved identically.

## Steps to test this PR:

- `TZ=Europe/Berlin npx playwright test tests/xe.com.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect autoconsent rule JSON and CMP tests for xe.com; no production app or security logic is touched.
> 
> **Overview**
> Updates the **xe.com** autoconsent rule to match xe’s in-house consent UI instead of brittle `[class*=ConsentBanner]` hooks, and broadens coverage so the rule runs on more URLs and test pages.
> 
> **Detection and actions** now target the consent `dialog` and bottom slide-in panel, with **Accept** / **Customize** / **Confirm** clicks wired to xe’s Tailwind button classes. The **opt-out** path replaces a fixed wait with a Customize click (with retry), then waits for `[data-testid="performance-toggle"]` before Confirm so a failed Customize does not accidentally Accept.
> 
> The **urlPattern** allows `http`/`https` and optional `www`. The **cookie test** expectation drops the `compliance` field from the matched `xeConsentState` substring. Playwright coverage adds the **en-gb currency converter** URL alongside the homepage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fddc1c1b551bec70b0195858bd24f1e2dbedcdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->