### PR TITLE
Rule update: pandectes

### DIFF
--- a/rules/autoconsent/pandectes.json
+++ b/rules/autoconsent/pandectes.json
@@ -15,7 +15,8 @@
     "optIn": [
         {
             "waitForThenClick": "#pandectes-banner .cc-allow"
-        }
+        },
+        { "hide": "#pandectes-banner", "optional": true }
     ],
     "optOut": [
         {
@@ -28,7 +29,8 @@
                 { "waitForVisible": ".pd-cp-ui-save" },
                 { "click": ".pd-cp-ui-save" }
             ]
-        }
+        },
+        { "hide": "#pandectes-banner", "optional": true }
     ],
     "test": [{ "wait": 500 }, { "eval": "EVAL_PANDECTES_TEST" }]
 }

--- a/tests/pandectes.spec.ts
+++ b/tests/pandectes.spec.ts
@@ -1,3 +1,8 @@
 import generateCMPTests from '../playwright/runner';
 
-generateCMPTests('pandectes', ['https://hollandscountryclothing.co.uk/', 'https://cluse.com/', 'https://www.parent.com/']);
+generateCMPTests('pandectes', [
+    'https://hollandscountryclothing.co.uk/',
+    'https://cluse.com/',
+    'https://www.parent.com/',
+    'https://swedishstockings.com/', // full-page overlay ("blocking") banner variant
+]);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1218229278515894?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Bug in existing rule

Pandectes' fadeOut() only sets display:none from a transitionend handler and skips entirely when the wrapper still has cc-invisible, which it does for the first fadeInTimeout (20ms) of the banner's fade-in. An autoconsent click inside that window leaves #pandectes-banner as a full-viewport, opacity:0, pointer-events:auto element at z-index 2147483647 that swallows every click while the page looks normal. Fix: hide #pandectes-banner after the opt-out/opt-in click (optional step, display:none !important). Because the banner is invisible in the broken state, the 'before' screenshots look like a healthy page; the load-bearing evidence is the elementFromPoint result and the raw-click test, plus the two annotated artifacts (swedishstockings-breakage-evidence-broken.png / -fixed.png) where the blocker is tinted red. 'Before' runs used 4-8x CPU throttling to widen the 20ms window; the breakage reproduced in us mobile, gb mobile and fr desktop, and stayed latent elsewhere. No autoconsent exception exists for swedishstockings.com in duckduckgo/privacy-configuration features/autoconsent.json, and none is needed. Residual note: the heuristic reject path (observed once on us desktop) clicks the same Decline button without the new hide step, so it could in principle hit the same race, but it only runs when no rule matches and the pandectes rule matches reliably here. Proxy runs needed --ignore-certificate-errors, otherwise every navigation failed with ERR_PROXY_CERTIFICATE_INVALID.

## Steps to test this PR:

- `npx playwright test tests/pandectes.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped autoconsent rule tweak plus an extra test URL; optional hide only runs after consent actions and matches patterns used in other CMP rules.
> 
> **Overview**
> Fixes a **race** where autoconsent can click Pandectes accept/decline during the banner’s short fade-in window: Pandectes may leave `#pandectes-banner` as an invisible, full-viewport layer that still captures clicks.
> 
> After the existing opt-in and opt-out flows, the rule now runs an **optional** `hide` on `#pandectes-banner` so the wrapper is forced off the page when the CMP doesn’t dismiss it cleanly.
> 
> Playwright coverage adds **`https://swedishstockings.com/`** (full-page overlay / “blocking” banner variant) alongside the existing Pandectes test URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 151b224cb1684c59064c8bdec0f2d3f0126dd7d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->