### PR TITLE
Rule update: rspb.org.uk

### DIFF
--- a/rules/autoconsent/rspb.json
+++ b/rules/autoconsent/rspb.json
@@ -1,0 +1,42 @@
+{
+    "name": "rspb.org.uk",
+    "vendorUrl": "https://www.rspb.org.uk/",
+    "cosmetic": false,
+    "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https://(\\w+\\.)?rspb\\.org\\.uk/"
+    },
+    "prehideSelectors": ["rspb-cookie-banner"],
+    "detectCmp": [
+        {
+            "exists": "rspb-cookie-banner"
+        }
+    ],
+    "detectPopup": [
+        {
+            "visible": "rspb-cookie-banner"
+        }
+    ],
+    "optIn": [
+        {
+            "waitForThenClick": "rspb-cookie-banner .buttons button.btn-primary"
+        }
+    ],
+    "optOut": [
+        {
+            "waitForThenClick": "rspb-cookie-banner .buttons button.btn-light"
+        },
+        {
+            "waitForVisible": "rspb-cookie-banner [data-testid=\"options\"]"
+        },
+        {
+            "waitForThenClick": "rspb-cookie-banner button[label=\"Save settings\"]"
+        }
+    ],
+    "test": [
+        {
+            "cookieContains": "RSPB.AllowMarketingCookies=No"
+        }
+    ]
+}

--- a/tests/rspb.spec.ts
+++ b/tests/rspb.spec.ts
@@ -1,0 +1,3 @@
+import generateCMPTests from '../playwright/runner';
+
+generateCMPTests('rspb.org.uk', ['https://www.rspb.org.uk/', 'https://www.rspb.org.uk/birds-and-wildlife']);


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203268166580279/task/1218314660310812?focus=true

## Description:

Automated autoconsent rule update from CPM triage.

Category: Site-specific pop-up

No autoconsent exception exists for rspb.org.uk: I fetched features/autoconsent.json, overrides/{android,ios,macos,windows,extension}-override.json and overrides/browsers/{brave,chrome,firefox,edge,safarimv3}-override.json from duckduckgo/privacy-configuration main and grepped locally for 'rspb' with zero hits, so there is no PR or Asana task to cite and no duplicate fix was proposed. The task listed no related sites ('none'), so there were no sibling sites to check; as a substitute I verified the rule on a second page of the same site (https://www.rspb.org.uk/birds-and-wildlife) and included it in the spec. I probed shop/community/events/group.rspb.org.uk: shop does not resolve, community redirects back to www, events returns 403 and group returns 202 without the Angular app, so none of them present this banner. Testing caveat: rspb.org.uk serves an Akamai 'The request is blocked.' page to headless Chromium both through the regional proxies and over a direct connection, so all testing used headed Google Chrome under Xvfb, still routed through the regional proxies. Escalated to the expanded region set because the opt-out relies on a language-dependent attribute selector (button[label="Save settings"]) and a structural class (.buttons button.btn-light); results were identical in all nine regions. The GDPR/EEA remainder (ch, no, it, es, se, dk) was skipped per the proxy-testing policy since the reported region is gb and the de/fr/nl/pl results already converge. Opt-in clicks 'Accept all'; opt-out never touches it, so no TIER2 button is clicked from optOut.

## Steps to test this PR:

- `xvfb-run -a npx playwright test tests/rspb.spec.ts --project=chrome`
- Review the regional screenshots and results linked from the Asana task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated site-specific consent automation with no changes to shared infrastructure or sensitive systems.
> 
> **Overview**
> Adds autoconsent coverage for **rspb.org.uk** so DuckDuckGo can dismiss the site’s `rspb-cookie-banner` CMP on matching URLs.
> 
> The new rule pre-hides the banner, detects it via the custom element, clicks **Accept all** on opt-in, and on opt-out opens preferences and saves with marketing off—asserting `RSPB.AllowMarketingCookies=No`. A Playwright spec runs the shared CMP harness against the homepage and `/birds-and-wildlife`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beb9af6e76b5d182ddf5abb725acadf198597ca6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->