### PR TITLE
Rule update: infomaniak-rgpd

### DIFF
--- a/rules/autoconsent/infomaniak-rgpd.json
+++ b/rules/autoconsent/infomaniak-rgpd.json
@@ -1,0 +1,9 @@
+{
+    "name": "infomaniak-rgpd",
+    "prehideSelectors": ["module-rgpd-component"],
+    "detectCmp": [{ "exists": "module-rgpd-component" }],
+    "detectPopup": [{ "visible": ["module-rgpd-component", ".modal"] }],
+    "optIn": [{ "waitForThenClick": ["module-rgpd-component", ".buttons > button:nth-of-type(1)"] }],
+    "optOut": [{ "waitForThenClick": ["module-rgpd-component", ".buttons > button:nth-of-type(2)"], "retry": 3 }],
+    "test": [{ "cookieContains": "cookieConsent=consent_1" }]
+}

--- a/tests/infomaniak-rgpd.spec.ts
+++ b/tests/infomaniak-rgpd.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('infomaniak-rgpd', ['https://www.swisstransfer.com/en-us', 'https://www.infomaniak.com/en']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1210234723599597?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

No related sites were listed in the task ('none'), so none were skipped. I independently checked two Infomaniak properties to justify a generic rule: www.infomaniak.com shows the same module-rgpd dialog and is in the spec; kmeet.infomaniak.com does not render the component at all and was therefore not added. PublicWWW could not be used to survey wider prevalence: every query, including a control query for 'onetrust-banner-sdk', returned 'API available for paid search results only', so the PUBLICWWW_KEY in this environment is not authorised for API results. Infrastructure caveat: the regional proxy endpoint (*.socks.duckduckgo.com) presents a Let's Encrypt certificate that expired on 2026-08-26, so every proxied navigation failed with ERR_PROXY_CERTIFICATE_INVALID; all regional testing was run with Chromium launched using --ignore-certificate-errors as a workaround. This affects only the test harness, not the shipped rule, but the proxy certificate should be renewed. On the popup itself: opt-out clicks 'Decline' (a genuine reject-all, not a TIER2 accept) which sets cookieConsent=consent_1 and googleConsent with ad_storage, ad_personalization, ad_user_data, analytics_storage, functionality_storage, personalization_storage and security_storage all denied; 'Accept all' sets cookieConsent=consent_3 with ad_storage and ad_personalization granted, confirming the two paths are distinguishable. The popup was identical in structure, wording and button order in all nine regions tested, so the structural nth-of-type selectors are not region-dependent, but I escalated to the expanded region set anyway because those selectors are structural rather than attribute-based. The site's separate 'I agree to the terms and conditions of use' button is part of the file-upload flow, not a consent dialog, and is deliberately left untouched. The remaining EEA regions (ch, no, it, es, se, dk) were skipped per the proxy-testing policy since they are optional even in an expanded pass and core plus expanded results were fully consistent.

## Steps to test this PR:

- `npx playwright test tests/infomaniak-rgpd.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CMP rule and tests only; no changes to core consent engine or security-sensitive paths.
> 
> **Overview**
> Adds autoconsent support for Infomaniak’s **`module-rgpd-component`** dialog on Swiss Transfer and Infomaniak sites.
> 
> The new rule **pre-hides** the component, detects the modal, clicks the **first** button for opt-in (“Accept all”) and the **second** for opt-out (“Decline”, with **retry**), and asserts opt-out via **`cookieConsent=consent_1`**. A Playwright spec runs the shared CMP harness against `swisstransfer.com` and `infomaniak.com`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0e4c9cfc984e6a3623231476d3d6ba29691e071. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->