### PR TITLE
Rule update: venngage.com

### DIFF
--- a/rules/autoconsent/venngage.json
+++ b/rules/autoconsent/venngage.json
@@ -1,0 +1,38 @@
+{
+    "name": "venngage.com",
+    "runContext": {
+        "urlPattern": "^https?://(\\w+\\.)?venngage\\.com/"
+    },
+    "prehideSelectors": [".gdpr_container", ".gdpr_modal_container"],
+    "detectCmp": [
+        {
+            "exists": ".gdpr .gdpr_manage_cookies_button"
+        },
+        {
+            "visible": ".gdpr .gdpr_container"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": ".gdpr .gdpr_container"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": ".gdpr .gdpr_accept_cookies_button"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": ".gdpr .gdpr_manage_cookies_button"
+        },
+        {
+            "waitForThenClick": ".gdpr_modal .gdpr_modal_button_reject"
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "vg_consent={\"functionality\":false,\"performance\":false,\"targeting\":false}"
+        }
+    ]
+}

--- a/tests/venngage.spec.ts
+++ b/tests/venngage.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('venngage.com', ['https://venngage.com/tools/accessible-color-palette-generator', 'https://infograph.venngage.com/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1206631347656383?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

Venngage serves its own consent widget (div.gdpr / section.gdpr_container, driven by cdn.venngage.com/assets/js/gdpr.js with globals CLI_Vg_Consent and Cookie_Vg_Handler), not a third-party CMP. The footer bar exposes only 'Cookie settings' and 'Accept all cookies'; the 'Reject All' control sits in the settings modal (.gdpr_modal_button_reject), so the new rule's optOut opens the modal and clicks Reject All, writing vg_consent={"functionality":false,"performance":false,"targeting":false}. Because the banner has no reject or dismiss control of its own, a heuristic-patterns fix was not applicable and clicking its single Accept would have been an opt-in. detectCmp additionally requires the banner to be visible: the buttons are server-rendered, so an exists-only check fires immediately while the banner is not shown until window load, which exhausted the ~5s popup-detection window and produced cmpDetected without popupFound; gating on visibility moves the waiting into findCmp, which retries for longer. Scoped with urlPattern ^https?://(\w+\.)?venngage\.com/ rather than left generic: PublicWWW returns only three other hits for gdpr_manage_cookies_button and neither infographicsme.com nor inbaloza.com still serves the banner, while infograph.venngage.com does, so the subdomain-covering pattern matches the popup's real footprint. No autoconsent exception exists for venngage in duckduckgo/privacy-configuration (checked features/autoconsent.json plus the android, ios and extension overrides; the macos and windows override files contain JSON5 trailing commas and were grepped as text). The expanded region set was skipped per the proxy-testing escalation policy: core results did not diverge, the rule has no region-dependent logic, its selectors are class-based and language-independent, and it is urlPattern-scoped rather than a widely-used generic rule. Note that all regional proxies in this environment presented an untrusted certificate, so Chromium was launched with --ignore-certificate-errors; this affects only the local test browser, not the rule.

## Steps to test this PR:

- `npx playwright test tests/venngage.spec.ts --project chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated autoconsent rule and tests only; no changes to shared infrastructure or security-sensitive code.
> 
> **Overview**
> Adds a **new site-specific autoconsent rule** for Venngage’s first-party GDPR bar on `venngage.com` and subdomains (`urlPattern` scoped to `*.venngage.com`).
> 
> The rule **pre-hides** `.gdpr_container` / `.gdpr_modal_container`, **detects** the CMP when the manage-cookies control exists and the banner is **visible** (avoiding early detection before load), and drives **opt-in** via Accept all or **opt-out** via Cookie settings then **Reject All** in the modal. Opt-out success is asserted with a `vg_consent` cookie where functionality, performance, and targeting are all `false`.
> 
> A **Playwright CMP test** (`tests/venngage.spec.ts`) runs the rule against the main site and `infograph.venngage.com`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87a0421d1647f4c53cda460a9e75aa8f9b91de80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->