### PR TITLE
Rule update: bbc.com

### DIFF
--- a/rules/autoconsent/bbc.com.json
+++ b/rules/autoconsent/bbc.com.json
@@ -1,27 +1,65 @@
 {
     "name": "bbc.com",
     "runContext": {
-        "urlPattern": "^https://(www\\.)?bbc\\.(com|co\\.uk)"
+        "urlPattern": "^https://(www\\.)?bbc\\.(com|co\\.uk)/"
     },
-    "prehideSelectors": ["*[aria-labelledby=\"consent-banner-title\"]"],
+    "prehideSelectors": ["*[aria-labelledby=\"consent-banner-title\"]", "#bbccookies-prompt"],
     "detectCmp": [
         {
-            "exists": "#consent-banner-title"
+            "any": [
+                {
+                    "exists": "#consent-banner-title"
+                },
+                {
+                    "exists": "#bbccookies-prompt"
+                }
+            ]
         }
     ],
     "detectPopup": [
         {
-            "visible": "#consent-banner-title"
+            "any": [
+                {
+                    "visible": "#consent-banner-title"
+                },
+                {
+                    "visible": "#bbccookies-prompt"
+                }
+            ]
         }
     ],
     "optIn": [
         {
-            "waitForThenClick": "button[data-testid=\"accept-button\"]"
+            "if": {
+                "exists": "#bbccookies-prompt"
+            },
+            "then": [
+                {
+                    "waitForThenClick": "#bbccookies-accept-button"
+                }
+            ],
+            "else": [
+                {
+                    "waitForThenClick": "button[data-testid=\"accept-button\"]"
+                }
+            ]
         }
     ],
     "optOut": [
         {
-            "waitForThenClick": "button[data-testid=\"reject-button\"]"
+            "if": {
+                "exists": "#bbccookies-prompt"
+            },
+            "then": [
+                {
+                    "waitForThenClick": "#bbccookies-reject-button"
+                }
+            ],
+            "else": [
+                {
+                    "waitForThenClick": "button[data-testid=\"reject-button\"]"
+                }
+            ]
         }
     ],
     "test": [

--- a/tests/bbc.com.spec.ts
+++ b/tests/bbc.com.spec.ts
@@ -1,3 +1,11 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('bbc.com', ['https://www.bbc.com/sport/formula1', 'https://www.bbc.co.uk/', 'https://www.bbc.co.uk/news']);
+// The first three URLs show the current banner, the rest show the legacy "orb" banner.
+generateCMPTests('bbc.com', [
+    'https://www.bbc.com/sport/formula1',
+    'https://www.bbc.co.uk/',
+    'https://www.bbc.co.uk/news',
+    'https://www.bbc.co.uk/programmes/m0024pz8',
+    'https://www.bbc.co.uk/iplayer',
+    'https://www.bbc.co.uk/sounds',
+]);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1211074929839894?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Bug in existing rule

The task listed no related sites ('none'), so no related-site checks were skipped. Root cause: BBC runs two banner implementations and the bbc.com rule only covered the newer #consent-banner-title dialog. Probing GB confirmed the legacy #bbccookies-prompt banner on /programmes, /iplayer, /sounds and /weather, and the newer dialog on /, /news, /bitesize, /food and bbc.com/sport/formula1. Before the fix the legacy banner was handled only by HEURISTIC-REJECT; after the fix rule bbc.com handles it. Regression check in GB after the change: /iplayer, /sounds, /weather, /, /news and bbc.com/sport/formula1 all opt out via bbc.com with ckns_policy=000 and ckns_explicit=1. selfTest reports false on the legacy variant because the cookie lands slightly after the check; the cookie is present in the post-run DOM inspection and the banner is gone, and self-tests are optional. Regions were escalated one step to fr as a sanity check because the US core result diverged (no banner served); the remaining expanded and optional GDPR regions were skipped since the rule branches on DOM variant rather than region and gb/de/fr agreed. The regional proxies required --ignore-certificate-errors in this VM; without it every navigation failed with ERR_PROXY_CERTIFICATE_INVALID.

## Steps to test this PR:

- `npx playwright test tests/bbc.com.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to BBC autoconsent rule and Playwright URLs only; no changes to core extension logic or sensitive data paths.
> 
> **Overview**
> Fixes **bbc.com** autoconsent so it handles both BBC cookie UIs: the newer `#consent-banner-title` dialog and the legacy **orb** `#bbccookies-prompt` banner (e.g. Programmes, iPlayer, Sounds).
> 
> Detection and prehide now match **either** banner via `any`. **optIn** / **optOut** branch on `#bbccookies-prompt` and click `#bbccookies-accept-button` / `#bbccookies-reject-button`, otherwise keep the existing `data-testid` accept/reject buttons. The run URL pattern now requires a path after the host (`...bbc.(com|co.uk)/`).
> 
> Playwright coverage adds three **co.uk** URLs that exercise the legacy banner, with a short comment distinguishing them from the three URLs that use the current banner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a67e7ff5b165a1ab18d4acaf0b90258651505f1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->