### PR TITLE
Rule update: rdc-concents

### DIFF
--- a/rules/autoconsent/rdc-concents.json
+++ b/rules/autoconsent/rdc-concents.json
@@ -1,0 +1,9 @@
+{
+    "name": "rdc-concents",
+    "prehideSelectors": ["#concentBanner", "#concentPopup"],
+    "detectCmp": [{ "exists": "#concentBanner .rdc-save-preferences, #concentPopup .rdc-save-preferences" }],
+    "detectPopup": [{ "visible": "#concentBanner .rdc-save-preferences, #concentPopup .rdc-save-preferences" }],
+    "optIn": [{ "waitForThenClick": "#concentBanner .acceptConcentButton, #concentPopup .acceptConcentButton" }],
+    "optOut": [{ "waitForThenClick": "#concentBanner .rdc-save-preferences, #concentPopup .rdc-save-preferences" }],
+    "test": [{ "exists": "#concentBanner, #concentPopup", "negated": true }]
+}

--- a/tests/rdc-concents.spec.ts
+++ b/tests/rdc-concents.spec.ts
@@ -1,0 +1,10 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('rdc-concents', [
+    'https://www.lemonjelly.com/en/',
+    'https://www.mascarilha.pt/pt/',
+    'https://www.maxmat.pt/pt/',
+    'https://www.jom.pt/pt/',
+    // modal (rdc-layout-1) variant
+    'https://www.decenio.com/pt/',
+]);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1211845649688930?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Unsupported common CMP

The popup is served by a shared e-commerce platform CMP: a jQuery plugin exposed as window.gdprConcents that renders #concentBanner (bottom banner) or #concentPopup.rdc-layout-1 (centered modal, also used on mobile viewports), with rdc- prefixed classes. PublicWWW returns ~120 sites with the same markup (mascarilha.pt, jom.pt, temahome.com, maxmat.pt, decenio.com, moviflor.pt, ...), so the fix is a generic rule with no urlPattern rather than a site-specific rule or heuristic patch. optOut clicks .rdc-save-preferences ('only the necessary ones' / 'apenas os necessarios'), which calls gdprConcents.acceptConcentButton('none', 0, 1): it POSTs consent, sets plg_cp=1; plg_cp_1=0; plg_cp_2=0 server-side and removes the banner. Those cookies are httpOnly so cookieContains cannot read them; the test step asserts the banner is gone instead. detectCmp requires the reject button, which keeps the rule off the legacy accept-only banner variant whose close X is wired to accept-all. No autoconsent exception exists for lemonjelly.com in duckduckgo/privacy-configuration (checked features/autoconsent.json and the android/ios/macos/windows/extension overrides by fetching and grepping them directly). Note: the regional proxies required --ignore-certificate-errors plus ignoreHTTPSErrors on this VM, otherwise every navigation failed with ERR_PROXY_CERTIFICATE_INVALID. The 'Are you in United States?/Canada?' store-locale prompt visible in the us and ca screenshots is a country redirect prompt, not a consent dialog, and is out of scope; it is present in the control screenshots too.

## Steps to test this PR:

- `npx playwright test tests/rdc-concents.spec.ts --project chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new opt-out autoconsent rule and tests only; no changes to existing rules or core consent infrastructure.
> 
> **Overview**
> Adds a **generic** autoconsent rule for the shared `gdprConcents` / RDC e-commerce CMP (`#concentBanner` and `#concentPopup`), with no site-specific `urlPattern`.
> 
> The rule **prehides** both banner and modal containers, **detects** only when a `.rdc-save-preferences` reject control is present (so legacy accept-only banners are skipped), **opts out** via that button and **opts in** via `.acceptConcentButton`, and **verifies** success by asserting the banner/popup elements are gone (httpOnly consent cookies are not checked).
> 
> A new Playwright spec runs the rule against five representative sites, including the `rdc-layout-1` modal variant on decenio.com.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ac15408ca0f28323d3d0e169e5701d50a1453f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->