### PR TITLE
Rule update: drouot-rgpd

### DIFF
--- a/rules/autoconsent/drouot-rgpd.json
+++ b/rules/autoconsent/drouot-rgpd.json
@@ -1,0 +1,9 @@
+{
+    "name": "drouot-rgpd",
+    "prehideSelectors": ["#rgpd-popup", "#rgpd-custom-popup"],
+    "detectCmp": [{ "exists": "#rgpd-popup #rgpd-continue-without-accepting" }],
+    "detectPopup": [{ "visible": "#rgpd-popup" }],
+    "optIn": [{ "waitForThenClick": "#rgpd-popup .rgpd-buttons button:last-child" }],
+    "optOut": [{ "waitForThenClick": "#rgpd-continue-without-accepting" }],
+    "test": [{ "cookieContains": "consentLevel=none" }]
+}

--- a/tests/drouot-rgpd.spec.ts
+++ b/tests/drouot-rgpd.spec.ts
@@ -1,0 +1,8 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('drouot-rgpd', [
+    'https://www.marambat-malafosse.com/en/lot/91213/8713440-henri-martin-18601943henri-marsearch=&',
+    'https://www.ader-paris.fr/',
+    'https://www.crait-muller.com/',
+    'https://www.daguerre.fr/',
+]);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1209972830373650?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

No autoconsent exception exists for marambat-malafosse.com in duckduckgo/privacy-configuration (checked features/autoconsent.json and the android/ios/macos/windows/extension overrides), so no PR or Asana task to reference. The task listed no related sites ('none'); I nonetheless checked three sibling sites found via PublicWWW (ader-paris.fr, crait-muller.com, daguerre.fr) in fr desktop — the popup appeared on all three and the new rule handled each (screenshots sibling-*-fr-after.png). No related site went unchecked. Escalated to the expanded region set because this is a new generic rule affecting 40+ sites; results were uniform across all regions. Optional EEA regions ch/no/it/es/se/dk were skipped per the proxy-testing policy. Environment issue: the regional proxy TLS certificate (*.socks.duckduckgo.com) expired on 2026-08-26, so every proxied Chromium navigation failed with ERR_PROXY_CERTIFICATE_INVALID; all runs used --ignore-certificate-errors as a workaround. The certificate should be renewed.

## Steps to test this PR:

- `npx playwright test tests/drouot-rgpd.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds consent-handling selectors and tests only; no auth, secrets, or core infrastructure changes.
> 
> **Overview**
> Adds a new **`drouot-rgpd`** autoconsent rule for the shared RGPD banner used across Drouot-related auction sites (e.g. marambat-malafosse.com and siblings).
> 
> The rule **pre-hides** `#rgpd-popup` / `#rgpd-custom-popup`, detects the CMP via the “continue without accepting” control, **opts in** via the last button in `.rgpd-buttons`, **opts out** via `#rgpd-continue-without-accepting`, and **self-tests** with `consentLevel=none` in cookies.
> 
> Playwright coverage registers four French auction-house URLs through the standard `generateCMPTests` runner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4f8cb212a28a60166a23d08334e3c053e639d24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->