### PR TITLE
Rule update: setupad

### DIFF
--- a/rules/autoconsent/setupad.json
+++ b/rules/autoconsent/setupad.json
@@ -1,0 +1,57 @@
+{
+    "name": "setupad",
+    "vendorUrl": "https://setupad.com/cmp/",
+    "prehideSelectors": [".stpd_cmp_wrapper"],
+    "detectCmp": [
+        {
+            "exists": ".stpd_cmp_wrapper .stpd_cmp_form"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": ".stpd_cmp_wrapper .stpd_cmp_form"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": ".stpd_cmp_wrapper .stpd_cta_btn"
+        }
+    ],
+    "optOut": [
+        {
+            "if": {
+                "exists": ".stpd_cmp_wrapper .stpd_flexed_btns button[type=\"submit\"]"
+            },
+            "then": [
+                {
+                    "waitForThenClick": ".stpd_cmp_wrapper .stpd_flexed_btns button[type=\"submit\"]"
+                }
+            ],
+            "else": [
+                {
+                    "waitForThenClick": ".stpd_cmp_wrapper .stpd_flexed_btns button[type=\"button\"]:not(.withdraw_consent)"
+                },
+                {
+                    "waitForVisible": ".stpd_cmp_wrapper .stpd_purposes_list"
+                },
+                {
+                    "click": ".stpd_cmp_wrapper input[type=\"checkbox\"]:checked",
+                    "all": true,
+                    "optional": true
+                },
+                {
+                    "waitForThenClick": ".stpd_cmp_wrapper .stpd_flexed_btns button[type=\"submit\"]"
+                }
+            ]
+        },
+        {
+            "waitForVisible": ".stpd_cmp_wrapper",
+            "check": "none"
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "euconsent-v2="
+        }
+    ]
+}

--- a/tests/setupad.spec.ts
+++ b/tests/setupad.spec.ts
@@ -1,0 +1,10 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('setupad', [
+    'https://www.filmsite.org/boxoffice.html',
+    'https://ezgif.com/',
+    'https://pdfresizer.com/',
+    // no "Reject all" button, opt-out goes through the settings screen
+    'https://www.fakenamegenerator.com/',
+    'https://www.worlddata.info/',
+]);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1210953287916704?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

The task listed no related sites ('none'), so none were skipped. I independently found seven more Setupad CMP sites via urlscan.io (PublicWWW returned 'API available for paid search results only' for every query, so that route was unusable) and verified all of them with the rule in gb on desktop: ezgif.com, pdfresizer.com, fakenamegenerator.com, worlddata.info, twoplayergames.org, musicalyst.com and whitescreen.online — all PASS, screenshots saved as artifacts/related-*.png. chrome-stats.com no longer serves the CMP and was dropped. Escalated to the expanded region set because the rule keys off structural selectors (button type attributes) rather than text; the remaining EEA regions (ch, no, it, es, se, dk) were skipped per policy since fr/nl/pl/de already confirmed consistent EEA behaviour. Heuristics did already reject this popup before the change (HEURISTIC-REJECT), but heuristic handling is not enabled in all configurations, which is why a deterministic CMP rule is the right fix. All proxied Chromium launches needed --ignore-certificate-errors; without it every request failed with ERR_PROXY_CERTIFICATE_INVALID.

## Steps to test this PR:

- `npx playwright test tests/setupad.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CMP rule and test URLs only; no changes to auth, data handling, or shared runtime logic.
> 
> **Overview**
> Adds **deterministic autoconsent handling** for the Setupad CMP (`.stpd_cmp_wrapper`), which was previously unsupported outside heuristic reject paths.
> 
> The new rule detects the popup, accepts via `.stpd_cta_btn`, and rejects either with a direct submit button or by opening settings, clearing checked purpose checkboxes, and confirming. Success is validated with an `euconsent-v2=` cookie check. **Playwright tests** exercise the rule against five live sites (including cases that only opt out through the settings UI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3342b3786c30fd49d9b52f65b5d4b16003c99cea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->