### PR TITLE
Rule update: mkdocs-material

### DIFF
--- a/rules/autoconsent/mkdocs-material.json
+++ b/rules/autoconsent/mkdocs-material.json
@@ -1,0 +1,30 @@
+{
+    "name": "mkdocs-material",
+    "vendorUrl": "https://squidfunk.github.io/mkdocs-material/setup/ensuring-data-privacy/",
+    "prehideSelectors": ["#__consent .md-consent__inner", "#__consent .md-consent__overlay"],
+    "detectCmp": [
+        {
+            "exists": "#__consent form[name='consent'] .md-consent__settings input[type='checkbox']"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#__consent:not([hidden]) .md-consent__inner"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "#__consent .md-consent__controls button.md-button--primary"
+        }
+    ],
+    "optOut": [
+        {
+            "click": "#__consent .md-consent__settings input[type='checkbox']:checked",
+            "all": true,
+            "optional": true
+        },
+        {
+            "waitForThenClick": "#__consent .md-consent__controls button.md-button--primary"
+        }
+    ]
+}

--- a/tests/mkdocs-material.spec.ts
+++ b/tests/mkdocs-material.spec.ts
@@ -1,0 +1,7 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('mkdocs-material', [
+    'https://docs.lightburnsoftware.com/1.7/',
+    'https://tomasvotava.github.io/fastapi-sso/',
+    'https://geek-cookbook.funkypenguin.co.nz/',
+]);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1209277260804676?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

No autoconsent exception exists for lightburnsoftware.com: I downloaded features/autoconsent.json from duckduckgo/privacy-configuration main and parsed its 249 exceptions (zero matches), and grepped all five platform override files. So there was no PR or Asana task to report and no duplicate-fix risk. The task listed no related sites ('none'), so nothing was left unchecked on that front. I did find two further Material for MkDocs sites with the consent dialog enabled and added them to the spec: tomasvotava.github.io/fastapi-sso (two categories, analytics + github) and geek-cookbook.funkypenguin.co.nz; both were also run through the us proxy and handled cleanly (screenshots artifacts/related-tomasvotava-github-io-fastapi-sso--us.png and artifacts/related-geek-cookbook-funkypenguin-co-nz--us.png). PublicWWW could not be used to gauge prevalence because the API key only returns 'API available for paid search results only'; I substituted GitHub code search over mkdocs.yml configs to find the extra sites. The regional proxies present a certificate Chromium rejects by default, so all proxied runs used --ignore-certificate-errors; this was confirmed against api.ipify.org before testing. I stayed on the core region set: us, gb and de produced identical popups and identical pass results, the rule contains no region-dependent logic, and its selectors are structural Material class names rather than localized text, so none of the escalation triggers applied. I still ran fr and jp as unscreenshotted sanity checks and both passed with optOut true. The remaining expanded and EEA regions are marked tested:false. Mobile: the report was macOS desktop, so per policy I ran desktop across the core set plus one mobile sanity check in us, which matched desktop.

## Steps to test this PR:

- `npx playwright test tests/mkdocs-material.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New third-party consent automation rule and test URLs only; no changes to auth, data handling, or core app logic.
> 
> **Overview**
> Adds **autoconsent support for Material for MkDocs** built-in consent (`#__consent`), so DuckDuckGo can detect the dialog, accept via the primary control, or opt out by clearing optional category checkboxes before confirming.
> 
> The new rule `mkdocs-material` uses structural selectors (`md-consent__*`, consent form checkboxes) plus **prehide** on the inner panel and overlay. **Playwright CMP tests** run the rule against three live docs sites: Lightburn, fastapi-sso, and geek-cookbook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67fbb4f2b448c4b793d856daa4335a2720298f11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->