### PR TITLE
Rule update: epidemicsound.com

### DIFF
--- a/rules/autoconsent/epidemicsound-com.json
+++ b/rules/autoconsent/epidemicsound-com.json
@@ -1,0 +1,19 @@
+{
+    "name": "epidemicsound.com",
+    "runContext": {
+        "urlPattern": "^https?://(\\w+\\.)?epidemicsound\\.com/"
+    },
+    "prehideSelectors": ["#es-cookie-banner"],
+    "detectCmp": [{ "exists": "#es-cookie-banner #es-consent-settings-btn" }],
+    "detectPopup": [{ "visible": "#es-consent-settings-btn" }],
+    "optIn": [{ "waitForThenClick": "#es-consent-accept-btn" }],
+    "optOut": [
+        { "waitFor": "#onetrust-pc-sdk .save-preference-btn-handler" },
+        { "waitForThenClick": "#es-consent-settings-btn" },
+        { "waitForVisible": "#onetrust-pc-sdk" },
+        { "click": "#onetrust-consent-sdk input.category-switch-handler:checked", "all": true, "optional": true },
+        { "waitForThenClick": "#onetrust-pc-sdk .save-preference-btn-handler" },
+        { "waitForVisible": "#es-consent-settings-btn", "check": "none" }
+    ],
+    "test": [{ "cookieContains": "OptanonAlertBoxClosed" }]
+}

--- a/tests/epidemicsound-com.spec.ts
+++ b/tests/epidemicsound-com.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('epidemicsound.com', ['https://www.epidemicsound.com/'], {});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1210753542933348?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

The popup is a site-built wrapper (#es-cookie-banner) around OneTrust/CookiePro: the site suppresses OneTrust's own banner, so the generic Onetrust rule detects the CMP but its detectPopup never matches and nothing is handled. The site banner exposes only an Accept button (TIER2, not clickable from optOut) and a 'Change cookie settings' button that calls OneTrust.ToggleInfoDisplay(); the resulting preference centre has no 'Reject all', only category toggles plus 'Confirm my choices'. The new rule waits for the OneTrust preference-centre markup before clicking the settings button, because the site's handler is a no-op while window.OneTrust is undefined and OneTrust loads roughly 1.2s after navigation - the first version of the rule failed on exactly that race. Non-essential categories (C0007, C0008) are already off by default in all regions observed, so the uncheck step is marked optional. Saving preferences sets OptanonAlertBoxClosed and the site removes its own banner from the DOM, so no cosmetic hide step is required. PublicWWW searches for es-consent-settings-btn and hasSeenCookieDisclosure return only a few scraped Epidemic Sound mirrors, confirming this is site-specific markup rather than a shared CMP, so a urlPattern-scoped rule is used instead of changing the generic OneTrust rule. No autoconsent exception exists for epidemicsound.com in duckduckgo/privacy-configuration (features/autoconsent.json fetched and grepped directly). Escalated to the expanded desktop set because the rule relies on structural OneTrust preference-centre selectors; all nine expanded regions passed. Proxy connections required Chromium to be launched with --ignore-certificate-errors, otherwise every navigation failed with ERR_PROXY_CERTIFICATE_INVALID.

## Steps to test this PR:

- `npx playwright test tests/epidemicsound-com.spec.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated site rule and test only; no changes to shared autoconsent engine or generic CMP handlers.
> 
> **Overview**
> Adds a **urlPattern-scoped** autoconsent rule for `epidemicsound.com` because the site shows its own `#es-cookie-banner` (with Accept and “Change cookie settings”) instead of OneTrust’s default banner, so the generic OneTrust rule never completes **detectPopup**.
> 
> The rule **pre-hides** `#es-cookie-banner`, **opt-in** clicks `#es-consent-accept-btn`, and **opt-out** waits for OneTrust’s preference UI to load before opening settings, optionally clears checked category toggles, saves via `.save-preference-btn-handler`, and asserts **`OptanonAlertBoxClosed`**. A Playwright spec wires **`generateCMPTests`** for `https://www.epidemicsound.com/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbf27b7f47f5f992dc544e81874b1110014db527. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->