### PR TITLE
Rule update: maticrobots-com

### DIFF
--- a/rules/autoconsent/maticrobots-com.json
+++ b/rules/autoconsent/maticrobots-com.json
@@ -1,0 +1,17 @@
+{
+    "name": "maticrobots-com",
+    "runContext": {
+        "urlPattern": "^https?://(\\w+\\.)?maticrobots\\.com/"
+    },
+    "prehideSelectors": ["section[aria-label=\"Cookie preferences\"]"],
+    "detectCmp": [{ "exists": "section[aria-label=\"Cookie preferences\"]" }],
+    "detectPopup": [{ "visible": "section[aria-label=\"Cookie preferences\"]" }],
+    "optIn": [{ "waitForThenClick": "xpath///section[@aria-label=\"Cookie preferences\"]//button[normalize-space()=\"Accept All\"]" }],
+    "optOut": [
+        { "waitForThenClick": "xpath///section[@aria-label=\"Cookie preferences\"]//button[normalize-space()=\"Cookie Settings\"]" },
+        { "waitForVisible": "div[role=\"dialog\"][aria-labelledby=\"consent-settings-title\"]" },
+        { "waitForThenClick": "xpath///label[contains(., \"Necessary and functional cookies\")]//input[@name=\"cookie-tier\"]" },
+        { "waitForThenClick": "div[role=\"dialog\"][aria-labelledby=\"consent-settings-title\"] button:not([aria-label])" }
+    ],
+    "test": [{ "cookieContains": "matic_consent=v1.a0.m0" }]
+}

--- a/rules/autoconsent/maticrobots-com.json
+++ b/rules/autoconsent/maticrobots-com.json
@@ -13,5 +13,5 @@
         { "waitForThenClick": "xpath///label[contains(., \"Necessary and functional cookies\")]//input[@name=\"cookie-tier\"]" },
         { "waitForThenClick": "div[role=\"dialog\"][aria-labelledby=\"consent-settings-title\"] button:not([aria-label])" }
     ],
-    "test": [{ "cookieContains": "matic_consent=v1.a0.m0" }]
+    "comment": "No self-test: saving the settings reloads the page, so the check would always run in a fresh context. Opt-out stores matic_consent=v1.a0.m0."
 }

--- a/tests/maticrobots-com.spec.ts
+++ b/tests/maticrobots-com.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('maticrobots-com', ['https://maticrobots.com/'], {});


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1218232242621274?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

No related sites were listed in the task ('none'), so no sibling sites were checked. No autoconsent exception exists for maticrobots.com in duckduckgo/privacy-configuration: I fetched features/autoconsent.json and the android/ios/macos/windows/extension overrides directly and grepped locally, all zero hits, so no PR or Asana task to reference. The banner is custom (Next.js + Tailwind, no vendor prefix) and a PublicWWW search for 'Dismiss and keep current cookie settings', 'cookie-tier' and 'consent-settings-title' returned no site sharing this markup, so the rule is urlPattern-scoped rather than generic. Escalated to the expanded region set because the opt-out relies on English text-anchored XPath selectors; all nine expanded regions plus a US mobile run behaved identically (same banner, same flow, same matic_consent=v1.a0.m0.e cookie). The optional GDPR regions (ch, no, it, es, se, dk) were skipped per policy since the site is a US .com with a single English variant and core results did not diverge. Regional proxies required Chromium to be launched with --ignore-certificate-errors: without it every navigation failed with ERR_PROXY_CERTIFICATE_INVALID, which looks like an expired or mismatched proxy certificate in this environment rather than anything site-specific. A few screenshot writes to /opt/cursor/artifacts intermittently failed with EIO and were simply retried successfully.

## Steps to test this PR:

- `npx playwright test tests/maticrobots-com.spec.ts`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated autoconsent rule and test file for one domain; no changes to shared consent infrastructure or security-sensitive paths.
> 
> **Overview**
> Adds **site-specific autoconsent support** for `maticrobots.com` via a new rule scoped to that domain’s URL pattern.
> 
> The rule targets a custom **“Cookie preferences”** section: it pre-hides and detects the banner, **Accept All** for opt-in, and a multi-step **Cookie Settings** dialog flow for opt-out (necessary/functional tier only). A comment documents that **self-test is omitted** because saving settings reloads the page.
> 
> A Playwright spec registers CMP tests against `https://maticrobots.com/` using the shared `generateCMPTests` runner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07a2342a3542ddd69a861a26379f9ab5d46351d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->