### PR TITLE
Rule update: fever-cookie-advice

### DIFF
--- a/rules/autoconsent/fever-cookie-advice.json
+++ b/rules/autoconsent/fever-cookie-advice.json
@@ -1,0 +1,51 @@
+{
+    "name": "fever-cookie-advice",
+    "vendorUrl": "https://feverup.com/",
+    "prehideSelectors": ["#cookie-advice.fv-cookie-advice"],
+    "detectCmp": [
+        {
+            "exists": "#cookie-advice.fv-cookie-advice"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#cookie-advice.fv-cookie-advice"
+        }
+    ],
+    "optIn": [
+        {
+            "if": {
+                "exists": "#cookie-advice [data-testid=\"accept-cookies-button\"]"
+            },
+            "then": [
+                {
+                    "waitForThenClick": "#cookie-advice [data-testid=\"accept-cookies-button\"]"
+                }
+            ],
+            "else": [
+                {
+                    "waitForThenClick": "#cookie-advice .fv-cookie-advice__close"
+                }
+            ]
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "#cookie-advice .fv-cookie-advice__message a:not([href]), #cookie-advice .fv-cookie-advice__message button"
+        },
+        {
+            "waitForVisible": ".fv-cookies-management"
+        },
+        {
+            "waitForThenClick": ":is(fv-cookies-management-sheet, .modal-content):has(.fv-cookies-management) button[class*=\"--primary\"]"
+        }
+    ],
+    "test": [
+        {
+            "wait": 500
+        },
+        {
+            "cookieContains": "fever_cookies_configuration"
+        }
+    ]
+}

--- a/tests/fever-cookie-advice.spec.ts
+++ b/tests/fever-cookie-advice.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('fever-cookie-advice', ['https://feverup.com/en/boston/candlelight', 'https://liveyourcity.com/en']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1210780272043861?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

The banner is Fever's own in-house notice, not a third-party CMP, but it appears on at least two Fever properties with different front-end stacks (Angular on feverup.com, Svelte on liveyourcity.com), found via PublicWWW on the 'fv-cookie-advice' class. Both are covered by one generic rule with no urlPattern, and both are in the spec. A 'fever' rule already existed for an unrelated Fever banner (astro-island[component-url*="CookiesBanner"] .cookies on nimrodsmovie2026.com and kaleidoentertainment.com); it does not match this markup, so I added a separate rule and left the existing one and its spec unchanged. No autoconsent exception exists for feverup.com or liveyourcity.com in duckduckgo/privacy-configuration (checked features/autoconsent.json exceptions and the android, ios, macos, windows and extension overrides). Two testing notes: the regional proxies require Chromium to be launched with --ignore-certificate-errors, otherwise every navigation fails with ERR_PROXY_CERTIFICATE_INVALID; and the US mobile 'before' screenshot shows a newsletter sign-up modal in front of the cookie bar, which is an unrelated site promo that appeared at random on that load (the cookie bar was still present in the DOM and unhandled).

## Steps to test this PR:

- `npx playwright test tests/fever-cookie-advice.spec.ts tests/fever.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated site-specific autoconsent rule and tests only; no changes to shared consent infrastructure or existing `fever` rule behavior.
> 
> **Overview**
> Adds a **new autoconsent rule** `fever-cookie-advice` for Fever’s in-house cookie UI (`#cookie-advice.fv-cookie-advice`), distinct from the existing `fever` rule that targets a different banner on other Fever properties.
> 
> The rule **pre-hides** the banner, detects it via DOM presence/visibility, and defines **opt-in** (accept button or close) and **opt-out** (open cookie management, then confirm in the sheet/modal). Success is verified with a **`fever_cookies_configuration` cookie** check after a short wait.
> 
> **Playwright coverage** registers the rule against `feverup.com` and `liveyourcity.com` through the shared `generateCMPTests` runner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f7ff762724c0b1f746d58d56a4c3745fd249666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->