### PR TITLE
Rule update: socialfunders

### DIFF
--- a/rules/autoconsent/socialfunders.json
+++ b/rules/autoconsent/socialfunders.json
@@ -1,0 +1,8 @@
+{
+    "name": "socialfunders",
+    "prehideSelectors": ["#cookie_modal"],
+    "detectCmp": [{ "exists": "#cookie_modal #id_cookies_necessary" }, { "exists": "#cookie_modal #id_cookies_all" }],
+    "detectPopup": [{ "visible": "#cookie_modal" }],
+    "optIn": [{ "waitForThenClick": "#cookie_modal #id_cookies_all" }],
+    "optOut": [{ "waitForThenClick": "#cookie_modal #id_cookies_necessary" }]
+}

--- a/tests/socialfunders.spec.ts
+++ b/tests/socialfunders.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('socialfunders', ['https://voting.re-fd.de/', 'https://www.foerderei.de/', 'https://www.bielefeld-zeigt-herz.de/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1209664881033888?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

No related sites were listed in the task ('none'), so none were skipped. Beyond the primary URL I additionally exercised two sibling platform sites (www.foerderei.de, www.bielefeld-zeigt-herz.de) through the Playwright spec, both handled by the new rule. CMP identification: the popup is served by the Socialfunders / GivingDesk donation-voting platform (Socialfunders.Utils JS namespace, givingdesk.de in the page CSP frame-ancestors); PublicWWW returns 100+ sites with identical #cookie_modal / #id_cookies_necessary / #id_cookies_all markup, so the rule is generic with no urlPattern. No autoconsent exception exists for re-fd.de in duckduckgo/privacy-configuration (checked features/autoconsent.json and all overrides/*-override.json), so no PR or Asana task to report. The rule has no test/selfTest step because clicking either consent button triggers a full page reload that invalidates the self-test; persistence (cookie_alert=true plus empty cookie_rule_detail) was verified manually and by reload. Regions ch, no, it, es, se, dk were skipped per the proxy-testing policy: the EEA cluster is represented by de/fr/nl/pl and the rule is language-independent (ID selectors only, no region-dependent logic). Infra note: the regional proxy TLS certificate expired 2026-08-26 (notAfter Aug 26 14:04:26 2026 GMT on *.socks.duckduckgo.com), causing ERR_PROXY_CERTIFICATE_INVALID; all proxied runs used Chromium's --ignore-certificate-errors as a workaround.

## Steps to test this PR:

- `npx playwright test tests/socialfunders.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a declarative consent rule and tests only; no auth, data handling, or shared runtime logic changes.
> 
> **Overview**
> Adds support for the **Socialfunders / GivingDesk** cookie modal used on donation and voting sites.
> 
> The new **`socialfunders`** rule pre-hides `#cookie_modal`, detects the CMP via `#id_cookies_necessary` / `#id_cookies_all`, and maps **opt-in** to “accept all” and **opt-out** to “necessary only” via `waitForThenClick`. There is no `urlPattern`, so the rule applies wherever that markup appears.
> 
> Playwright coverage runs the rule against **voting.re-fd.de**, **foerderei.de**, and **bielefeld-zeigt-herz.de**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3220ce283372dd812fa17bc4df9daf3715266eb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->