### PR TITLE
Rule update: hometogo

### DIFF
--- a/rules/autoconsent/hometogo.json
+++ b/rules/autoconsent/hometogo.json
@@ -1,0 +1,18 @@
+{
+    "name": "hometogo",
+    "prehideSelectors": ["[data-test=\"cookie-consent-notification\"]"],
+    "detectCmp": [{ "exists": "[data-test=\"cookie-consent-notification\"] [data-test=\"accept-button\"]" }],
+    "detectPopup": [{ "visible": "[data-test=\"cookie-consent-notification\"]" }],
+    "optIn": [{ "waitForThenClick": "[data-test=\"cookie-consent-notification\"] [data-test=\"accept-button\"]" }],
+    "optOut": [
+        {
+            "if": { "exists": "[data-test=\"cookie-consent-notification\"] [data-test=\"dismiss-button\"]" },
+            "then": [{ "waitForThenClick": "[data-test=\"cookie-consent-notification\"] [data-test=\"dismiss-button\"]" }],
+            "else": [
+                { "waitForThenClick": "[data-test=\"cookie-consent-notification\"] [data-test=\"settings-button\"]" },
+                { "waitForThenClick": "[data-test=\"cookie-consent-modal\"] [data-test=\"accept-button\"]" }
+            ]
+        }
+    ],
+    "test": [{ "cookieContains": "cookie_consent=" }]
+}

--- a/tests/hometogo.spec.ts
+++ b/tests/hometogo.spec.ts
@@ -1,0 +1,8 @@
+import generateCMPTests from '../playwright/runner';
+
+// hometogo.com serves a banner with an explicit reject button; the other HomeToGo Group
+// brands only offer "Cookie settings", so the reject path goes through the settings modal.
+const urls = ['https://www.hometogo.com/', 'https://www.casamundo.com/', 'https://www.hometogo.de/'];
+
+generateCMPTests('hometogo', urls, { mobile: false });
+generateCMPTests('hometogo', urls, { mobile: true });


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1209695800296713?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

HomeToGo Group ships an in-house consent banner ([data-test="cookie-consent-notification"]) shared across hometogo.com, its ccTLDs and casamundo.com, so the fix is a generic rule rather than a urlPattern-scoped one. Two flavours exist: a US one with an explicit "Reject non-essential" button (already handled by the existing heuristics, which is why the reported US desktop case passed before the change) and a settings-only one with just "Cookie settings" and "OK", which the heuristics cannot handle because the first layer has no reject control. The rule clicks [data-test="dismiss-button"] when present, and otherwise opens the settings modal via [data-test="settings-button"] and clicks Apply ([data-test="cookie-consent-modal"] [data-test="accept-button"]); the modal's category toggles default to off on a fresh session, so Apply stores a reject and writes cookie_consent with every category set to 0. The flavour is chosen per brand and locale rather than by IP (hometogo.de and casamundo.com serve the settings-only flavour even from a US IP). No autoconsent exception exists for hometogo in duckduckgo/privacy-configuration features/autoconsent.json. Escalated to the expanded region set because the rule contains region-dependent if/else logic. Testing notes: the site is behind Cloudflare, which serves an interactive bot challenge to datacenter proxy IPs, so the harness had to run Chromium headed under Xvfb and retry until an unchallenged exit IP was drawn; separately, the regional proxy endpoint's TLS certificate (CN=*.socks.duckduckgo.com) expired on 26 Aug 2026, so Chromium had to be launched with --ignore-certificate-errors for any proxied run to connect at all. That expiry is unrelated to this report but should be renewed. selfTest reported false for fr and ca desktop while the banner was in fact removed (the cookie had not yet been written when the self test ran); screenshots confirm both are handled.

## Steps to test this PR:

- `npx playwright test tests/hometogo.spec.ts --project=chrome && npx playwright test tests/hometogo.spec.ts --project=iphoneSE`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New site-specific autoconsent rule and tests only; no changes to auth, data handling, or core extension infrastructure.
> 
> **Overview**
> Adds a new **`hometogo`** autoconsent rule for the shared HomeToGo Group in-house banner (`cookie-consent-notification`), covering **hometogo.com**, **casamundo.com**, and **hometogo.de** without URL-pattern scoping.
> 
> **Opt-in** clicks the banner accept control; **opt-out** uses conditional logic: click **`dismiss-button`** when the US-style reject control exists, otherwise open **Cookie settings** and apply via the modal accept button (for settings-only locales/brands). Detection and success verification use the same `data-test` selectors and a **`cookie_consent=`** cookie check.
> 
> Adds **`tests/hometogo.spec.ts`** to run desktop and mobile Playwright CMP tests against all three URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0d98207f80f2ef2bd414d3906ca35ff484f6f08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->