### PR TITLE
Rule update: workday

### DIFF
--- a/rules/autoconsent/workday.json
+++ b/rules/autoconsent/workday.json
@@ -1,0 +1,30 @@
+{
+    "name": "workday",
+    "vendorUrl": "https://www.workday.com/",
+    "prehideSelectors": ["[data-automation-id=\"legalNotice\"]"],
+    "detectCmp": [
+        {
+            "exists": "[data-automation-id=\"legalNoticeDeclineButton\"]"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "[data-automation-id=\"legalNotice\"]"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "[data-automation-id=\"legalNoticeAcceptButton\"]"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "[data-automation-id=\"legalNoticeDeclineButton\"]"
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "enablePrivacyTracking=false"
+        }
+    ]
+}

--- a/tests/workday.spec.ts
+++ b/tests/workday.spec.ts
@@ -1,0 +1,7 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('workday', [
+    'https://oreillyauto.wd1.myworkdayjobs.com/oreilly/job/Store-02642-Phoenix-AZ/Delivery-Specialist_R124502/apply',
+    'https://sanofi.wd3.myworkdayjobs.com/SanofiCareers',
+    'https://salesforce.wd12.myworkdayjobs.com/External_Career_Site',
+]);

--- a/tests/workday.spec.ts
+++ b/tests/workday.spec.ts
@@ -4,4 +4,6 @@ generateCMPTests('workday', [
     'https://oreillyauto.wd1.myworkdayjobs.com/oreilly/job/Store-02642-Phoenix-AZ/Delivery-Specialist_R124502/apply',
     'https://sanofi.wd3.myworkdayjobs.com/SanofiCareers',
     'https://salesforce.wd12.myworkdayjobs.com/External_Career_Site',
+    // Workday also serves career sites from myworkdaysite.com, so the rule must not be host-scoped.
+    'https://wd3.myworkdaysite.com/recruiting/havas/HealthYouExternalCareerSite',
 ]);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1210508201472666?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

The reported page shows Workday's own cookie notice (container [data-automation-id="legalNotice"], buttons legalNoticeDeclineButton / legalNoticeAcceptButton) pinned above the site header. Autoconsent detected nothing before the change in any region, and the tier2 heuristics did not match it either. The markup is Workday-hosted and identical across tenants (verified on sanofi.wd3 and salesforce.wd12 careers sites), so I added a generic rule rules/autoconsent/workday.json with no urlPattern rather than a site-scoped rule. detectCmp keys off the decline button so accept-only variants fall through to the heuristics instead of being opted in. Declining sets the cookie enablePrivacyTracking=false, used as the self test. Escalated to the expanded region set because the rule is generic and applies to all Workday careers sites; the six remaining EEA regions were skipped as the EEA cluster behaved identically in de, fr, nl and pl. No autoconsent exception exists for myworkdayjobs.com in duckduckgo/privacy-configuration (features/autoconsent.json and all five platform overrides fetched and grepped locally). Side note, not breakage: declining removes the 'Apply With LinkedIn' third-party button in some regions, which is the site's own response to declining tracking cookies and also happens on a manual Decline click. All proxy runs required Chromium launched with --ignore-certificate-errors because the regional HTTPS proxies otherwise fail with ERR_PROXY_CERTIFICATE_INVALID in this environment.

## Steps to test this PR:

- `npx playwright test tests/workday.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New CMP rule and tests only; no changes to auth, data handling, or core extension logic.
> 
> **Overview**
> Adds **generic** autoconsent support for Workday-hosted career sites that show the shared legal notice (`legalNotice` / accept / decline controls).
> 
> The new `workday` rule pre-hides the banner, detects the CMP via the decline button (so accept-only pages still fall through to heuristics), clicks accept or decline as configured, and verifies opt-out with `enablePrivacyTracking=false` in cookies. Playwright coverage runs against several `myworkdayjobs.com` tenants plus a `myworkdaysite.com` URL so the rule stays unscoped by host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0deb2cbe84a43e803a35d609b02fe1f6ac89ea5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->