### PR TITLE
Rule update: mco-consent

### DIFF
--- a/rules/autoconsent/mco-consent.json
+++ b/rules/autoconsent/mco-consent.json
@@ -1,0 +1,14 @@
+{
+    "name": "mco-consent",
+    "prehideSelectors": [
+        ".mco-consent-pop-up",
+        ".mco-consent-slide-up",
+        ".mco-consent-slide-up__backdrop",
+        ".mco-overlay:has(.mco-consent)"
+    ],
+    "detectCmp": [{ "exists": "#mco-consent" }],
+    "detectPopup": [{ "visible": "[class*=\"mco-consent-\"][class*=\"__button-decline\"]" }],
+    "optIn": [{ "waitForThenClick": "[class*=\"mco-consent-\"][class*=\"__button-confirm\"]" }],
+    "optOut": [{ "waitForThenClick": "[class*=\"mco-consent-\"][class*=\"__button-decline\"]" }],
+    "test": [{ "cookieContains": "\"acceptedAll\":false" }]
+}

--- a/tests/mco-consent.spec.ts
+++ b/tests/mco-consent.spec.ts
@@ -1,0 +1,12 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('mco-consent', [
+    // pop-up variant
+    'https://www.kaiserlodge.at/en/getting-here.html',
+    'https://www.hotel-adonis.ch/',
+    'https://www.obergaisberg.at/',
+    // slide-up variant
+    'https://www.grundlhof.at/',
+    'https://www.sommer-card.at/',
+    'https://www.hotel-resch.at/',
+]);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1208822157689809?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

The task listed no related sites to check, so there were none I could not check. While identifying the CMP I did open 16 further sites that use it (grundlhof.at, damuels.at, plankenhof.at, hotel-adonis.ch, smaragdresort.at, sommer-card.at, loipenstubn.at, skischulekrimml.com, ritterhof-ellmau.at, obergaisberg.at, defrancesco.at, noichl.com, alpinholiday.com, hotel-resch.at, kaiserhof-going.at, firstlobster.com); every one showed a visible 'Decline all' button in one of the two layouts, and six of them are now in the spec. Two testing caveats worth recording. First, the site's /cookielist.json.api endpoint answers Playwright's default headless user agent with {"state":15,"msg":"not_allowed","info":"access from bot"}, and the consent app then crashes on the missing 'groups' field and renders nothing, so the page falsely looks popup-free; all regional proxy runs therefore used a real desktop or mobile Chrome user agent, which makes the popup appear reliably. The repo Playwright spec run is unaffected and needed no user-agent override. Second, the regional proxy endpoint is currently presenting an expired Let's Encrypt certificate for *.socks.duckduckgo.com, so every proxied browser failed with ERR_PROXY_CERTIFICATE_INVALID until launched with --ignore-certificate-errors; this affects the shared proxy-testing infrastructure rather than this task. Escalated to the expanded region set because this is a new generic rule that will apply to roughly 584 sites; the optional EEA regions ch, no, it, es, se and dk were skipped per policy since the four EEA/UK regions tested (de, fr, nl, pl, gb) were identical. The heuristic path (HEURISTIC-REJECT) does handle this popup, but enableHeuristicDetection defaults to false and heuristicMode defaults to 'off' in lib/utils.ts, so it does not help the reporter in production; the before-state runs were re-captured with a production-matching heuristics-off config to reflect that.

## Steps to test this PR:

- `npx playwright test tests/mco-consent.spec.ts --project=chrome && npx playwright test tests/mco-consent.spec.ts --project=webkit`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New CMP rule and integration tests only; no auth, secrets, or core infrastructure changes.
> 
> **Overview**
> Adds autoconsent support for the **mco-consent** CMP, which appears on a large set of hospitality/travel sites in pop-up and slide-up layouts.
> 
> The new rule in `rules/autoconsent/mco-consent.json` detects `#mco-consent`, waits for a visible decline button, clicks confirm or decline for opt-in/opt-out, pre-hides common overlay/pop-up selectors, and asserts opt-out via a cookie containing `"acceptedAll":false`. `tests/mco-consent.spec.ts` wires six live URLs (three pop-up, three slide-up) through the shared `generateCMPTests` runner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96daa6624ad3648910461606b36370afa23aa862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->