### PR TITLE
Rule update: cookieyes

### DIFF
--- a/rules/autoconsent/cookieyes.json
+++ b/rules/autoconsent/cookieyes.json
@@ -3,27 +3,55 @@
     "prehideSelectors": [".cky-overlay,.cky-consent-container"],
     "detectCmp": [{ "exists": ".cky-consent-container" }],
     "detectPopup": [{ "visible": ".cky-consent-container" }],
-    "optIn": [{ "waitForThenClick": ".cky-consent-container [data-cky-tag=accept-button]" }],
+    "optIn": [
+        {
+            "if": { "exists": ".cky-consent-container [data-cky-tag=accept-button]" },
+            "then": [{ "waitForThenClick": ".cky-consent-container [data-cky-tag=accept-button]" }],
+            "else": [
+                {
+                    "if": { "exists": ".cky-consent-container [data-cky-tag=donotsell-button]" },
+                    "then": [{ "waitForThenClick": ".cky-consent-container [data-cky-tag=close-button]" }]
+                }
+            ]
+        }
+    ],
     "optOut": [
         {
             "if": { "exists": ".cky-consent-container [data-cky-tag=reject-button]" },
             "then": [{ "waitForThenClick": ".cky-consent-container [data-cky-tag=reject-button]" }],
             "else": [
                 {
-                    "if": { "exists": ".cky-consent-container [data-cky-tag=settings-button]" },
+                    "if": { "exists": ".cky-consent-container [data-cky-tag=donotsell-button]" },
                     "then": [
-                        { "click": ".cky-consent-container [data-cky-tag=settings-button]" },
-                        { "waitFor": ".cky-modal-open input[type=checkbox],.cky-consent-bar-expand input[type=checkbox]" },
+                        { "waitForThenClick": ".cky-consent-container [data-cky-tag=donotsell-button]" },
+                        { "waitFor": ".cky-modal [data-cky-tag=optout-option-toggle]" },
                         {
-                            "click": ".cky-modal-open input[type=checkbox]:checked,.cky-consent-bar-expand input[type=checkbox]:checked",
+                            "click": ".cky-modal [data-cky-tag=optout-option-toggle]:not(:checked)",
                             "all": true,
                             "optional": true
                         },
-                        {
-                            "waitForThenClick": ".cky-modal [data-cky-tag=detail-save-button],.cky-consent-bar-expand [data-cky-tag=detail-save-button]"
-                        }
+                        { "waitForThenClick": ".cky-modal [data-cky-tag=optout-confirm-button]" },
+                        { "waitForVisible": ".cky-modal [data-cky-tag=optout-success]", "optional": true },
+                        { "waitForThenClick": ".cky-modal [data-cky-tag=optout-close]", "optional": true }
                     ],
-                    "else": [{ "hide": ".cky-consent-container,.cky-overlay,.cky-consent-bar-expand" }]
+                    "else": [
+                        {
+                            "if": { "exists": ".cky-consent-container [data-cky-tag=settings-button]" },
+                            "then": [
+                                { "click": ".cky-consent-container [data-cky-tag=settings-button]" },
+                                { "waitFor": ".cky-modal-open input[type=checkbox],.cky-consent-bar-expand input[type=checkbox]" },
+                                {
+                                    "click": ".cky-modal-open input[type=checkbox]:checked,.cky-consent-bar-expand input[type=checkbox]:checked",
+                                    "all": true,
+                                    "optional": true
+                                },
+                                {
+                                    "waitForThenClick": ".cky-modal [data-cky-tag=detail-save-button],.cky-consent-bar-expand [data-cky-tag=detail-save-button]"
+                                }
+                            ],
+                            "else": [{ "hide": ".cky-consent-container,.cky-overlay,.cky-consent-bar-expand" }]
+                        }
+                    ]
                 }
             ]
         }

--- a/tests/cookieyes.spec.ts
+++ b/tests/cookieyes.spec.ts
@@ -7,4 +7,7 @@ generateCMPTests('cookieyes', [
     'https://ttinteractive.com/',
     'https://www.chronofhorse.com/',
     'https://nl.flaminfitness.com/products/30l-tactical-backpack',
+    // CCPA "Do Not Share My Personal Information" variant (US visitors only)
+    'https://www.quantamagazine.org/at-17-hannah-cairo-solved-a-major-math-mystery-20250801/',
+    'https://taxfoundation.org/',
 ]);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1210953094907490?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Bug in existing rule

No autoconsent exception exists for quantamagazine.org: I fetched features/autoconsent.json and the android/ios/macos/windows/extension override files from duckduckgo/privacy-configuration main and grepped locally for 'quanta' with zero hits, and no files exist under overrides/browsers matching either. The task listed no related sites ('none'), so there were no additional sites to check beyond the primary URL; I did however verify the fix on four extra CookieYes CCPA sites found via data/coverage.json (traveloregon.com, macpaw.com, taxfoundation.org, www.truenas.com), all US desktop, all passing with self-test true and clean screenshots. Escalated to the expanded region set because the rule is region-dependent and generic. Mobile: reported OS is macOS (desktop), so per policy I ran one mobile sanity check in the reproducing region (us); it matched desktop behaviour, so mobile was not expanded to other regions. PublicWWW could not be used for prevalence checks - every query returned 'API available for paid search results only' - so cross-site prevalence was established from data/coverage.json instead. Two blockers worth reporting: (1) the regional proxy TLS certificate for *.socks.duckduckgo.com expired on 2026-08-26, causing ERR_PROXY_CERTIFICATE_INVALID on every region, so all proxied runs used Chromium with --ignore-certificate-errors as a workaround; the proxy certificate should be renewed. (2) The optout-success wait and optout-close click are marked optional so the rule still completes on CookieYes setups that do not render the success notice.

## Steps to test this PR:

- `npx playwright test tests/cookieyes.spec.ts --project=chrome -g "quantamagazine|taxfoundation"`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consent opt-in/opt-out branching for a widely used CMP; mis-clicks could accept tracking or leave banners open on some regional layouts, though legacy settings/reject paths are preserved as fallbacks.
> 
> **Overview**
> Updates the **cookieyes** autoconsent rule so US **CCPA** banners that expose “Do Not Sell/Share” instead of a normal accept/reject pair are handled correctly.
> 
> **optIn** is now conditional: accept when present; otherwise, if only the do-not-sell entry point exists, dismiss via the close button instead of failing.
> 
> **optOut** tries the do-not-sell modal flow first (open modal, toggle opt-out options, confirm, with optional success/close steps), and only falls back to the existing settings/checkbox path—or hide—when that button is missing.
> 
> Playwright coverage adds **quantamagazine.org** and **taxfoundation.org** as US CCPA regression URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be934e347cdd27fec296a630138d10c1a24dfb2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->