### PR TITLE
Rule update: tlc-direct

### DIFF
--- a/rules/autoconsent/tlc-direct.json
+++ b/rules/autoconsent/tlc-direct.json
@@ -1,0 +1,18 @@
+{
+    "name": "tlc-direct",
+    "runContext": { "urlPattern": "^https?://(\\w+\\.)?tlc-direct\\.co\\.uk/" },
+    "prehideSelectors": ["#cookie-consent"],
+    "detectCmp": [
+        { "exists": "#cookie-consent #cookie-consent-btn-customise" },
+        { "exists": "#cookie-consent #cookie-consent-btn-accept-some" }
+    ],
+    "detectPopup": [{ "visible": "#cookie-consent" }],
+    "optIn": [{ "waitForThenClick": "#cookie-consent-btn-accept-all" }],
+    "optOut": [
+        { "waitForThenClick": "#cookie-consent-btn-customise" },
+        { "if": { "exists": "#consent-marketing:checked" }, "then": [{ "click": "#consent-marketing" }] },
+        { "if": { "exists": "#consent-analytics:checked" }, "then": [{ "click": "#consent-analytics" }] },
+        { "waitForThenClick": "#cookie-consent-btn-accept-some" }
+    ],
+    "test": [{ "cookieContains": "%22analytics%22%3Afalse%2C%22marketing%22%3Afalse" }]
+}

--- a/tests/tlc-direct.spec.ts
+++ b/tests/tlc-direct.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('tlc-direct', ['https://www.tlc-direct.co.uk/'], {
+    testOptIn: false,
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1218173883155376?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

The task listed no related sites ('none'), so there were none to check. The apex host http://tlc-direct.co.uk/ redirects to https://www.tlc-direct.co.uk/ and serves an invalid load-balancer certificate on the way, so all testing used the www host; the rule's urlPattern covers both. Infrastructure issue unrelated to this change: the regional proxy certificate for *.socks.duckduckgo.com expired 26 Aug 2026 (notAfter=Aug 26 14:04:26 2026 GMT), which made every proxied navigation fail with ERR_PROXY_CERTIFICATE_INVALID; all runs reported here used Chromium's --ignore-certificate-errors to work around it, and results were otherwise normal. The popup markup is unique to this site: PublicWWW returned zero results for 'cookie-consent__state-2' and 'cookie-consent__button--customise' in both page source and JS files, and the sites matching the similar 'cookie-consent-btn-accept-some' / 'cookie-consent-btn-customise' ids (gyorsjogositvany.hu, dotgo.uk, enviroriskwizard.com, legalregister.co.uk) were inspected and carry unrelated banners with different structures. A heuristic-patterns fix was considered and rejected: the opt-out requires two clicks across two dialog states, and the only single-click alternative is the close X, which stores no consent (sessionStorage only). No stale site-specific or generated rule covers this domain, and data/coverage.json has no tlc entry. The expanded region set was not needed: core results agreed, the rule has no region-dependent logic, it uses stable element IDs rather than language-dependent selectors, and it is urlPattern-scoped rather than a widely-used generic rule.

## Steps to test this PR:

- `npx playwright test tests/tlc-direct.spec.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New isolated autoconsent rule and test only; no changes to shared runner logic or existing rules.
> 
> **Overview**
> Adds a **site-specific autoconsent rule** for `tlc-direct.co.uk` that targets the `#cookie-consent` banner, accepts all cookies on opt-in, and on opt-out walks through customise to turn off marketing/analytics before saving partial consent. Opt-out success is asserted via a **cookieContains** check for disabled analytics and marketing.
> 
> Adds a **Playwright CMP spec** (`tests/tlc-direct.spec.ts`) that exercises the rule against `https://www.tlc-direct.co.uk/` with **opt-in tests disabled** (`testOptIn: false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bd687fc693b3fee9f055e1f6082011fbe267532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->