### PR TITLE
Rule update: lendable

### DIFF
--- a/rules/autoconsent/lendable.json
+++ b/rules/autoconsent/lendable.json
@@ -1,0 +1,39 @@
+{
+    "name": "lendable",
+    "runContext": {
+        "urlPattern": "^https?://([\\w-]+\\.)?lendable\\.co\\.uk/"
+    },
+    "prehideSelectors": ["[class*=\"CookiesBanner_cookies-banner\"]"],
+    "detectCmp": [
+        {
+            "exists": "[class*=\"CookiesBanner_cookies-banner\"] [class*=\"CookiesBanner_buttons\"] button"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "[class*=\"CookiesBanner_cookies-banner\"]"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "[class*=\"CookiesBanner_buttons\"] button:last-child"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "[class*=\"CookiesBanner_buttons\"] button:first-child"
+        },
+        {
+            "waitForThenClick": "[role=\"dialog\"] [class*=\"_actions_\"] button:first-child"
+        },
+        {
+            "waitForVisible": "[class*=\"CookiesBanner_cookies-banner\"]",
+            "check": "none"
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "%22marketing%22%3Afalse"
+        }
+    ]
+}

--- a/tests/lendable.spec.ts
+++ b/tests/lendable.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('lendable', ['https://www.lendable.co.uk/', 'https://asda.lendable.co.uk/login']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1209521381492331?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

The banner exposes only 'Manage cookies' and 'Allow all' at the top level, which classifyPopup scores as 'none' (settings present, no reject/acknowledge), so heuristics correctly declined to act; the 'Reject all' control is inside the preference dialog behind 'Manage cookies'. PublicWWW searches for 'CookiesBanner_cookies-banner' and 'cookies-banner-visible' returned only unrelated sites sharing generic CSS-module naming, so this is a Lendable-built component rather than a shared CMP; the same banner appears on www.lendable.co.uk, so the rule is scoped by urlPattern to lendable.co.uk and its subdomains and the spec covers both sites. A heuristic-pattern fix was not viable because the reject button is not reachable from the banner itself. No autoconsent exception exists for lendable.co.uk in duckduckgo/privacy-configuration. Selectors use [class*=...] prefixes so they survive CSS-module hash changes. Reject all persists consent in the cookie-settings cookie, which the rule's test step asserts. All proxied browsers were launched with --ignore-certificate-errors because the regional proxy's TLS certificate is rejected by default Chromium; regional egress was confirmed via the per-region squid hostnames (uks/usc/dew). Regions ch, no, it, es, se, dk were skipped per the expanded-set policy.

## Steps to test this PR:

- `npx playwright test tests/lendable.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated site-specific autoconsent rule and tests; no changes to shared consent engine or security-sensitive paths.
> 
> **Overview**
> Adds **autoconsent support** for Lendable’s in-house cookie banner on `lendable.co.uk` and subdomains.
> 
> The new rule targets the `CookiesBanner_*` UI: **opt-in** clicks “Allow all”; **opt-out** opens “Manage cookies”, then “Reject all” in the preference dialog, and checks the banner is gone. Selectors use `[class*=...]` so they stay stable across CSS-module hashes. A **test** step asserts the consent cookie includes `marketing:false` after reject.
> 
> Playwright coverage runs the `lendable` rule against `https://www.lendable.co.uk/` and `https://asda.lendable.co.uk/login`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8d94d31f34212090c8266c48c0f25d55fd4b34a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->