### PR TITLE
Rule update: godaddy-privacy-widget

### DIFF
--- a/rules/autoconsent/godaddy-privacy-widget.json
+++ b/rules/autoconsent/godaddy-privacy-widget.json
@@ -1,0 +1,9 @@
+{
+    "name": "godaddy-privacy-widget",
+    "prehideSelectors": ["#gtm_privacy"],
+    "detectCmp": [{ "exists": ["#gtm_privacy", "#privacy_widget"] }],
+    "detectPopup": [{ "visible": ["#gtm_privacy", "#privacy_widget"] }],
+    "optIn": [{ "waitForThenClick": ["#gtm_privacy", "#pw_accept"] }],
+    "optOut": [{ "waitForThenClick": ["#gtm_privacy", "#pw_decline"] }],
+    "test": [{ "cookieContains": "pwinteraction=" }]
+}

--- a/tests/godaddy-privacy-widget.spec.ts
+++ b/tests/godaddy-privacy-widget.spec.ts
@@ -1,0 +1,8 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('godaddy-privacy-widget', [
+    'https://sitecheck.sucuri.net/',
+    'https://trodomains.co.uk/',
+    'https://www.hosting-options.co.uk/',
+    'https://www.my-domains.co.uk/',
+]);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1210852943630680?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

The popup is GoDaddy's privacy widget, rendered inside the shadow root of a #gtm_privacy host, which is why autoconsent (including tier2 heuristics) detected nothing before the change. PublicWWW returns ~3000 sites embedding <div id="gtm_privacy"></div>, so the rule is generic with no urlPattern. Banner markup and buttons (Manage / Decline / Accept plus a close control) were identical in us, gb, de, jp, fr, nl, pl, au and ca, so no regional branching was needed. No autoconsent exception exists for sucuri.net in duckduckgo/privacy-configuration features/autoconsent.json. Opt-out clicks #pw_decline and sets the pwinteraction cookie; the widget then removes itself and does not reappear after reload, so detectCmp stops matching. Mobile was tested in all four core-set regions (us, gb, de, jp) and matched desktop exactly, so mobile was not repeated across the expanded regions. Regional proxies required --ignore-certificate-errors for the browser to accept the proxy's TLS interception.

## Steps to test this PR:

- `npx playwright test tests/godaddy-privacy-widget.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive autoconsent rule and Playwright coverage only; no changes to shared runner logic or security-sensitive paths.
> 
> **Overview**
> Adds support for **GoDaddy’s privacy widget** (hosted under `#gtm_privacy` with `#privacy_widget`), which autoconsent previously missed because the banner lives in a shadow root.
> 
> The new rule **pre-hides** `#gtm_privacy`, **detects** the CMP/popup via those selectors, **opts in/out** by clicking `#pw_accept` / `#pw_decline`, and **verifies** consent via a `pwinteraction=` cookie. A Playwright spec runs the standard CMP test harness against four GoDaddy-embedded sites (e.g. Sucuri sitecheck and UK domain hosts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72499ed29c734709ae455ed934e80869d46fb46f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->