### PR TITLE
Rule update: cookiebot.be

### DIFF
--- a/rules/autoconsent/cookiebot-be.json
+++ b/rules/autoconsent/cookiebot-be.json
@@ -1,0 +1,9 @@
+{
+    "name": "cookiebot.be",
+    "prehideSelectors": ["#cbPopupWrap.cb-popup--open"],
+    "detectCmp": [{ "exists": "#cbPopupWrap #cbRefuseTrigger" }],
+    "detectPopup": [{ "visible": "#cbPopupWrap.cb-popup--open" }],
+    "optIn": [{ "waitForThenClick": "#cbPopupWrap #cbAcceptTrigger" }],
+    "optOut": [{ "waitForThenClick": "#cbPopupWrap #cbRefuseTrigger" }],
+    "test": [{ "cookieContains": "cbDataAccepted=1" }]
+}

--- a/tests/cookiebot-be.spec.ts
+++ b/tests/cookiebot-be.spec.ts
@@ -1,0 +1,6 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('cookiebot.be', [
+    'https://thebelgian.com/en/products/squares/squares-milk-salted-brownie-176g',
+    'https://moneycorner.com/en/banknotes/phillippines-100-piso-2025-pick-new-b',
+]);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1212599526622283?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

No autoconsent exception exists for thebelgian.com in duckduckgo/privacy-configuration (checked features/autoconsent.json and the android/ios/macos/windows/extension overrides by fetching and grepping them directly), so no PR or Asana task to report and no duplicate fix. The task listed no related sites ('none'), so there were no related sites left unchecked; I nevertheless found and checked a second site on the same CMP, moneycorner.com, which the new rule also handles (screenshots moneycorner-de-desktop-control.png and moneycorner-de-desktop-after.png). The CMP is cookiebot.be, a Belgian platform unrelated to Cookiebot/Usercentrics, loaded client-side (requests to cookiebot.be/nl/api/v1, /nl/translation/..., /nl/css/default) and branded with a cookiebot.be link in the dialog footer. PublicWWW could not be used: the API returned 'API available for paid search results only' for every query, so additional sites were found via web search instead, which turned up only moneycorner.com. Escalation to the expanded region set was not triggered: core results agreed, the rule has no region-dependent logic, and it relies on stable ids (#cbPopupWrap, #cbRefuseTrigger, #cbAcceptTrigger) rather than language-dependent or structural selectors, and it is a brand-new rule rather than a change to a widely-used generic one. Two environment notes: the regional proxies in this VM only connect with Chromium launched using --ignore-certificate-errors (otherwise every navigation fails with ERR_PROXY_CERTIFICATE_INVALID), and /opt/cursor/artifacts intermittently returned EIO on write, so screenshots were written to /tmp first and copied over. One CMP quirk worth recording: the consent cookies (cbData, cbDataAccepted) are written with the current page path as the cookie path, so the banner reappears on a different path of the same site; that is the CMP's own behaviour, not a rule problem, and the rule handles the banner again on those paths.

## Steps to test this PR:

- `npx playwright test tests/cookiebot-be.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New isolated autoconsent rule and tests only; no changes to shared infrastructure or existing rules.
> 
> **Overview**
> Adds support for the **cookiebot.be** consent platform (distinct from Cookiebot/Usercentrics), covering sites such as thebelgian.com and moneycorner.com.
> 
> The new rule detects the open popup via `#cbPopupWrap`, clicks accept/refuse triggers for opt-in/opt-out, pre-hides the open banner, and verifies consent with `cbDataAccepted=1`. Playwright coverage is wired through `tests/cookiebot-be.spec.ts` against those two URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7da7bfddcc4bafb5ea5ff6fda4016a03af9233f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->