### PR TITLE
Rule update: vmock

### DIFF
--- a/rules/autoconsent/vmock.json
+++ b/rules/autoconsent/vmock.json
@@ -29,7 +29,8 @@
         },
         {
             "waitForVisible": ".manage-cookies-modal",
-            "negated": true
+            "timeout": 2000,
+            "check": "none"
         }
     ],
     "test": [

--- a/rules/autoconsent/vmock.json
+++ b/rules/autoconsent/vmock.json
@@ -1,0 +1,40 @@
+{
+    "name": "vmock",
+    "vendorUrl": "https://www.vmock.com/",
+    "runContext": {
+        "urlPattern": "^https?://(\\w+\\.)?vmock\\.com/"
+    },
+    "prehideSelectors": [".cookie-policy-modal", ".manage-cookies-modal"],
+    "detectCmp": [
+        {
+            "exists": ".cookie-policy-modal .cookie-policy-details button.manage"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": ".cookie-policy-modal .cookie-policy-details button.manage"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": ".cookie-policy-modal .cookie-policy-details button.accept"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": ".cookie-policy-modal .cookie-policy-details button.manage"
+        },
+        {
+            "waitForThenClick": ".manage-cookies-modal .manage-cookies-footer button.btn-outline-primary"
+        },
+        {
+            "waitForVisible": ".manage-cookies-modal",
+            "negated": true
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "%22analytics%22:false"
+        }
+    ]
+}

--- a/tests/vmock.spec.ts
+++ b/tests/vmock.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('vmock', ['https://www.vmock.com/', 'https://www.vmock.com/bu/']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1203255952365411?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

The VMock consent dialog's first layer exposes only 'Accept All' and 'Reject/Customize'. Heuristic detection matched the popup text (DETECT_PATTERNS hits on 'We use cookies', 'Accept All', 'By continuing ... cookies') but classifyButtonTextRegex classifies 'Reject/Customize' as a settings button, so classifyPopup returned 'none' and the popup was filtered out even in tier2 mode. That behaviour is correct, since the button opens a second 'Accept Cookies' modal instead of rejecting; a heuristic-pattern change would have been the wrong fix. The second modal contains a genuine 'Reject All' button, so the new rule clicks through both layers. Opt-out persists as the cookie user_cookie_consent={"essential":true,"analytics":false,"social":false}, asserted by the rule's test step. PublicWWW searches for "cookie-policy-modal", "manage-cookies-modal" and "user_cookie_consent" returned only unrelated sites, confirming this is VMock's own React implementation rather than a shared CMP, so the rule is scoped with urlPattern ^https?://(\w+\.)?vmock\.com/. No autoconsent exception exists for vmock.com in duckduckgo/privacy-configuration (features/autoconsent.json or the android/ios/macos/windows/extension overrides). The core region set was not escalated to the expanded set: results did not diverge, the rule has no region-dependent logic, its selectors are class-based rather than language-dependent, and it is site-scoped rather than a widely-used generic rule. Environment note: the regional proxies presented a certificate untrusted by the container (ERR_PROXY_CERTIFICATE_INVALID on every region, including the api.ipify.org smoke test), so all proxied browsers were launched with --ignore-certificate-errors; this affects only TLS validation, not page behaviour. Control screenshots for gb/de and us-mobile were re-captured during the post-fix run; they show the unmodified page state without autoconsent and are identical to the pre-fix control state.

## Steps to test this PR:

- `npx playwright test tests/vmock.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated autoconsent rule and test for one vendor domain; no changes to shared detection or core consent logic.
> 
> **Overview**
> Adds **site-specific autoconsent** for VMock’s two-step cookie UI, which heuristics could not handle because the first-layer “Reject/Customize” control is treated as settings rather than reject.
> 
> The new `vmock` rule is limited to `vmock.com` via `urlPattern`, pre-hides the policy/manage modals, detects the CMP via the manage button, accepts on opt-in, and on opt-out opens manage then clicks **Reject All** in the second modal. A test step asserts opt-out via `user_cookie_consent` containing `"analytics":false`.
> 
> A Playwright spec runs the standard CMP suite against `https://www.vmock.com/` and `/bu/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4269c0c667f05c9b5916fb5b8eaf7de0b31a4b30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->