### PR TITLE
Rule update: bcferries.com

### DIFF
--- a/rules/autoconsent/bcferries.com.json
+++ b/rules/autoconsent/bcferries.com.json
@@ -1,0 +1,37 @@
+{
+    "name": "bcferries.com",
+    "_metadata": {
+        "vendorUrl": "https://www.bcferries.com/"
+    },
+    "runContext": {
+        "urlPattern": "^https?://(\\w+\\.)?bcferries\\.com/"
+    },
+    "prehideSelectors": ["#note .cpref"],
+    "detectCmp": [
+        {
+            "exists": "#note .cpref #cPrefToggle"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#note .cpref"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "#cAccept"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "#cPrefToggle"
+        },
+        {
+            "waitForThenClick": "#cPrefModal label[for=\"tab-4r\"]"
+        },
+        {
+            "waitForThenClick": "#cPrefSave"
+        }
+    ],
+    "comment": "Saving preferences triggers the site's own location.reload(), so a cookieContains self-test races with the navigation and is omitted."
+}

--- a/tests/bcferries.com.spec.ts
+++ b/tests/bcferries.com.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('bcferries.com', ['https://www.bcferries.com/', 'https://www.bcferries.com/routes-fares']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217573333813354?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

No related sites were listed in the task ('none'), so none were skipped and no additional sites required checking. Privacy-configuration exception lookup: fetched features/autoconsent.json, overrides/{android,ios,macos,windows,extension}-override.json and all nine files under overrides/browsers/ directly and grepped locally for 'bcferries' - zero hits, so no exception, PR or Asana task exists for this domain. CMP identification: the banner markup is emitted by an inline site script (inserted after the SAP Hybris '.yCmsContentSlot'), and PublicWWW searches for 'cPrefToggle', 'cPrefModal', 'tempCpref' and 'cPrefSave' (including depth:all) returned no results, so this is a site-specific popup and a urlPattern-scoped rule is appropriate. A heuristic-patterns fix was considered and rejected: the banner exposes no reject/dismiss control, only Accept plus a Cookie Preferences link, so opting out requires a three-step modal flow that heuristics cannot express. Regional escalation was not triggered: core results did not diverge, the rule has no region-dependent logic and uses stable element IDs rather than language-dependent text, and it is site-scoped rather than a widely-used generic rule. Mobile matched desktop in the reported region, so mobile was not expanded. Infrastructure note: all regional proxy endpoints currently serve an expired Let's Encrypt certificate for *.socks.duckduckgo.com, so every browser launch needed --ignore-certificate-errors; without it Chromium fails with ERR_PROXY_CERTIFICATE_INVALID in all regions. This is worth fixing in the proxy fleet.

## Steps to test this PR:

- `npx playwright test tests/bcferries.com.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated site-specific autoconsent rule and test only; no changes to shared runner logic or existing rules.
> 
> **Overview**
> Adds autoconsent coverage for **bcferries.com** via a new urlPattern-scoped rule and matching Playwright CMP tests on the home page and routes/fares URL.
> 
> The rule targets a **site-specific** banner (`#note .cpref`) with stable IDs: **opt-in** clicks `#cAccept`; **opt-out** runs a three-step flow (preferences toggle, tab label for `tab-4r`, save). The banner is pre-hidden while detection runs. A **cookieContains self-test is intentionally omitted** because saving preferences triggers `location.reload()`, which would race the self-test.
> 
> **`tests/bcferries.com.spec.ts`** wires the rule into the standard `generateCMPTests` runner for regression checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a29266ca912bda5b597464a2d9b24bae3209182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->