### PR TITLE
Rule update: rug-nl

### DIFF
--- a/rules/autoconsent/rug-nl.json
+++ b/rules/autoconsent/rug-nl.json
@@ -1,0 +1,33 @@
+{
+    "name": "rug-nl",
+    "_metadata": {
+        "vendorUrl": "https://www.rug.nl/"
+    },
+    "cosmetic": false,
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https?://(\\w+\\.)?rug\\.nl/"
+    },
+    "prehideSelectors": ["#ConsentBar"],
+    "detectCmp": [
+        {
+            "exists": "#ConsentBar [data-js--cookie=\"cookies-accept-functional\"]"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "#ConsentBar"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "#ConsentBar [data-js--cookie=\"cookies-accept-all\"]"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "#ConsentBar [data-js--cookie=\"cookies-accept-functional\"]"
+        }
+    ]
+}

--- a/tests/rug-nl.spec.ts
+++ b/tests/rug-nl.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('rug-nl', ['https://www.rug.nl/ggdc/productivity/pwt/?lang=en', 'https://www.rug.nl/library/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1206688758125374?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

The popup is the University of Groningen's in-house consent bar: #ConsentBar with rug-prefixed classes and three tier buttons carrying data-js--cookie="cookies-accept-functional" (Essential), "...-regular" (Standard) and "...-all" (Complete). Heuristic detection with tier2 enabled found nothing: the popup body text matches no DETECT_PATTERNS entry, and the reject-equivalent control's text is "Essential\nProvides basic functions and uses anonymized cookies.", which matches no REJECT_PATTERNS entry. Extending the heuristic patterns to cover it would have needed both a new detect pattern and a reject pattern shaped around this one site's wording, so a urlPattern-scoped JSON rule was the right fit. PublicWWW searches for "rug-cookie-consent" and "cookies-accept-functional" returned only rug.nl for this markup (rug.ro and the co.uk/pl hits use unrelated banners with different DOM, verified by loading four of them), so this is not a shared CMP. No autoconsent exception exists for rug.nl: I fetched features/autoconsent.json and all five platform override files from duckduckgo/privacy-configuration and grepped locally rather than relying on gh search code. Clicking Essential sets cookie-consent=decline and retargeting-cookie-consent=decline about 260ms later and then reloads the main frame; a framenavigated trace confirmed the reload. Because of that reload the rule has no test steps: an initial version with a cookieContains self test plus a 500ms wait caused optOut to never report a result, since the engine was destroyed mid-wait. Region coverage: core set us, gb, de plus the reported region (us, already core), and additionally nl as the site's ccTLD. No escalation to the expanded set: the rule has no region-dependent logic, uses locale-independent data-attribute selectors, is urlPattern-scoped rather than a widely-used generic rule, and all four regions produced identical results on both device classes. Environment note: the regional proxies present an untrusted TLS certificate in this container, so Chromium was launched with --ignore-certificate-errors and ignoreHTTPSErrors; proxy routing itself worked and IP geolocation was as expected.

## Steps to test this PR:

- `npx playwright test tests/rug-nl.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated JSON rule and test spec with no changes to shared autoconsent engine or existing rules.
> 
> **Overview**
> Adds **site-specific autoconsent** for **rug.nl** (University of Groningen) where heuristics did not match the in-house `#ConsentBar` UI.
> 
> The new **`rug-nl`** rule is scoped with a `rug.nl` URL pattern, pre-hides `#ConsentBar`, and uses data-attribute selectors: **opt-in** clicks **Complete** (`cookies-accept-all`), **opt-out** clicks **Essential** (`cookies-accept-functional`). Playwright coverage runs **`generateCMPTests`** against two sample URLs (GGDC productivity page and library).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7c81e1681430804d9c855bbd9269fbed9767f6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->