### PR TITLE
Rule update: mipro.com.tw

### DIFF
--- a/rules/autoconsent/mipro.com.tw.json
+++ b/rules/autoconsent/mipro.com.tw.json
@@ -1,0 +1,10 @@
+{
+    "name": "mipro.com.tw",
+    "runContext": { "urlPattern": "^https?://(\\w+\\.)?mipro\\.com\\.tw/" },
+    "prehideSelectors": [".cookie-modal.open"],
+    "detectCmp": [{ "exists": ".cookie-modal.open .cookie-box" }],
+    "detectPopup": [{ "visible": ".cookie-modal.open .btn-box .simple-btn.cancel" }],
+    "optIn": [{ "waitForThenClick": ".cookie-modal.open .btn-box .simple-btn.agree" }],
+    "optOut": [{ "waitForThenClick": ".cookie-modal.open .btn-box .simple-btn.cancel" }],
+    "test": [{ "exists": ".cookie-modal.open", "negated": true }]
+}

--- a/tests/mipro.com.tw.spec.ts
+++ b/tests/mipro.com.tw.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('mipro.com.tw', ['https://www.mipro.com.tw/en', 'https://www.mipro.com.tw/'], {});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217584384290903?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

The popup is a custom 'Cookie' modal (NO / YES) injected client-side: div.cookie-modal.open > div.cookie-block with div.btn-box > div.btnText.simple-btn.cancel (NO) and .agree (YES). Heuristic detection finds the popup candidate but collects zero buttons, because lib/heuristics.ts BUTTON_LIKE_ELEMENT_SELECTOR covers [class*="button"] and not 'btn'-prefixed classes; the popup therefore classifies as 'none'. The button text 'NO' already matches REJECT_PATTERNS, so no heuristic-pattern change would have helped. PublicWWW searches for cookie-modal+cookie-block, 'btnText simple-btn agree', 'simple-btn agree', 'btnText simple-btn' and 'cookieLanguageModule' found no other sites with this markup, so it is not a shared CMP and a runContext.urlPattern-scoped rule is used. Opting out writes sessionStorage['cookie-disagree']='true' (nothing in cookies or localStorage), which is why the rule's test step asserts the modal no longer carries the 'open' class rather than using cookieContains. Side finding not fixed here: tlcbio.com, built on the same agency template (shared 'data-aost' signature), has a similar DENY/ACCEPT cookie bar whose controls are also div.btn, missed for the same heuristic reason; broadening BUTTON_LIKE_ELEMENT_SELECTOR to [class*="btn"] would cover both but is a change to a widely used generic mechanism and was kept out of this site-specific fix. Testing note: the regional proxy endpoints currently serve an expired TLS certificate, so Chromium was launched with --ignore-certificate-errors; this affects only the proxy hop, not the site under test. Escalation to the expanded region set was not warranted: the three core regions produced identical popups and identical outcomes, and the rule has no region-dependent logic or language-dependent selectors.

## Steps to test this PR:

- `npx playwright test tests/mipro.com.tw.spec.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a new JSON rule and test file; no changes to shared heuristics or core autoconsent logic.
> 
> **Overview**
> Adds a **site-specific autoconsent rule** for `mipro.com.tw` because the custom cookie modal uses `simple-btn` controls that generic heuristics do not treat as buttons.
> 
> The rule scopes to the domain via `runContext.urlPattern`, pre-hides `.cookie-modal.open`, detects the CMP via `.cookie-box`, and opts in/out by clicking **agree** and **cancel** in `.btn-box`. Success is verified with a negated `exists` check on `.cookie-modal.open` (opt-out persists via `sessionStorage`, not cookies).
> 
> A new Playwright spec runs the standard CMP runner against `https://www.mipro.com.tw/en` and the site root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a44490ad1a2e0c520cbed59fcb46db3e90618154. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->