### PR TITLE
Rule update: aquasana.com

### DIFF
--- a/rules/autoconsent/aquasana-com.json
+++ b/rules/autoconsent/aquasana-com.json
@@ -1,8 +1,8 @@
 {
     "name": "aquasana.com",
     "prehideSelectors": ["#consent-tracking"],
-    "detectCmp": [{ "exists": "#consent-tracking" }],
-    "detectPopup": [{ "exists": "#consent-tracking" }],
+    "detectCmp": [{ "visible": "#consent-tracking" }],
+    "detectPopup": [{ "visible": "#consent-tracking" }],
     "optIn": [
         {
             "waitForThenClick": "#consent-tracking .affirm.btn"

--- a/tests/aquasana-com.spec.ts
+++ b/tests/aquasana-com.spec.ts
@@ -1,3 +1,3 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('aquasana.com', ['https://www.martinguitar.com/', 'https://www.dunhamssports.com/'], {});
+generateCMPTests('aquasana.com', ['https://www.martinguitar.com/', 'https://www.quorumlightinglights.com/'], {});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1217222607436097?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Bug in existing rule

Root cause was not OneTrust but the generic aquasana.com rule, which detected the Salesforce Commerce Cloud #consent-tracking container by existence. SFCC storefronts render that container on every page regardless of banner state; on pacsun.com it is present but display:none (d-none). Being in the initial HTML it resolved instantly and won autoconsent's Promise.any popup race against OneTrust, then hid an already-hidden element and reported success with a passing self-test, leaving the real banner visible. In other runs it was the only CMP found in findCmp, so detection ended with 'no popup found' before OneTrust rendered and the banner was never handled. The fix requires visibility in both detectCmp and detectPopup, which strictly narrows matching. No autoconsent exception exists for pacsun.com in duckduckgo/privacy-configuration: I fetched features/autoconsent.json and all five platform overrides directly and grepped locally, with zero hits. The task listed no related sites ('none'), but because the change touches a shared generic rule I checked the rule's own sites: martinguitar.com (popup shown, handled), quorumlightinglights.com (popup shown, handled), craftmadelightinglights.com (popup shown, handled), dunhamssports.com (rule's CMP gone, now handled by heuristics). quorumlightinglights.com serves no #consent-tracking element at all in gb/de, which is geo behaviour and not a regression. Testing constraint: pacsun.com sits behind a PerimeterX bot wall that blocks plain Playwright both directly and over every regional proxy, so all tests ran through playwright-extra with the stealth plugin, headful real Chrome under xvfb, plus --ignore-certificate-errors (the proxy TLS certificate is not in this VM's trust store). Individual runs still intermittently hit the 'Press & Hold' challenge and were retried; those runs are excluded from the results. Mobile: the reported OS is mac desktop so mobile was a sanity check only. The US mobile proxy was blocked on roughly 20 consecutive attempts, so the mobile check was done in gb where the popup reproduces identically - before the change gb mobile showed the same false success with the banner left up, after the change the popup is handled (by HEURISTIC-REJECT in that run rather than the Onetrust rule; either path leaves the banner dismissed). Regions skipped: ch, no, it, es, se, dk are optional even in an expanded pass and none was named in the report or relevant to a .com US retailer.

## Steps to test this PR:

- `npx playwright test tests/aquasana-com.spec.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrower CMP detection on a shared generic rule; reduces incorrect matches rather than broadening behavior, with targeted Playwright fixture update.
> 
> **Overview**
> Fixes false positives on Salesforce Commerce Cloud sites where `#consent-tracking` is always in the DOM but hidden until a real banner shows.
> 
> **aquasana-com.json** switches `detectCmp` and `detectPopup` from `exists` to `visible` on `#consent-tracking`, so the rule only wins when the container is actually shown—avoiding races with OneTrust and bogus “success” when only a hidden element was matched.
> 
> **aquasana-com.spec.ts** replaces the dunhamssports.com fixture URL with quorumlightinglights.com to align tests with sites still covered by this rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18b9b8e5f239a8133282d16d3eb264d51cc6922d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->