### PR TITLE
Rule update: consent-flo

### DIFF
--- a/rules/autoconsent/consent-flo.json
+++ b/rules/autoconsent/consent-flo.json
@@ -1,0 +1,24 @@
+{
+    "name": "consent-flo",
+    "prehideSelectors": ["._flo-consent-root"],
+    "detectCmp": [{ "exists": "._flo-consent-root ._flo-consent-modal-contextual ._flo-consent-button--accept-selected" }],
+    "detectPopup": [{ "visible": "._flo-consent-root ._flo-consent-modal:not(._flo-consent-modal-contextual)" }],
+    "optIn": [{ "waitForThenClick": "._flo-consent-modal:not(._flo-consent-modal-contextual) ._flo-consent-button--accept" }],
+    "optOut": [
+        {
+            "if": { "exists": "._flo-consent-modal:not(._flo-consent-modal-contextual) ._flo-consent-button--reject" },
+            "then": [{ "waitForThenClick": "._flo-consent-modal:not(._flo-consent-modal-contextual) ._flo-consent-button--reject" }],
+            "else": [
+                { "waitForThenClick": "._flo-consent-button--settings" },
+                { "waitForVisible": "._flo-consent-modal-contextual ._flo-consent-button--accept-selected" },
+                {
+                    "click": "._flo-consent-modal-contextual ._flo-consent-checkbox:checked:not(._flo-consent-checkbox--necessary)",
+                    "all": true,
+                    "optional": true
+                },
+                { "waitForThenClick": "._flo-consent-modal-contextual ._flo-consent-button--accept-selected" }
+            ]
+        }
+    ],
+    "test": [{ "exists": "._flo-consent-root._flo-consent-hide" }]
+}

--- a/tests/consent-flo.spec.ts
+++ b/tests/consent-flo.spec.ts
@@ -1,0 +1,5 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('consent-flo', ['https://goodnightgoodluckbroadway.com/', 'https://everybrilliantthing.com/', 'https://p3.productions/'], {
+    testOptIn: false,
+});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1208026592770676?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

No autoconsent exception exists for goodnightgoodluckbroadway.com in duckduckgo/privacy-configuration: I fetched features/autoconsent.json and overrides/{android,ios,macos,windows,extension}-override.json directly and grepped locally for the domain, with no hits. The popup is Farlo Consent Flo, a commercial CMP loaded from consent.farlo.co.uk via Google Tag Manager, so it warranted a generic rule rather than a urlPattern-scoped one. Reading flo.js showed the CMP's hide_decline_all config option defaults to true and omits the ._flo-consent-button--reject control, which is why the reported site shows only 'Cookie Settings' and 'Accept All'. The rule therefore clicks the reject button when a site exposes it and otherwise opens the settings panel, clears any pre-checked optional toggles (excluding the always-on --necessary one), and clicks 'Accept Selected'; in the script acceptSelected() with nothing selected writes the same consent state as rejectAll(), so this is a genuine opt-out and not a TIER2 accept. The self-test asserts ._flo-consent-root._flo-consent-hide, a class added only by hideModule(), which is reachable only from updateConsent() after consent is persisted. The task listed no related sites ('none'), so there were none I could not check; I nonetheless went looking for sibling installs of this CMP for the spec file and found two (everybrilliantthing.com and p3.productions) by rendering candidate sites and testing for ._flo-consent-root, both of which the rule handles (screenshots artifacts/sibling-ebt-us-desktop.png and artifacts/sibling-p3-us-desktop.png, verified visually). PublicWWW could not be used at all: every query, including a known-good control query for onetrust-banner-sdk, returned 'API available for paid search results only' with the provided PUBLICWWW_KEY. It would not have helped regardless, since Consent Flo is GTM-injected and never appears in server-rendered HTML, which is all PublicWWW indexes. Escalation to the expanded region set was not triggered under the proxy-testing policy: the core results converged exactly, the rule contains no region-dependent logic, its selectors are CMP class prefixes rather than language-specific or brittle structural ones, and it is a brand-new rule rather than a change to a widely-used existing one. Regional proxies required --ignore-certificate-errors plus ignoreHTTPSErrors for this host, which otherwise failed with ERR_PROXY_CERTIFICATE_INVALID. The reload-loop probe screenshot is at artifacts/reload-check-us-desktop.png. One caveat worth noting: the stored consent leaves cross_domain at the site's default of 1 because that toggle is not rendered as a checkbox on this install; it controls only sharing consent state across the operator's sibling domains, not tracking, and analytics, performance, and targeting are all written as 0.

## Steps to test this PR:

- `npx playwright test tests/consent-flo.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new CMP rule and tests only; no changes to shared consent infrastructure or existing rules.
> 
> **Overview**
> Adds autoconsent support for **Farlo Consent Flo** (`consent-flo`), a GTM-loaded CMP used on sites such as goodnightgoodluckbroadway.com.
> 
> The rule pre-hides `._flo-consent-root`, detects the banner modal, opts in via **Accept All**, and opts out by clicking **Reject** when present or by opening settings, unchecking optional pre-selected boxes, and confirming **Accept Selected**. Success is verified when the root gets `._flo-consent-hide`.
> 
> Playwright coverage runs opt-out tests only (`testOptIn: false`) against three sibling installs: goodnightgoodluckbroadway.com, everybrilliantthing.com, and p3.productions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83be63fba36340fd15e3db534819c6ea83790fca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->