### PR TITLE
Rule update: idxrcookies

### DIFF
--- a/rules/autoconsent/idxrcookies.json
+++ b/rules/autoconsent/idxrcookies.json
@@ -1,0 +1,8 @@
+{
+    "name": "idxrcookies",
+    "prehideSelectors": ["body > #idxrcookies"],
+    "detectCmp": [{ "exists": "body > #idxrcookies #idxrcookiesKO" }],
+    "detectPopup": [{ "visible": "body > #idxrcookies #idxrcookiesKO" }],
+    "optIn": [{ "waitForThenClick": "body > #idxrcookies #idxrcookiesOK" }],
+    "optOut": [{ "waitForThenClick": "body > #idxrcookies #idxrcookiesKO" }]
+}

--- a/tests/idxrcookies.spec.ts
+++ b/tests/idxrcookies.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('idxrcookies', ['https://www.modele-lettre.com/', 'https://www.lafabriquegivree.com/', 'https://alexolivier.fr/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1209399690791462?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

No autoconsent exception exists for modele-lettre.com: I fetched features/autoconsent.json plus all overrides/{android,ios,macos,windows,extension}-override.json and the nine files under overrides/browsers/ and grepped locally for the domain, with no hits. Nothing to print for a PR or Asana task, and no duplicate fix was proposed. The task listed no related sites ('none'), so no related-site checks were skipped; I still cross-checked the CMP on additional installs of my own: lafabriquegivree.com and alexolivier.fr (both fr, desktop, handled by the new rule), tissus-eychenne.com (fr, desktop, handled), shop.uic.org (de, desktop, handled) and the vendor demo idxcookies.prestademo.es (es, desktop). Spec sites are modele-lettre.com, lafabriquegivree.com and alexolivier.fr. tissus-eychenne.com was left out of the spec because the site loads too slowly from CI to detect within the runner window even though the rule works on it over a proxy; shop.uic.org was left out because it also runs tarteaucitron and the acted-on CMP is ambiguous; the vendor demo was left out because it renders its banner via a flaky ajax view. Before-state runs were made with the rule removed and heuristics disabled, which mirrors the shipped config where enableHeuristicDetection is false and heuristicMode is 'off' — that is why the reporter saw the popup even though the tier2 heuristic can reject it when enabled. Regional escalation: core plus the reported region converged, and the rule uses stable module ids rather than language-dependent or brittle structural selectors, so per the proxy-testing policy I did not run the expanded set on the primary URL. Environment note: the regional proxies presented an untrusted certificate to Chromium on this VM (ERR_PROXY_CERTIFICATE_INVALID for every region), so all proxied runs added --ignore-certificate-errors; that is a local environment workaround and no repository or skill file was changed for it. PublicWWW could not be used because the configured key returns 'API available for paid search results only', so CMP prevalence was established from the vendor demo store, a technology-profiling dataset listing ~163 installs, and the presence of ###idxrcookies in the AdGuard and EasyList cookie annoyance lists.

## Steps to test this PR:

- `npx playwright test tests/idxrcookies.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a declarative consent rule and tests only; no auth, data handling, or runtime logic changes.
> 
> **Overview**
> Adds support for the **idxrcookies** cookie banner so autoconsent can dismiss it on sites that use this CMP.
> 
> The new rule pre-hides `#idxrcookies`, detects the banner via `#idxrcookiesKO`, accepts with `#idxrcookiesOK`, and rejects via `#idxrcookiesKO`. Playwright coverage runs against **modele-lettre.com**, **lafabriquegivree.com**, and **alexolivier.fr**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b71d1e8e2752c5d40446b6eae0e66b78b2d54021. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->